### PR TITLE
feat(ui): add markdown rendering and enhance tool message display

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,21 @@ dependencies {
     implementation(libs.recyclerview)
     implementation(libs.okhttp)
     implementation(libs.gson)
+    
+    // Markwon for markdown rendering
+    implementation(libs.markwon.core) {
+        exclude(group = "org.jetbrains", module = "annotations-java5")
+    }
+    implementation(libs.markwon.ext.strikethrough) {
+        exclude(group = "org.jetbrains", module = "annotations-java5")
+    }
+    implementation(libs.markwon.ext.tables) {
+        exclude(group = "org.jetbrains", module = "annotations-java5")
+    }
+    implementation(libs.markwon.ext.tasklist) {
+        exclude(group = "org.jetbrains", module = "annotations-java5")
+    }
+    
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
     testImplementation(libs.mockito.core)

--- a/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
+++ b/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
@@ -1,5 +1,6 @@
 package io.finett.droidclaw.adapter;
 
+import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +15,7 @@ import java.util.List;
 import io.finett.droidclaw.R;
 import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.util.MarkdownRenderer;
 
 public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHolder> {
     private static final int VIEW_TYPE_USER = 0;
@@ -109,29 +111,44 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
 
     static class UserMessageViewHolder extends MessageViewHolder {
         private final TextView messageText;
+        private final Context context;
 
         UserMessageViewHolder(@NonNull View itemView) {
             super(itemView);
             messageText = itemView.findViewById(R.id.messageText);
+            context = itemView.getContext();
         }
 
         @Override
         void bind(ChatMessage message) {
-            messageText.setText(message.getContent());
+            String content = message.getContent();
+            if (content != null && MarkdownRenderer.containsMarkdown(content)) {
+                MarkdownRenderer.render(context, messageText, content);
+            } else {
+                messageText.setText(content);
+            }
         }
     }
 
     static class AssistantMessageViewHolder extends MessageViewHolder {
         private final TextView messageText;
+        private final Context context;
 
         AssistantMessageViewHolder(@NonNull View itemView) {
             super(itemView);
             messageText = itemView.findViewById(R.id.messageText);
+            context = itemView.getContext();
         }
 
         @Override
         void bind(ChatMessage message) {
-            messageText.setText(message.getContent());
+            String content = message.getContent();
+            // Always render assistant messages as markdown since they often contain formatting
+            if (content != null) {
+                MarkdownRenderer.render(context, messageText, content);
+            } else {
+                messageText.setText("");
+            }
         }
     }
 
@@ -152,33 +169,156 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
             if (message.getToolCalls() != null && !message.getToolCalls().isEmpty()) {
                 // Show the first tool call's name as the main text
                 LlmApiService.ToolCall firstToolCall = message.getToolCalls().get(0);
-                toolCallText.setText(firstToolCall.getName());
+                String toolName = firstToolCall.getName();
+                
+                // Set icon based on tool type
+                String icon = getToolIcon(toolName);
+                toolCallIcon.setText(icon);
+                
+                // Format tool name for display
+                toolCallText.setText(formatToolName(toolName));
 
                 // Show all tool call arguments
                 StringBuilder argsBuilder = new StringBuilder();
                 for (LlmApiService.ToolCall toolCall : message.getToolCalls()) {
-                    argsBuilder.append("Tool: ").append(toolCall.getName())
-                            .append("\nArgs: ").append(toolCall.getArguments().toString())
-                            .append("\n\n");
+                    if (message.getToolCalls().size() > 1) {
+                        argsBuilder.append("• ").append(toolCall.getName()).append("\n");
+                    }
+                    argsBuilder.append(formatArguments(toolCall.getArguments().toString()))
+                            .append("\n");
                 }
                 toolCallArgs.setText(argsBuilder.toString().trim());
             }
         }
+        
+        private String getToolIcon(String toolName) {
+            if (toolName.contains("shell") || toolName.contains("execute")) {
+                return "💻";
+            } else if (toolName.contains("file") || toolName.contains("read") || toolName.contains("write")) {
+                return "📁";
+            } else if (toolName.contains("python") || toolName.contains("pip")) {
+                return "🐍";
+            } else if (toolName.contains("search")) {
+                return "🔍";
+            } else if (toolName.contains("list")) {
+                return "📋";
+            } else {
+                return "🔧";
+            }
+        }
+        
+        private String formatToolName(String toolName) {
+            // Convert snake_case to Title Case
+            String[] parts = toolName.split("_");
+            StringBuilder formatted = new StringBuilder();
+            for (String part : parts) {
+                if (formatted.length() > 0) {
+                    formatted.append(" ");
+                }
+                formatted.append(part.substring(0, 1).toUpperCase())
+                        .append(part.substring(1).toLowerCase());
+            }
+            return formatted.toString();
+        }
+        
+        private String formatArguments(String args) {
+            // Pretty-print JSON arguments with limited length
+            if (args.length() > 200) {
+                return args.substring(0, 197) + "...";
+            }
+            return args;
+        }
     }
 
     static class ToolResultMessageViewHolder extends MessageViewHolder {
+        private final View toolResultHeader;
+        private final TextView toolResultIcon;
         private final TextView toolResultLabel;
+        private final TextView toolResultToggle;
         private final TextView toolResultContent;
+        private boolean isExpanded = false;
 
         ToolResultMessageViewHolder(@NonNull View itemView) {
             super(itemView);
+            toolResultHeader = itemView.findViewById(R.id.toolResultHeader);
+            toolResultIcon = itemView.findViewById(R.id.toolResultIcon);
             toolResultLabel = itemView.findViewById(R.id.toolResultLabel);
+            toolResultToggle = itemView.findViewById(R.id.toolResultToggle);
             toolResultContent = itemView.findViewById(R.id.toolResultContent);
+            
+            // Set up click listener for expand/collapse
+            toolResultHeader.setOnClickListener(v -> toggleExpanded());
         }
 
         @Override
         void bind(ChatMessage message) {
-            toolResultContent.setText(message.getContent());
+            String content = message.getContent();
+            String toolName = message.getToolName();
+            Context context = itemView.getContext();
+            
+            // Set label with tool name
+            if (toolName != null) {
+                toolResultLabel.setText(formatToolName(toolName) + " result");
+            } else {
+                toolResultLabel.setText("Tool result");
+            }
+            
+            // Determine if result indicates success or error
+            boolean isError = content != null && (content.toLowerCase().contains("error:")
+                    || content.toLowerCase().startsWith("error"));
+            
+            // Set icon based on success/error
+            toolResultIcon.setText(isError ? "❌" : "✅");
+            
+            // Set content with markdown rendering if applicable
+            if (content != null) {
+                if (MarkdownRenderer.containsMarkdown(content)) {
+                    MarkdownRenderer.render(context, toolResultContent, content);
+                } else {
+                    toolResultContent.setText(content);
+                }
+            } else {
+                toolResultContent.setText("No output");
+            }
+            
+            // Start collapsed if content is long
+            if (content != null && content.length() > 100) {
+                isExpanded = false;
+                updateExpandState();
+            } else {
+                isExpanded = true;
+                toolResultToggle.setVisibility(View.GONE);
+                toolResultContent.setMaxLines(Integer.MAX_VALUE);
+            }
+        }
+        
+        private void toggleExpanded() {
+            isExpanded = !isExpanded;
+            updateExpandState();
+        }
+        
+        private void updateExpandState() {
+            if (isExpanded) {
+                toolResultToggle.setText("▲");
+                toolResultContent.setMaxLines(Integer.MAX_VALUE);
+            } else {
+                toolResultToggle.setText("▼");
+                toolResultContent.setMaxLines(3);
+            }
+        }
+        
+        private String formatToolName(String toolName) {
+            // Convert snake_case to Title Case
+            String[] parts = toolName.split("_");
+            StringBuilder formatted = new StringBuilder();
+            for (String part : parts) {
+                if (formatted.length() > 0) {
+                    formatted.append(" ");
+                }
+                formatted.append(part.substring(0, 1).toUpperCase())
+                        .append(part.substring(1).toLowerCase());
+            }
+            return formatted.toString();
         }
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -41,6 +41,7 @@ public class ChatFragment extends Fragment {
     private View statusContainer;
     private ProgressBar progressBar;
     private TextView statusText;
+    private TextView statusSubText;
     private ChatAdapter chatAdapter;
     private LlmApiService apiService;
     private SettingsManager settingsManager;
@@ -91,6 +92,7 @@ public class ChatFragment extends Fragment {
         statusContainer = view.findViewById(R.id.statusContainer);
         progressBar = view.findViewById(R.id.progressBar);
         statusText = view.findViewById(R.id.statusText);
+        statusSubText = view.findViewById(R.id.statusSubText);
     }
 
     private void setupRecyclerView() {
@@ -183,18 +185,26 @@ public class ChatFragment extends Fragment {
         agentLoop.start(conversationHistory, new AgentLoop.AgentCallback() {
             @Override
             public void onProgress(String status) {
-                updateStatus(status);
+                updateStatus(status, null);
             }
 
             @Override
             public void onToolCall(String toolName, String arguments) {
                 Log.d(TAG, "Tool call: " + toolName + " with args: " + arguments);
-                updateStatus("Executing: " + toolName);
+                
+                // Enhanced status messages for different tool types
+                String statusMessage = getToolStatusMessage(toolName, arguments);
+                String iterationInfo = "Step " + agentLoop.getIterationCount() + "/20";
+                updateStatus(statusMessage, iterationInfo);
             }
 
             @Override
             public void onToolResult(String toolName, String result) {
                 Log.d(TAG, "Tool result: " + toolName + " -> " + result.substring(0, Math.min(100, result.length())));
+                
+                // Show brief result feedback
+                String iterationInfo = "Step " + agentLoop.getIterationCount() + "/20";
+                updateStatus("✓ " + formatToolName(toolName) + " completed", iterationInfo);
             }
 
             @Override
@@ -227,9 +237,17 @@ public class ChatFragment extends Fragment {
         messageInput.setEnabled(!loading);
     }
 
-    private void updateStatus(String status) {
+    private void updateStatus(String status, String subStatus) {
         if (statusText != null) {
             statusText.setText(status);
+        }
+        if (statusSubText != null) {
+            if (subStatus != null) {
+                statusSubText.setText(subStatus);
+                statusSubText.setVisibility(View.VISIBLE);
+            } else {
+                statusSubText.setVisibility(View.GONE);
+            }
         }
         if (statusContainer != null) {
             statusContainer.setVisibility(View.VISIBLE);
@@ -240,6 +258,62 @@ public class ChatFragment extends Fragment {
         if (chatAdapter.getItemCount() > 0) {
             recyclerView.scrollToPosition(chatAdapter.getItemCount() - 1);
         }
+    }
+    
+    /**
+     * Get a user-friendly status message for tool execution.
+     */
+    private String getToolStatusMessage(String toolName, String arguments) {
+        // Check for skill-related tools
+        if (toolName.equals("list_files") && arguments.contains(".agent/skills")) {
+            return "🔍 Discovering available skills...";
+        } else if (toolName.equals("read_file") && arguments.contains(".agent/skills")) {
+            return "📖 Loading skill definition...";
+        } else if (toolName.equals("read_file") && arguments.contains("SKILL.md")) {
+            return "📖 Reading skill instructions...";
+        }
+        
+        // Tool-specific messages
+        switch (toolName) {
+            case "execute_shell":
+                return "💻 Running shell command...";
+            case "execute_python":
+                return "🐍 Executing Python script...";
+            case "pip_install":
+                return "📦 Installing Python package...";
+            case "read_file":
+                return "📄 Reading file...";
+            case "write_file":
+                return "✏️ Writing file...";
+            case "edit_file":
+                return "✏️ Editing file...";
+            case "list_files":
+                return "📋 Listing directory...";
+            case "search_files":
+                return "🔍 Searching files...";
+            case "delete_file":
+                return "🗑️ Deleting file...";
+            case "file_info":
+                return "ℹ️ Getting file info...";
+            default:
+                return "🔧 Executing: " + formatToolName(toolName);
+        }
+    }
+    
+    /**
+     * Format tool name from snake_case to Title Case.
+     */
+    private String formatToolName(String toolName) {
+        String[] parts = toolName.split("_");
+        StringBuilder formatted = new StringBuilder();
+        for (String part : parts) {
+            if (formatted.length() > 0) {
+                formatted.append(" ");
+            }
+            formatted.append(part.substring(0, 1).toUpperCase())
+                    .append(part.substring(1).toLowerCase());
+        }
+        return formatted.toString();
     }
 
     @Override

--- a/app/src/main/java/io/finett/droidclaw/util/MarkdownRenderer.java
+++ b/app/src/main/java/io/finett/droidclaw/util/MarkdownRenderer.java
@@ -1,0 +1,103 @@
+package io.finett.droidclaw.util;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.TypefaceSpan;
+import android.widget.TextView;
+
+import io.noties.markwon.Markwon;
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
+import io.noties.markwon.ext.tables.TablePlugin;
+import io.noties.markwon.ext.tasklist.TaskListPlugin;
+
+/**
+ * Utility class for rendering markdown text in TextViews.
+ * Uses Markwon library with support for:
+ * - Basic markdown (bold, italic, headers, lists, links)
+ * - Code blocks (monospace font, no syntax highlighting)
+ * - Tables
+ * - Strikethrough
+ * - Task lists
+ */
+public class MarkdownRenderer {
+    private static Markwon instance;
+
+    /**
+     * Get singleton Markwon instance configured with all plugins.
+     *
+     * @param context Android context
+     * @return Configured Markwon instance
+     */
+    public static Markwon getInstance(Context context) {
+        if (instance == null) {
+            instance = Markwon.builder(context)
+                    .usePlugin(StrikethroughPlugin.create())
+                    .usePlugin(TablePlugin.create(context))
+                    .usePlugin(TaskListPlugin.create(context))
+                    .build();
+        }
+        return instance;
+    }
+
+    /**
+     * Render markdown text into a TextView.
+     *
+     * @param context  Android context
+     * @param textView Target TextView
+     * @param markdown Markdown text to render
+     */
+    public static void render(Context context, TextView textView, String markdown) {
+        if (markdown == null || markdown.isEmpty()) {
+            textView.setText("");
+            return;
+        }
+        
+        getInstance(context).setMarkdown(textView, markdown);
+    }
+
+    /**
+     * Convert markdown to Spanned (for compatibility with older code).
+     *
+     * @param context  Android context
+     * @param markdown Markdown text
+     * @return Spanned text with markdown formatting
+     */
+    public static CharSequence toSpanned(Context context, String markdown) {
+        if (markdown == null || markdown.isEmpty()) {
+            return "";
+        }
+        
+        return getInstance(context).toMarkdown(markdown);
+    }
+
+    /**
+     * Check if text contains markdown syntax.
+     * This is a simple heuristic check for common markdown patterns.
+     *
+     * @param text Text to check
+     * @return true if text likely contains markdown
+     */
+    public static boolean containsMarkdown(String text) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        
+        // Check for common markdown patterns
+        return text.contains("**") ||     // Bold
+               text.contains("__") ||     // Bold
+               text.contains("```") ||    // Code block
+               text.contains("`") ||      // Inline code
+               text.contains("# ") ||     // Headers
+               text.contains("## ") ||    // Headers
+               text.contains("### ") ||   // Headers
+               text.contains("[") && text.contains("](") || // Links
+               text.contains("- [") ||    // Task lists
+               text.contains("~~") ||     // Strikethrough
+               text.contains("| ") ||     // Tables
+               text.matches("(?s).*^\\d+\\.\\s.*"); // Numbered lists (multiline)
+    }
+}

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -18,32 +18,60 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:listitem="@layout/item_message_user" />
 
-    <LinearLayout
+    <com.google.android.material.card.MaterialCardView
         android:id="@+id/statusContainer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:padding="8dp"
         android:visibility="gone"
+        app:cardBackgroundColor="?android:attr/colorBackground"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="4dp"
         app:layout_constraintBottom_toTopOf="@id/inputContainer"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginBottom="8dp">
 
-        <ProgressBar
-            android:id="@+id/progressBar"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginEnd="8dp" />
-
-        <TextView
-            android:id="@+id/statusText"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="14sp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="10dp">
 
-    </LinearLayout>
+            <ProgressBar
+                android:id="@+id/progressBar"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginEnd="10dp"
+                style="?android:attr/progressBarStyleSmall" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/statusText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="13sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/statusSubText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="11sp"
+                    android:visibility="gone" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
 
     <LinearLayout
         android:id="@+id/inputContainer"

--- a/app/src/main/res/layout/item_message_tool_call.xml
+++ b/app/src/main/res/layout/item_message_tool_call.xml
@@ -3,43 +3,63 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingVertical="8dp">
+    android:paddingVertical="8dp"
+    android:paddingHorizontal="8dp">
 
-    <LinearLayout
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/toolCallCard"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="12dp"
         android:layout_gravity="start"
-        android:maxWidth="280dp"
-        android:layout_marginEnd="80dp">
+        android:layout_marginEnd="80dp"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="2dp"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
 
-        <TextView
-            android:id="@+id/toolCallIcon"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="🔧"
-            android:textSize="16sp"
-            android:layout_marginEnd="8dp" />
+            android:orientation="vertical"
+            android:padding="12dp"
+            android:maxWidth="280dp">
 
-        <TextView
-            android:id="@+id/toolCallText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="14sp"
-            android:textColor="?android:attr/textColorPrimary" />
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
 
-    </LinearLayout>
+                <TextView
+                    android:id="@+id/toolCallIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="🔧"
+                    android:textSize="18sp"
+                    android:layout_marginEnd="8dp" />
 
-    <TextView
-        android:id="@+id/toolCallArgs"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="12sp"
-        android:textColor="?android:attr/textColorSecondary"
-        android:layout_marginStart="24dp"
-        android:layout_marginTop="4dp"
-        android:fontFamily="monospace" />
+                <TextView
+                    android:id="@+id/toolCallText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:textColor="#1976D2" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/toolCallArgs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="?android:attr/textColorSecondary"
+                android:layout_marginTop="8dp"
+                android:fontFamily="monospace"
+                android:maxLines="10"
+                android:ellipsize="end" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_message_tool_result.xml
+++ b/app/src/main/res/layout/item_message_tool_result.xml
@@ -1,30 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingVertical="8dp">
+    android:paddingVertical="4dp"
+    android:paddingHorizontal="8dp">
 
-    <TextView
-        android:id="@+id/toolResultLabel"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/toolResultCard"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Tool result:"
-        android:textSize="12sp"
-        android:textStyle="bold"
-        android:textColor="?android:attr/textColorPrimary" />
+        android:layout_gravity="start"
+        android:layout_marginEnd="60dp"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="1dp">
 
-    <TextView
-        android:id="@+id/toolResultContent"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="14sp"
-        android:textColor="?android:attr/textColorPrimary"
-        android:layout_marginTop="4dp"
-        android:layout_marginEnd="80dp"
-        android:maxWidth="280dp"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="12dp"
-        android:layout_gravity="start" />
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="10dp"
+            android:maxWidth="300dp">
+
+            <!-- Header with icon, label and expand/collapse toggle -->
+            <LinearLayout
+                android:id="@+id/toolResultHeader"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/toolResultIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="✅"
+                    android:textSize="14sp"
+                    android:layout_marginEnd="6dp" />
+
+                <TextView
+                    android:id="@+id/toolResultLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Tool result"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    android:textColor="#388E3C" />
+
+                <TextView
+                    android:id="@+id/toolResultToggle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="▼"
+                    android:textSize="10sp"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:layout_marginStart="8dp" />
+
+            </LinearLayout>
+
+            <!-- Collapsible content area -->
+            <TextView
+                android:id="@+id/toolResultContent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="11sp"
+                android:textColor="?android:attr/textColorSecondary"
+                android:fontFamily="monospace"
+                android:layout_marginTop="6dp"
+                android:maxLines="15"
+                android:ellipsize="end" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
 
 </LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ robolectric = "4.12.2"
 testCore = "1.6.1"
 fragmentTesting = "1.8.6"
 mockito = "5.11.0"
+markwon = "4.6.2"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -36,6 +37,11 @@ test-runner = { group = "androidx.test", name = "runner", version.ref = "testCor
 fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "fragmentTesting" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+markwon-core = { group = "io.noties.markwon", name = "core", version.ref = "markwon" }
+markwon-ext-strikethrough = { group = "io.noties.markwon", name = "ext-strikethrough", version.ref = "markwon" }
+markwon-ext-tables = { group = "io.noties.markwon", name = "ext-tables", version.ref = "markwon" }
+markwon-ext-tasklist = { group = "io.noties.markwon", name = "ext-tasklist", version.ref = "markwon" }
+markwon-syntax-highlight = { group = "io.noties.markwon", name = "syntax-highlight", version.ref = "markwon" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Integrate Markwon library for markdown rendering in chat messages, supporting bold, italic, headers, code blocks, tables, strikethrough, and task lists. Enhance tool call and tool result message layouts with MaterialCardView styling, dynamic icons, and collapsible results.

Key changes:
- Add MarkdownRenderer utility class using Markwon library
- Render markdown in user, assistant, and tool result messages
- Enhance tool call UI with tool-type icons and formatted names
- Add collapsible tool results with expand/collapse toggle
- Improve status indicator with MaterialCardView and iteration counter
- Add skill discovery status messages for agent operations