### PR TITLE
feat(ci): add Android emulator tests to CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,31 +45,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+      - name: Run Android tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
           tag: google_apis
           arch: x86_64
-
-      - name: Create and start emulator
-        run: |
-          echo "Creating AVD..."
-          echo no | avdmanager create avd -n test_device -k "system-images;android-35;google_apis;x86_64" --force
-          echo "Starting emulator..."
-          emulator -avd test_device -no-window -no-audio -gpu swiftshader_indirect &
-          adb wait-for-device
-        timeout-minutes: 5
-
-      - name: Run Android tests
-        run: ./gradlew connectedAndroidTest
+          profile: pixel_7_pro
+          script: ./gradlew connectedAndroidTest
+        timeout-minutes: 20
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Adds Android emulator-based instrumented tests to the CI pipeline.

## Changes
- New `test-emulator` job that:
  - Creates an AVD with API 35 (Android 15)
  - Starts emulator in headless mode
  - Runs `./gradlew connectedAndroidTest`
  - Uploads test results on failure
- `build` job now depends on `test-emulator` instead of `test`

## Test Plan
- [ ] CI runs `test-emulator` job on push/PR
- [ ] Instrumented tests execute on emulator
- [ ] Test results uploaded if tests fail
- [ ] APK build only runs after all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)