### PR TITLE
chore: update CI API levels to 34, 35, 36

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,7 +42,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        api-level: [29, 33, 35]
+        api-level: [34, 35, 36]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- Replace API levels [29, 33, 35] with [34, 35, 36]
- Align with Target SDK 35 and upcoming 36