### PR TITLE
feat(agent): add tool approval workflow and configurable agent settings

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
@@ -3,45 +3,93 @@ package io.finett.droidclaw.agent;
 import android.util.Log;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.tool.Tool;
 import io.finett.droidclaw.tool.ToolRegistry;
 import io.finett.droidclaw.tool.ToolResult;
+import io.finett.droidclaw.util.SettingsManager;
 
 /**
  * AgentLoop handles the iterative tool-calling workflow.
- * 
+ *
  * Flow:
  * 1. User sends a message
  * 2. LLM responds (may include tool calls)
- * 3. If tool calls exist, execute them
+ * 3. If tool calls exist, execute them (with approval if required)
  * 4. Send tool results back to LLM
  * 5. Repeat until LLM provides final text response
  */
 public class AgentLoop {
     private static final String TAG = "AgentLoop";
-    private static final int MAX_ITERATIONS = 20;
+    private static final int DEFAULT_MAX_ITERATIONS = 20;
 
     private final LlmApiService apiService;
     private final ToolRegistry toolRegistry;
+    private final SettingsManager settingsManager;
     private int iterationCount;
+    private int maxIterations;
+    private boolean requireApproval;
 
+    /**
+     * Callback interface for agent events.
+     */
     public interface AgentCallback {
         void onProgress(String status);
         void onToolCall(String toolName, String arguments);
         void onToolResult(String toolName, String result);
         void onComplete(String finalResponse, List<ChatMessage> conversationHistory);
         void onError(String error);
+        
+        /**
+         * Called when a tool requires user approval before execution.
+         *
+         * @param toolName Name of the tool requesting approval
+         * @param description Human-readable description of what the tool will do
+         * @param arguments The tool arguments
+         * @param approvalCallback Callback to indicate approval or denial
+         */
+        void onApprovalRequired(String toolName, String description, JsonObject arguments, ApprovalCallback approvalCallback);
+    }
+    
+    /**
+     * Callback for tool approval decisions.
+     */
+    public interface ApprovalCallback {
+        void onApproved();
+        void onDenied();
     }
 
+    /**
+     * Creates an AgentLoop without settings (for backwards compatibility).
+     * Uses default values for max iterations and approval.
+     */
     public AgentLoop(LlmApiService apiService, ToolRegistry toolRegistry) {
+        this(apiService, toolRegistry, null);
+    }
+    
+    /**
+     * Creates an AgentLoop with settings for configuration.
+     */
+    public AgentLoop(LlmApiService apiService, ToolRegistry toolRegistry, SettingsManager settingsManager) {
         this.apiService = apiService;
         this.toolRegistry = toolRegistry;
+        this.settingsManager = settingsManager;
         this.iterationCount = 0;
+        
+        // Load settings
+        if (settingsManager != null) {
+            this.maxIterations = settingsManager.getMaxAgentIterations();
+            this.requireApproval = settingsManager.isRequireApproval();
+        } else {
+            this.maxIterations = DEFAULT_MAX_ITERATIONS;
+            this.requireApproval = true; // Default to requiring approval
+        }
     }
 
     /**
@@ -66,12 +114,12 @@ public class AgentLoop {
     private void executeIteration(List<ChatMessage> conversationHistory, AgentCallback callback) {
         iterationCount++;
         
-        if (iterationCount > MAX_ITERATIONS) {
-            callback.onError("Maximum iterations reached. The agent may be stuck in a loop.");
+        if (iterationCount > maxIterations) {
+            callback.onError("Maximum iterations (" + maxIterations + ") reached. The agent may be stuck in a loop.");
             return;
         }
 
-        Log.d(TAG, "Iteration " + iterationCount + "/" + MAX_ITERATIONS);
+        Log.d(TAG, "Iteration " + iterationCount + "/" + maxIterations);
 
         // Get tool definitions
         JsonArray tools = toolRegistry.getToolDefinitions();
@@ -116,40 +164,98 @@ public class AgentLoop {
         ChatMessage toolCallMessage = ChatMessage.createToolCallMessage(toolCalls);
         conversationHistory.add(toolCallMessage);
 
-        // Execute each tool call and add results to history
-        for (LlmApiService.ToolCall toolCall : toolCalls) {
-            String toolName = toolCall.getName();
-            String arguments = toolCall.getArguments().toString();
-            
-            Log.d(TAG, "Executing tool: " + toolName + " with args: " + arguments);
-            callback.onToolCall(toolName, arguments);
-
-            // Execute the tool
-            ToolResult result = toolRegistry.executeTool(toolName, toolCall.getArguments());
-            
-            String resultContent;
-            if (result.isSuccess()) {
-                resultContent = result.getContent();
-                Log.d(TAG, "Tool " + toolName + " succeeded: " + resultContent);
-            } else {
-                resultContent = "Error: " + result.getError();
-                Log.e(TAG, "Tool " + toolName + " failed: " + result.getError());
-            }
-
-            callback.onToolResult(toolName, resultContent);
-
-            // Add tool result to conversation history
-            ChatMessage toolResultMessage = ChatMessage.createToolResultMessage(
-                toolCall.getId(),
-                toolName,
-                resultContent
-            );
-            conversationHistory.add(toolResultMessage);
+        // Process tool calls sequentially with approval support
+        processToolCallsWithApproval(toolCalls, 0, conversationHistory, callback);
+    }
+    
+    /**
+     * Process tool calls sequentially, requesting approval when needed.
+     */
+    private void processToolCallsWithApproval(List<LlmApiService.ToolCall> toolCalls, int index,
+                                               List<ChatMessage> conversationHistory, AgentCallback callback) {
+        if (index >= toolCalls.size()) {
+            // All tool calls processed, continue the loop
+            callback.onProgress("Sending tool results to LLM...");
+            executeIteration(conversationHistory, callback);
+            return;
+        }
+        
+        LlmApiService.ToolCall toolCall = toolCalls.get(index);
+        String toolName = toolCall.getName();
+        JsonObject arguments = toolCall.getArguments();
+        
+        Log.d(TAG, "Processing tool: " + toolName + " with args: " + arguments.toString());
+        callback.onToolCall(toolName, arguments.toString());
+        
+        // Check if this tool requires approval
+        Tool tool = toolRegistry.getTool(toolName);
+        boolean needsApproval = requireApproval && tool != null && tool.requiresApproval();
+        
+        if (needsApproval) {
+            // Request approval from user
+            String description = tool.getApprovalDescription(arguments);
+            callback.onApprovalRequired(toolName, description, arguments, new ApprovalCallback() {
+                @Override
+                public void onApproved() {
+                    // Execute the tool and continue
+                    executeToolAndContinue(toolCall, toolCalls, index, conversationHistory, callback);
+                }
+                
+                @Override
+                public void onDenied() {
+                    // Add denial result to history and continue
+                    String resultContent = "Tool execution denied by user";
+                    Log.d(TAG, "Tool " + toolName + " denied by user");
+                    callback.onToolResult(toolName, resultContent);
+                    
+                    ChatMessage toolResultMessage = ChatMessage.createToolResultMessage(
+                        toolCall.getId(),
+                        toolName,
+                        resultContent
+                    );
+                    conversationHistory.add(toolResultMessage);
+                    
+                    // Process next tool call
+                    processToolCallsWithApproval(toolCalls, index + 1, conversationHistory, callback);
+                }
+            });
+        } else {
+            // Execute without approval
+            executeToolAndContinue(toolCall, toolCalls, index, conversationHistory, callback);
+        }
+    }
+    
+    /**
+     * Execute a tool and continue processing remaining tool calls.
+     */
+    private void executeToolAndContinue(LlmApiService.ToolCall toolCall, List<LlmApiService.ToolCall> toolCalls,
+                                        int index, List<ChatMessage> conversationHistory, AgentCallback callback) {
+        String toolName = toolCall.getName();
+        
+        // Execute the tool
+        ToolResult result = toolRegistry.executeTool(toolName, toolCall.getArguments());
+        
+        String resultContent;
+        if (result.isSuccess()) {
+            resultContent = result.getContent();
+            Log.d(TAG, "Tool " + toolName + " succeeded: " + resultContent);
+        } else {
+            resultContent = "Error: " + result.getError();
+            Log.e(TAG, "Tool " + toolName + " failed: " + result.getError());
         }
 
-        // Continue the loop - send tool results back to LLM
-        callback.onProgress("Sending tool results to LLM...");
-        executeIteration(conversationHistory, callback);
+        callback.onToolResult(toolName, resultContent);
+
+        // Add tool result to conversation history
+        ChatMessage toolResultMessage = ChatMessage.createToolResultMessage(
+            toolCall.getId(),
+            toolName,
+            resultContent
+        );
+        conversationHistory.add(toolResultMessage);
+        
+        // Process next tool call
+        processToolCallsWithApproval(toolCalls, index + 1, conversationHistory, callback);
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -1,5 +1,6 @@
 package io.finett.droidclaw.fragment;
 
+import android.app.AlertDialog;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -17,6 +18,8 @@ import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.gson.JsonObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,8 +60,10 @@ public class ChatFragment extends Fragment {
         settingsManager = new SettingsManager(requireContext());
         apiService = new LlmApiService(settingsManager);
         chatRepository = new ChatRepository(requireContext());
-        toolRegistry = new ToolRegistry(requireContext());
-        agentLoop = new AgentLoop(apiService, toolRegistry);
+        // Create ToolRegistry with SettingsManager for shell access settings
+        toolRegistry = new ToolRegistry(requireContext(), settingsManager);
+        // Create AgentLoop with SettingsManager for approval settings
+        agentLoop = new AgentLoop(apiService, toolRegistry, settingsManager);
         
         // Get session ID from arguments
         Bundle args = getArguments();
@@ -226,7 +231,35 @@ public class ChatFragment extends Fragment {
                 setLoading(false);
                 Toast.makeText(requireContext(), error, Toast.LENGTH_LONG).show();
             }
+            
+            @Override
+            public void onApprovalRequired(String toolName, String description, JsonObject arguments,
+                                           AgentLoop.ApprovalCallback approvalCallback) {
+                // Show approval dialog on UI thread
+                requireActivity().runOnUiThread(() -> {
+                    showApprovalDialog(toolName, description, approvalCallback);
+                });
+            }
         });
+    }
+    
+    /**
+     * Show a dialog asking user to approve or deny a tool execution.
+     */
+    private void showApprovalDialog(String toolName, String description, AgentLoop.ApprovalCallback approvalCallback) {
+        new AlertDialog.Builder(requireContext())
+            .setTitle("Approve Tool Execution?")
+            .setMessage("Tool: " + formatToolName(toolName) + "\n\n" + description)
+            .setPositiveButton("Approve", (dialog, which) -> {
+                Log.d(TAG, "User approved tool: " + toolName);
+                approvalCallback.onApproved();
+            })
+            .setNegativeButton("Deny", (dialog, which) -> {
+                Log.d(TAG, "User denied tool: " + toolName);
+                approvalCallback.onDenied();
+            })
+            .setCancelable(false)
+            .show();
     }
 
     private void setLoading(boolean loading) {

--- a/app/src/main/java/io/finett/droidclaw/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/SettingsFragment.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.SeekBar;
@@ -14,6 +16,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
+
+import com.google.android.material.switchmaterial.SwitchMaterial;
 
 import io.finett.droidclaw.R;
 import io.finett.droidclaw.util.SettingsManager;
@@ -28,6 +32,13 @@ public class SettingsFragment extends Fragment {
     private TextView temperatureValue;
     private Button saveButton;
     private SettingsManager settingsManager;
+    
+    // Agent settings views
+    private SwitchMaterial shellAccessSwitch;
+    private AutoCompleteTextView sandboxModeDropdown;
+    private EditText maxIterationsInput;
+    private SwitchMaterial requireApprovalSwitch;
+    private EditText shellTimeoutInput;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -59,6 +70,29 @@ public class SettingsFragment extends Fragment {
         temperatureSeekBar = view.findViewById(R.id.temperatureSeekBar);
         temperatureValue = view.findViewById(R.id.temperatureValue);
         saveButton = view.findViewById(R.id.saveButton);
+        
+        // Agent settings views
+        shellAccessSwitch = view.findViewById(R.id.shellAccessSwitch);
+        sandboxModeDropdown = view.findViewById(R.id.sandboxModeDropdown);
+        maxIterationsInput = view.findViewById(R.id.maxIterationsInput);
+        requireApprovalSwitch = view.findViewById(R.id.requireApprovalSwitch);
+        shellTimeoutInput = view.findViewById(R.id.shellTimeoutInput);
+        
+        // Setup sandbox mode dropdown
+        setupSandboxModeDropdown();
+    }
+    
+    private void setupSandboxModeDropdown() {
+        String[] sandboxModes = {
+            getString(R.string.sandbox_strict),
+            getString(R.string.sandbox_relaxed)
+        };
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(
+            requireContext(),
+            android.R.layout.simple_dropdown_item_1line,
+            sandboxModes
+        );
+        sandboxModeDropdown.setAdapter(adapter);
     }
 
     private void loadSettings() {
@@ -72,6 +106,20 @@ public class SettingsFragment extends Fragment {
         int progress = (int) (temperature * 100);
         temperatureSeekBar.setProgress(progress);
         updateTemperatureLabel(temperature);
+        
+        // Load agent settings
+        shellAccessSwitch.setChecked(settingsManager.isShellAccessEnabled());
+        
+        String sandboxMode = settingsManager.getSandboxMode();
+        if ("relaxed".equals(sandboxMode)) {
+            sandboxModeDropdown.setText(getString(R.string.sandbox_relaxed), false);
+        } else {
+            sandboxModeDropdown.setText(getString(R.string.sandbox_strict), false);
+        }
+        
+        maxIterationsInput.setText(String.valueOf(settingsManager.getMaxAgentIterations()));
+        requireApprovalSwitch.setChecked(settingsManager.isRequireApproval());
+        shellTimeoutInput.setText(String.valueOf(settingsManager.getShellTimeoutSeconds()));
     }
 
     private void setupListeners() {
@@ -102,6 +150,8 @@ public class SettingsFragment extends Fragment {
         String modelName = modelNameInput.getText().toString().trim();
         String systemPrompt = systemPromptInput.getText().toString().trim();
         String maxTokensStr = maxTokensInput.getText().toString().trim();
+        String maxIterationsStr = maxIterationsInput.getText().toString().trim();
+        String shellTimeoutStr = shellTimeoutInput.getText().toString().trim();
 
         // Validation
         if (apiKey.isEmpty()) {
@@ -131,7 +181,39 @@ public class SettingsFragment extends Fragment {
             return;
         }
 
+        // Validate agent settings
+        int maxIterations;
+        try {
+            maxIterations = Integer.parseInt(maxIterationsStr);
+            if (maxIterations < 1 || maxIterations > 50) {
+                maxIterationsInput.setError("Max iterations must be between 1 and 50");
+                return;
+            }
+        } catch (NumberFormatException e) {
+            maxIterationsInput.setError("Invalid number");
+            return;
+        }
+        
+        int shellTimeout;
+        try {
+            shellTimeout = Integer.parseInt(shellTimeoutStr);
+            if (shellTimeout < 5 || shellTimeout > 300) {
+                shellTimeoutInput.setError("Shell timeout must be between 5 and 300 seconds");
+                return;
+            }
+        } catch (NumberFormatException e) {
+            shellTimeoutInput.setError("Invalid number");
+            return;
+        }
+
         float temperature = temperatureSeekBar.getProgress() / 100f;
+        
+        // Determine sandbox mode from dropdown selection
+        String sandboxMode = "strict";
+        String selectedSandbox = sandboxModeDropdown.getText().toString();
+        if (selectedSandbox.equals(getString(R.string.sandbox_relaxed))) {
+            sandboxMode = "relaxed";
+        }
 
         // Save settings
         settingsManager.setApiKey(apiKey);
@@ -140,6 +222,13 @@ public class SettingsFragment extends Fragment {
         settingsManager.setSystemPrompt(systemPrompt);
         settingsManager.setMaxTokens(maxTokens);
         settingsManager.setTemperature(temperature);
+        
+        // Save agent settings
+        settingsManager.setShellAccessEnabled(shellAccessSwitch.isChecked());
+        settingsManager.setSandboxMode(sandboxMode);
+        settingsManager.setMaxAgentIterations(maxIterations);
+        settingsManager.setRequireApproval(requireApprovalSwitch.isChecked());
+        settingsManager.setShellTimeoutSeconds(shellTimeout);
 
         Toast.makeText(requireContext(), "Settings saved", Toast.LENGTH_SHORT).show();
         Navigation.findNavController(requireView()).navigateUp();

--- a/app/src/main/java/io/finett/droidclaw/tool/Tool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/Tool.java
@@ -10,7 +10,7 @@ public interface Tool {
     /**
      * Gets the name of the tool.
      * This is used in the tool_calls from the LLM.
-     * 
+     *
      * @return Tool name (e.g., "read_file", "execute_shell")
      */
     String getName();
@@ -18,7 +18,7 @@ public interface Tool {
     /**
      * Gets the tool definition for the OpenAI API.
      * This defines the tool's schema for function calling.
-     * 
+     *
      * @return ToolDefinition object
      */
     ToolDefinition getDefinition();
@@ -30,4 +30,28 @@ public interface Tool {
      * @return ToolResult containing the execution result
      */
     ToolResult execute(JsonObject arguments);
+    
+    /**
+     * Indicates whether this tool requires user approval before execution.
+     * Destructive operations (shell execution, file deletion, file overwriting)
+     * should return true.
+     *
+     * Default implementation returns false (safe tools).
+     *
+     * @return true if the tool requires user approval, false otherwise
+     */
+    default boolean requiresApproval() {
+        return false;
+    }
+    
+    /**
+     * Gets a human-readable description of what this tool call will do.
+     * Used in approval dialogs to help users understand the operation.
+     *
+     * @param arguments The arguments that will be passed to the tool
+     * @return Human-readable description of the operation
+     */
+    default String getApprovalDescription(JsonObject arguments) {
+        return "Execute " + getName() + " tool";
+    }
 }

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -6,9 +6,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.finett.droidclaw.filesystem.VirtualFileSystem;
 import io.finett.droidclaw.filesystem.WorkspaceManager;
@@ -25,21 +28,44 @@ import io.finett.droidclaw.tool.impl.FileSearchTool;
 import io.finett.droidclaw.tool.impl.FileWriteTool;
 import io.finett.droidclaw.tool.impl.PythonTool;
 import io.finett.droidclaw.tool.impl.ShellTool;
+import io.finett.droidclaw.util.SettingsManager;
 
 /**
  * Registry for managing all available tools.
  * Provides tools to the LLM for function calling.
+ * Respects SettingsManager configuration for tool availability.
  */
 public class ToolRegistry {
+    private static final String TOOL_EXECUTE_SHELL = "execute_shell";
+    private static final String TOOL_EXECUTE_PYTHON = "execute_python";
+    
+    // Tools that require shell access to be enabled
+    private static final Set<String> SHELL_ACCESS_TOOLS = new HashSet<>(Arrays.asList(
+        TOOL_EXECUTE_SHELL,
+        TOOL_EXECUTE_PYTHON
+    ));
+    
     private final Map<String, Tool> tools = new HashMap<>();
     private final Context context;
     private final WorkspaceManager workspaceManager;
     private final VirtualFileSystem vfs;
     private final ShellExecutor shellExecutor;
     private final PythonExecutor pythonExecutor;
+    private final SettingsManager settingsManager;
 
+    /**
+     * Creates a ToolRegistry without settings (for backwards compatibility).
+     */
     public ToolRegistry(Context context) {
+        this(context, null);
+    }
+    
+    /**
+     * Creates a ToolRegistry with settings for configuration.
+     */
+    public ToolRegistry(Context context, SettingsManager settingsManager) {
         this.context = context;
+        this.settingsManager = settingsManager;
 
         // Initialize workspace and filesystem
         this.workspaceManager = new WorkspaceManager(context);
@@ -65,7 +91,7 @@ public class ToolRegistry {
      * Register all available tools.
      */
     private void registerTools() {
-        // File system tools
+        // File system tools (always available)
         registerTool(new FileReadTool(vfs));
         registerTool(new FileWriteTool(vfs));
         registerTool(new FileEditTool(vfs, workspaceManager.getPathValidator()));
@@ -74,9 +100,23 @@ public class ToolRegistry {
         registerTool(new FileInfoTool(vfs));
         registerTool(new FileSearchTool(vfs));
         
-        // Execution tools
+        // Execution tools (always registered, but execution may be blocked by settings)
         registerTool(new ShellTool(workspaceManager.getPathValidator(), ShellConfig.createDefault()));
         registerTool(new PythonTool(context, workspaceManager.getWorkspaceRoot(), PythonConfig.createDefault()));
+    }
+    
+    /**
+     * Check if shell access is enabled in settings.
+     */
+    public boolean isShellAccessEnabled() {
+        return settingsManager == null || settingsManager.isShellAccessEnabled();
+    }
+    
+    /**
+     * Check if a tool requires shell access to be enabled.
+     */
+    public boolean requiresShellAccess(String toolName) {
+        return SHELL_ACCESS_TOOLS.contains(toolName);
     }
 
     /**
@@ -120,12 +160,19 @@ public class ToolRegistry {
     /**
      * Get tool definitions for the OpenAI API.
      * Returns a JSON array of tool definitions.
-     * 
+     * Only includes tools that are currently enabled in settings.
+     *
      * @return JsonArray of tool definitions
      */
     public JsonArray getToolDefinitions() {
         JsonArray definitions = new JsonArray();
+        boolean shellEnabled = isShellAccessEnabled();
+        
         for (Tool tool : tools.values()) {
+            // Skip shell/python tools if shell access is disabled
+            if (requiresShellAccess(tool.getName()) && !shellEnabled) {
+                continue;
+            }
             definitions.add(tool.getDefinition().toJson());
         }
         return definitions;
@@ -133,7 +180,8 @@ public class ToolRegistry {
 
     /**
      * Execute a tool by name with the given arguments.
-     * 
+     * Checks if the tool is allowed to execute based on settings.
+     *
      * @param toolName Name of the tool to execute
      * @param arguments Arguments for the tool
      * @return ToolResult containing the execution result
@@ -142,6 +190,11 @@ public class ToolRegistry {
         Tool tool = getTool(toolName);
         if (tool == null) {
             return ToolResult.error("Tool not found: " + toolName);
+        }
+        
+        // Check if shell access is required but not enabled
+        if (requiresShellAccess(toolName) && !isShellAccessEnabled()) {
+            return ToolResult.error("Shell access is disabled. Enable it in Settings to use " + toolName);
         }
         
         try {

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/FileDeleteTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/FileDeleteTool.java
@@ -41,6 +41,18 @@ public class FileDeleteTool implements Tool {
     public ToolDefinition getDefinition() {
         return definition;
     }
+    
+    @Override
+    public boolean requiresApproval() {
+        return true; // File deletion is a destructive operation
+    }
+    
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        String path = arguments.has("path") ?
+            arguments.get("path").getAsString() : "unknown file";
+        return "Delete file or directory:\n" + path;
+    }
 
     @Override
     public ToolResult execute(JsonObject arguments) {

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/FileEditTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/FileEditTool.java
@@ -58,6 +58,20 @@ public class FileEditTool implements Tool {
     public ToolDefinition getDefinition() {
         return definition;
     }
+    
+    @Override
+    public boolean requiresApproval() {
+        return true; // File editing modifies existing files
+    }
+    
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        String path = arguments.has("path") ?
+            arguments.get("path").getAsString() : "unknown file";
+        String operation = arguments.has("operation") ?
+            arguments.get("operation").getAsString() : "unknown";
+        return "Edit file (" + operation + "):\n" + path;
+    }
 
     @Override
     public ToolResult execute(JsonObject arguments) {

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/FileWriteTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/FileWriteTool.java
@@ -45,6 +45,20 @@ public class FileWriteTool implements Tool {
     public ToolDefinition getDefinition() {
         return definition;
     }
+    
+    @Override
+    public boolean requiresApproval() {
+        return true; // File writing can overwrite existing files
+    }
+    
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        String path = arguments.has("path") ?
+            arguments.get("path").getAsString() : "unknown file";
+        boolean append = arguments.has("append") && arguments.get("append").getAsBoolean();
+        String action = append ? "Append to" : "Write to";
+        return action + " file:\n" + path;
+    }
 
     @Override
     public ToolResult execute(JsonObject arguments) {

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/PythonTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/PythonTool.java
@@ -53,6 +53,25 @@ public class PythonTool implements Tool {
     }
 
     @Override
+    public boolean requiresApproval() {
+        return true; // Python execution can be dangerous
+    }
+    
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        if (arguments.has("package")) {
+            return "Install Python package via pip:\n" + arguments.get("package").getAsString();
+        } else if (arguments.has("script_path")) {
+            return "Execute Python script:\n" + arguments.get("script_path").getAsString();
+        } else if (arguments.has("code")) {
+            String code = arguments.get("code").getAsString();
+            String preview = code.length() > 50 ? code.substring(0, 47) + "..." : code;
+            return "Execute Python code:\n" + preview;
+        }
+        return "Execute Python operation";
+    }
+
+    @Override
     public ToolDefinition getDefinition() {
         JsonObject parameters = new ToolDefinition.ParametersBuilder()
                 .addString("code", "Python code to execute", false)

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ShellTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ShellTool.java
@@ -114,6 +114,20 @@ public class ShellTool implements Tool {
     public String getName() {
         return TOOL_NAME;
     }
+    
+    @Override
+    public boolean requiresApproval() {
+        return true; // Shell commands are potentially dangerous
+    }
+    
+    @Override
+    public String getApprovalDescription(com.google.gson.JsonObject arguments) {
+        String command = arguments.has("command") ?
+            arguments.get("command").getAsString() : "unknown command";
+        String workingDir = arguments.has("working_directory") ?
+            arguments.get("working_directory").getAsString() : ".";
+        return "Execute shell command:\n" + command + "\n\nWorking directory: " + workingDir;
+    }
 
     @Override
     public ToolDefinition getDefinition() {

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -11,12 +11,26 @@ public class SettingsManager {
     private static final String KEY_SYSTEM_PROMPT = "system_prompt";
     private static final String KEY_MAX_TOKENS = "max_tokens";
     private static final String KEY_TEMPERATURE = "temperature";
+    
+    // Agent settings keys (DroidClaw is always an agent)
+    private static final String KEY_SHELL_ACCESS_ENABLED = "shell_access_enabled";
+    private static final String KEY_SANDBOX_MODE = "sandbox_mode";
+    private static final String KEY_MAX_AGENT_ITERATIONS = "max_agent_iterations";
+    private static final String KEY_REQUIRE_APPROVAL = "require_approval";
+    private static final String KEY_SHELL_TIMEOUT_SECONDS = "shell_timeout_seconds";
 
     private static final String DEFAULT_API_URL = "https://api.openai.com/v1/chat/completions";
     private static final String DEFAULT_MODEL_NAME = "gpt-3.5-turbo";
     private static final String DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
     private static final int DEFAULT_MAX_TOKENS = 1024;
     private static final float DEFAULT_TEMPERATURE = 0.7f;
+    
+    // Agent settings defaults (DroidClaw is always an agent)
+    private static final boolean DEFAULT_SHELL_ACCESS_ENABLED = false;
+    private static final String DEFAULT_SANDBOX_MODE = "strict"; // "strict" or "relaxed"
+    private static final int DEFAULT_MAX_AGENT_ITERATIONS = 20;
+    private static final boolean DEFAULT_REQUIRE_APPROVAL = true;
+    private static final int DEFAULT_SHELL_TIMEOUT_SECONDS = 30;
 
     private final SharedPreferences prefs;
 
@@ -75,5 +89,46 @@ public class SettingsManager {
     public boolean isConfigured() {
         String apiKey = getApiKey();
         return apiKey != null && !apiKey.trim().isEmpty();
+    }
+    
+    // Agent settings (DroidClaw is always an agent)
+    public boolean isShellAccessEnabled() {
+        return prefs.getBoolean(KEY_SHELL_ACCESS_ENABLED, DEFAULT_SHELL_ACCESS_ENABLED);
+    }
+    
+    public void setShellAccessEnabled(boolean enabled) {
+        prefs.edit().putBoolean(KEY_SHELL_ACCESS_ENABLED, enabled).apply();
+    }
+    
+    public String getSandboxMode() {
+        return prefs.getString(KEY_SANDBOX_MODE, DEFAULT_SANDBOX_MODE);
+    }
+    
+    public void setSandboxMode(String mode) {
+        prefs.edit().putString(KEY_SANDBOX_MODE, mode).apply();
+    }
+    
+    public int getMaxAgentIterations() {
+        return prefs.getInt(KEY_MAX_AGENT_ITERATIONS, DEFAULT_MAX_AGENT_ITERATIONS);
+    }
+    
+    public void setMaxAgentIterations(int iterations) {
+        prefs.edit().putInt(KEY_MAX_AGENT_ITERATIONS, iterations).apply();
+    }
+    
+    public boolean isRequireApproval() {
+        return prefs.getBoolean(KEY_REQUIRE_APPROVAL, DEFAULT_REQUIRE_APPROVAL);
+    }
+    
+    public void setRequireApproval(boolean require) {
+        prefs.edit().putBoolean(KEY_REQUIRE_APPROVAL, require).apply();
+    }
+    
+    public int getShellTimeoutSeconds() {
+        return prefs.getInt(KEY_SHELL_TIMEOUT_SECONDS, DEFAULT_SHELL_TIMEOUT_SECONDS);
+    }
+    
+    public void setShellTimeoutSeconds(int seconds) {
+        prefs.edit().putInt(KEY_SHELL_TIMEOUT_SECONDS, seconds).apply();
     }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -136,6 +136,139 @@
 
         </LinearLayout>
 
+        <!-- Agent Settings Section -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/agent_settings"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp" />
+
+        <!-- Shell Access Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/shell_access"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/shell_access_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/shellAccessSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <!-- Sandbox Mode Dropdown -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/sandboxModeLayout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/sandbox_mode"
+            app:boxBackgroundMode="outline">
+
+            <AutoCompleteTextView
+                android:id="@+id/sandboxModeDropdown"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Max Iterations -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/max_iterations"
+            app:helperText="@string/max_iterations_description"
+            app:boxBackgroundMode="outline">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/maxIterationsInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Require Approval Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/require_approval"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/require_approval_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/requireApprovalSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <!-- Shell Timeout -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:hint="@string/shell_timeout"
+            app:helperText="@string/shell_timeout_description"
+            app:boxBackgroundMode="outline">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/shellTimeoutInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/saveButton"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,20 @@
     <string name="max_tokens">Max Tokens</string>
     <string name="temperature">Temperature</string>
     <string name="save_settings">Save Settings</string>
+    
+    <!-- Agent settings -->
+    <string name="agent_settings">Agent Settings</string>
+    <string name="shell_access">Shell Access</string>
+    <string name="shell_access_description">Allow agent to execute shell commands</string>
+    <string name="sandbox_mode">Sandbox Mode</string>
+    <string name="sandbox_strict">Strict (Workspace only)</string>
+    <string name="sandbox_relaxed">Relaxed (External storage access)</string>
+    <string name="max_iterations">Max Agent Iterations</string>
+    <string name="max_iterations_description">Maximum number of tool execution cycles (1-50)</string>
+    <string name="require_approval">Require Approval</string>
+    <string name="require_approval_description">Ask for confirmation before executing tools</string>
+    <string name="shell_timeout">Shell Timeout (seconds)</string>
+    <string name="shell_timeout_description">Maximum time for shell command execution (5-300)</string>
 
     <!-- Skills UI strings -->
     <string name="skills">Skills</string>

--- a/app/src/test/java/io/finett/droidclaw/agent/AgentLoopTest.java
+++ b/app/src/test/java/io/finett/droidclaw/agent/AgentLoopTest.java
@@ -304,7 +304,7 @@ public class AgentLoopTest {
         agentLoop.start(conversation, mockCallback);
         
         // Verify max iterations error
-        verify(mockCallback).onError(contains("Maximum iterations reached"));
+        verify(mockCallback).onError(contains("Maximum iterations"));
         verify(mockCallback, never()).onComplete(anyString(), anyList());
     }
 

--- a/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
@@ -135,4 +135,124 @@ public class SettingsManagerTest {
         assertEquals(512, newInstance.getMaxTokens());
         assertEquals(0.5f, newInstance.getTemperature(), 0.001f);
     }
+
+    // ========================
+    // Agent Settings Tests
+    // ========================
+
+    @Test
+    public void isShellAccessEnabled_whenNotSet_returnsFalse() {
+        assertFalse(settingsManager.isShellAccessEnabled());
+    }
+
+    @Test
+    public void setShellAccessEnabled_storesAndRetrievesValue() {
+        settingsManager.setShellAccessEnabled(true);
+
+        assertTrue(settingsManager.isShellAccessEnabled());
+    }
+
+    @Test
+    public void setShellAccessEnabled_canBeDisabled() {
+        settingsManager.setShellAccessEnabled(true);
+        settingsManager.setShellAccessEnabled(false);
+
+        assertFalse(settingsManager.isShellAccessEnabled());
+    }
+
+    @Test
+    public void getSandboxMode_whenNotSet_returnsStrict() {
+        assertEquals("strict", settingsManager.getSandboxMode());
+    }
+
+    @Test
+    public void setSandboxMode_storesAndRetrievesValue() {
+        settingsManager.setSandboxMode("relaxed");
+
+        assertEquals("relaxed", settingsManager.getSandboxMode());
+    }
+
+    @Test
+    public void setSandboxMode_canBeSetToStrict() {
+        settingsManager.setSandboxMode("relaxed");
+        settingsManager.setSandboxMode("strict");
+
+        assertEquals("strict", settingsManager.getSandboxMode());
+    }
+
+    @Test
+    public void getMaxAgentIterations_whenNotSet_returnsDefault() {
+        assertEquals(20, settingsManager.getMaxAgentIterations());
+    }
+
+    @Test
+    public void setMaxAgentIterations_storesAndRetrievesValue() {
+        settingsManager.setMaxAgentIterations(50);
+
+        assertEquals(50, settingsManager.getMaxAgentIterations());
+    }
+
+    @Test
+    public void setMaxAgentIterations_canBeSetToMinimum() {
+        settingsManager.setMaxAgentIterations(1);
+
+        assertEquals(1, settingsManager.getMaxAgentIterations());
+    }
+
+    @Test
+    public void isRequireApproval_whenNotSet_returnsTrue() {
+        assertTrue(settingsManager.isRequireApproval());
+    }
+
+    @Test
+    public void setRequireApproval_storesAndRetrievesValue() {
+        settingsManager.setRequireApproval(false);
+
+        assertFalse(settingsManager.isRequireApproval());
+    }
+
+    @Test
+    public void setRequireApproval_canBeEnabled() {
+        settingsManager.setRequireApproval(false);
+        settingsManager.setRequireApproval(true);
+
+        assertTrue(settingsManager.isRequireApproval());
+    }
+
+    @Test
+    public void getShellTimeoutSeconds_whenNotSet_returnsDefault() {
+        assertEquals(30, settingsManager.getShellTimeoutSeconds());
+    }
+
+    @Test
+    public void setShellTimeoutSeconds_storesAndRetrievesValue() {
+        settingsManager.setShellTimeoutSeconds(60);
+
+        assertEquals(60, settingsManager.getShellTimeoutSeconds());
+    }
+
+    @Test
+    public void setShellTimeoutSeconds_canBeSetToMaximum() {
+        settingsManager.setShellTimeoutSeconds(300);
+
+        assertEquals(300, settingsManager.getShellTimeoutSeconds());
+    }
+
+    @Test
+    public void agentSettingsPersistAcrossInstances() {
+        settingsManager.setShellAccessEnabled(true);
+        settingsManager.setSandboxMode("relaxed");
+        settingsManager.setMaxAgentIterations(30);
+        settingsManager.setRequireApproval(false);
+        settingsManager.setShellTimeoutSeconds(120);
+
+        Context context = RuntimeEnvironment.getApplication();
+        SettingsManager newInstance = new SettingsManager(context);
+
+        assertTrue(newInstance.isShellAccessEnabled());
+        assertEquals("relaxed", newInstance.getSandboxMode());
+        assertEquals(30, newInstance.getMaxAgentIterations());
+        assertFalse(newInstance.isRequireApproval());
+        assertEquals(120, newInstance.getShellTimeoutSeconds());
+    }
 }


### PR DESCRIPTION
Implement user approval system for destructive tool operations and add comprehensive agent configuration options in settings.

Changes:
- Add ApprovalCallback interface to AgentLoop for tool approval flow
- Add requiresApproval() and getApprovalDescription() to Tool interface
- Mark destructive tools (shell, python, file write/edit/delete) as requiring approval with descriptive messages
- Add agent settings to SettingsManager: shell access toggle, sandbox mode, max iterations, require approval, shell timeout
- Update ToolRegistry to respect shell access settings
- Add approval dialog UI in ChatFragment
- Extend settings UI with agent configuration section
- Fix AgentLoopTest assertion for max iterations error message
- Add comprehensive tests for new SettingsManager agent settings