### PR TITLE
feat(agent): add file upload support with attachment management

### DIFF
--- a/app/src/androidTest/java/io/finett/droidclaw/adapter/ChatAdapterTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/adapter/ChatAdapterTest.java
@@ -861,4 +861,164 @@ public class ChatAdapterTest {
             assertNotNull("ViewHolder for type " + i + " should not be null", viewHolder);
         }
     }
+
+    // ==================== ATTACHMENT TESTS ====================
+
+    @Test
+    public void addMessage_attachmentMessage_increasesCount() {
+        ChatMessage attachment = ChatMessage.createAttachmentMessage(
+                "/path/to/file.txt", "file.txt", "text/plain");
+        adapter.addMessage(attachment);
+
+        assertEquals(1, adapter.getItemCount());
+    }
+
+    @Test
+    public void getItemViewType_attachmentMessage_returnsAttachmentType() {
+        adapter.addMessage(ChatMessage.createAttachmentMessage(
+                "/path/to/file.txt", "file.txt", "text/plain"));
+
+        int viewType = adapter.getItemViewType(0);
+
+        assertEquals(ChatMessage.TYPE_ATTACHMENT, viewType);
+    }
+
+    @Test
+    public void onCreateViewHolder_attachmentMessage_createsCorrectViewHolder() {
+        Context context = TestThemeHelper.getThemedContext();
+        RecyclerView recyclerView = new RecyclerView(context);
+        recyclerView.setLayoutManager(new LinearLayoutManager(context));
+
+        ChatAdapter.MessageViewHolder viewHolder = adapter.onCreateViewHolder(
+                recyclerView,
+                ChatMessage.TYPE_ATTACHMENT
+        );
+
+        assertNotNull(viewHolder);
+        assertNotNull(viewHolder.itemView);
+    }
+
+    @Test
+    public void onBindViewHolder_attachmentMessage_bindsCorrectly() {
+        ChatMessage attachment = ChatMessage.createAttachmentMessage(
+                "/path/to/report.pdf", "report.pdf", "application/pdf");
+        adapter.addMessage(attachment);
+
+        Context context = TestThemeHelper.getThemedContext();
+        RecyclerView recyclerView = new RecyclerView(context);
+        recyclerView.setLayoutManager(new LinearLayoutManager(context));
+        ChatAdapter.MessageViewHolder viewHolder = adapter.onCreateViewHolder(
+                recyclerView,
+                ChatMessage.TYPE_ATTACHMENT
+        );
+
+        adapter.onBindViewHolder(viewHolder, 0);
+
+        // AttachmentMessageViewHolder uses Chip as the root view
+        com.google.android.material.chip.Chip chip = (com.google.android.material.chip.Chip) viewHolder.itemView;
+        assertNotNull(chip.getText());
+        assertTrue("Chip text should contain filename",
+                chip.getText().toString().contains("report.pdf"));
+    }
+
+    @Test
+    public void addMessage_userMessageWithAttachments_showsAttachments() {
+        java.util.List<io.finett.droidclaw.model.FileAttachment> attachments = new java.util.ArrayList<>();
+        attachments.add(new io.finett.droidclaw.model.FileAttachment(
+                "abc_test.png", "test.png", "/tmp/abc_test.png", "image/png"));
+
+        ChatMessage message = ChatMessage.createUserMessageWithAttachments("Look at this", attachments);
+        adapter.addMessage(message);
+
+        assertEquals(1, adapter.getItemCount());
+        assertTrue(adapter.getMessages().get(0).hasAttachments());
+    }
+
+    @Test
+    public void onBindViewHolder_userMessageWithAttachments_bindsAttachments() {
+        java.util.List<io.finett.droidclaw.model.FileAttachment> attachments = new java.util.ArrayList<>();
+        attachments.add(new io.finett.droidclaw.model.FileAttachment(
+                "abc_test.txt", "test.txt", "/tmp/abc_test.txt", "text/plain"));
+
+        ChatMessage message = ChatMessage.createUserMessageWithAttachments("Check this", attachments);
+        adapter.addMessage(message);
+
+        Context context = TestThemeHelper.getThemedContext();
+        RecyclerView recyclerView = new RecyclerView(context);
+        recyclerView.setLayoutManager(new LinearLayoutManager(context));
+        ChatAdapter.MessageViewHolder viewHolder = adapter.onCreateViewHolder(
+                recyclerView,
+                ChatMessage.TYPE_USER
+        );
+
+        adapter.onBindViewHolder(viewHolder, 0);
+
+        // Verify attachments container exists
+        android.widget.LinearLayout attachmentsContainer = viewHolder.itemView.findViewById(R.id.attachmentsContainer);
+        assertNotNull(attachmentsContainer);
+    }
+
+    @Test
+    public void onBindViewHolder_toolResultMessage_hasFilesContainer() {
+        ChatMessage toolResult = ChatMessage.createToolResultMessage("call-123", "write_file",
+                "File created: `report.txt`");
+        adapter.addMessage(toolResult);
+
+        Context context = TestThemeHelper.getThemedContext();
+        RecyclerView recyclerView = new RecyclerView(context);
+        recyclerView.setLayoutManager(new LinearLayoutManager(context));
+        ChatAdapter.MessageViewHolder viewHolder = adapter.onCreateViewHolder(
+                recyclerView,
+                ChatMessage.TYPE_TOOL_RESULT
+        );
+
+        adapter.onBindViewHolder(viewHolder, 0);
+
+        // Verify files container exists in tool result
+        android.widget.LinearLayout filesContainer = viewHolder.itemView.findViewById(R.id.toolResultFilesContainer);
+        assertNotNull(filesContainer);
+    }
+
+    @Test
+    public void allMessageTypes_includingAttachment_viewHolderCreation() {
+        Context context = TestThemeHelper.getThemedContext();
+        RecyclerView recyclerView = new RecyclerView(context);
+        recyclerView.setLayoutManager(new LinearLayoutManager(context));
+
+        // Add all message types
+        adapter.addMessage(new ChatMessage("System", ChatMessage.TYPE_SYSTEM));
+        adapter.addMessage(new ChatMessage("User", ChatMessage.TYPE_USER));
+        adapter.addMessage(new ChatMessage("Assistant", ChatMessage.TYPE_ASSISTANT));
+        adapter.addMessage(ChatMessage.createToolCallMessage(null));
+        adapter.addMessage(ChatMessage.createToolResultMessage("c1", "tool", "result"));
+        ChatMessage ctx = new ChatMessage("Context", ChatMessage.TYPE_CONTEXT_CARD);
+        ctx.setIsContextCard(true);
+        ctx.setContextType("heartbeat");
+        ctx.setTimestamp(1000L);
+        adapter.addMessage(ctx);
+        adapter.addMessage(ChatMessage.createAttachmentMessage("/path/f.txt", "f.txt", "text/plain"));
+
+        assertEquals(7, adapter.getItemCount());
+
+        // Verify all view types
+        int[] expectedTypes = {
+                ChatMessage.TYPE_SYSTEM,
+                ChatMessage.TYPE_USER,
+                ChatMessage.TYPE_ASSISTANT,
+                ChatMessage.TYPE_TOOL_CALL,
+                ChatMessage.TYPE_TOOL_RESULT,
+                ChatMessage.TYPE_CONTEXT_CARD,
+                ChatMessage.TYPE_ATTACHMENT
+        };
+
+        for (int i = 0; i < 7; i++) {
+            assertEquals(expectedTypes[i], adapter.getItemViewType(i));
+
+            ChatAdapter.MessageViewHolder viewHolder = adapter.onCreateViewHolder(
+                    recyclerView,
+                    adapter.getItemViewType(i)
+            );
+            assertNotNull("ViewHolder for type " + i + " should not be null", viewHolder);
+        }
+    }
 }

--- a/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
+++ b/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
@@ -1,20 +1,31 @@
 package io.finett.droidclaw.adapter;
 
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.FileProvider;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.chip.Chip;
+
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.finett.droidclaw.R;
 import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.FileAttachment;
 import io.finett.droidclaw.util.MarkdownRenderer;
 
 public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHolder> {
@@ -23,6 +34,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
     private static final int VIEW_TYPE_TOOL_CALL = 2;
     private static final int VIEW_TYPE_TOOL_RESULT = 3;
     private static final int VIEW_TYPE_CONTEXT_CARD = 5;
+    private static final int VIEW_TYPE_ATTACHMENT = 6;
 
     private final List<ChatMessage> messages = new ArrayList<>();
 
@@ -60,6 +72,11 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
                 view = LayoutInflater.from(parent.getContext())
                         .inflate(R.layout.item_message_context_card, parent, false);
                 return new ContextCardMessageViewHolder(view);
+
+            case VIEW_TYPE_ATTACHMENT:
+                view = LayoutInflater.from(parent.getContext())
+                        .inflate(R.layout.item_attachment_chip, parent, false);
+                return new AttachmentMessageViewHolder(view);
 
             default:
                 view = LayoutInflater.from(parent.getContext())
@@ -117,11 +134,13 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
 
     static class UserMessageViewHolder extends MessageViewHolder {
         private final TextView messageText;
+        private final LinearLayout attachmentsContainer;
         private final Context context;
 
         UserMessageViewHolder(@NonNull View itemView) {
             super(itemView);
             messageText = itemView.findViewById(R.id.messageText);
+            attachmentsContainer = itemView.findViewById(R.id.attachmentsContainer);
             context = itemView.getContext();
         }
 
@@ -132,6 +151,79 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
                 MarkdownRenderer.render(context, messageText, content);
             } else {
                 messageText.setText(content);
+            }
+
+            // Display attachments if present
+            renderAttachments(message);
+        }
+
+        /**
+         * Renders file attachment chips for the message.
+         */
+        private void renderAttachments(ChatMessage message) {
+            attachmentsContainer.removeAllViews();
+
+            if (!message.hasAttachments()) {
+                attachmentsContainer.setVisibility(View.GONE);
+                return;
+            }
+
+            attachmentsContainer.setVisibility(View.VISIBLE);
+
+            for (FileAttachment attachment : message.getAttachments()) {
+                Chip chip = (Chip) LayoutInflater.from(context)
+                        .inflate(R.layout.item_attachment_chip, attachmentsContainer, false);
+
+                String icon = attachment.getDisplayIcon();
+                chip.setText(icon + " " + attachment.getOriginalName());
+
+                // Click to open file
+                chip.setOnClickListener(v -> openFile(attachment));
+
+                attachmentsContainer.addView(chip);
+            }
+        }
+
+        /**
+         * Opens the attached file with an external app.
+         */
+        private void openFile(FileAttachment attachment) {
+            File file = new File(attachment.getAbsolutePath());
+            if (!file.exists()) {
+                Toast.makeText(context, "File not found: " + attachment.getOriginalName(),
+                        Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            try {
+                Uri fileUri = FileProvider.getUriForFile(context,
+                        context.getPackageName() + ".fileprovider", file);
+
+                Intent intent = new Intent(Intent.ACTION_VIEW);
+                intent.setDataAndType(fileUri, attachment.getMimeType());
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                // Check if there's an app to handle this intent
+                if (intent.resolveActivity(context.getPackageManager()) != null) {
+                    context.startActivity(intent);
+                } else {
+                    // No app found - show chooser with "Open with" prompt
+                    Intent chooser = Intent.createChooser(intent,
+                            context.getString(R.string.file_viewer_open_with));
+                    if (chooser.resolveActivity(context.getPackageManager()) != null) {
+                        context.startActivity(chooser);
+                    } else {
+                        Toast.makeText(context,
+                                context.getString(R.string.file_viewer_no_app_found,
+                                        attachment.getOriginalName()),
+                                Toast.LENGTH_LONG).show();
+                    }
+                }
+            } catch (Exception e) {
+                Toast.makeText(context,
+                        context.getString(R.string.file_viewer_open_error,
+                                attachment.getOriginalName()),
+                        Toast.LENGTH_LONG).show();
             }
         }
     }
@@ -242,7 +334,13 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         private final TextView toolResultLabel;
         private final TextView toolResultToggle;
         private final TextView toolResultContent;
+        private final LinearLayout filesContainer;
         private boolean isExpanded = false;
+
+        // Pattern to detect file paths in tool results
+        private static final Pattern FILE_REF_PATTERN = Pattern.compile(
+            "`([^`]+)`|(/data/data/[^\\s]+|uploads/[^\\s]+)"
+        );
 
         ToolResultMessageViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -251,7 +349,8 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
             toolResultLabel = itemView.findViewById(R.id.toolResultLabel);
             toolResultToggle = itemView.findViewById(R.id.toolResultToggle);
             toolResultContent = itemView.findViewById(R.id.toolResultContent);
-            
+            filesContainer = itemView.findViewById(R.id.toolResultFilesContainer);
+
             // Set up click listener for expand/collapse
             toolResultHeader.setOnClickListener(v -> toggleExpanded());
         }
@@ -296,6 +395,9 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
                 toolResultToggle.setVisibility(View.GONE);
                 toolResultContent.setMaxLines(Integer.MAX_VALUE);
             }
+
+            // Detect and render file references
+            renderFileReferences(content);
         }
         
         private void toggleExpanded() {
@@ -325,6 +427,124 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
                         .append(part.substring(1).toLowerCase());
             }
             return formatted.toString();
+        }
+
+        /**
+         * Detects file references in tool result content and displays them as clickable chips.
+         */
+        private void renderFileReferences(String content) {
+            filesContainer.removeAllViews();
+
+            if (content == null) {
+                filesContainer.setVisibility(View.GONE);
+                return;
+            }
+
+            java.util.Set<String> foundFiles = new java.util.HashSet<>();
+            Matcher matcher = FILE_REF_PATTERN.matcher(content);
+            while (matcher.find()) {
+                String rawPath = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+                if (rawPath == null || rawPath.isEmpty()) continue;
+
+                // Skip common non-file patterns
+                if (rawPath.contains("```") || rawPath.contains("\n") ||
+                    rawPath.startsWith("[") || rawPath.startsWith("(")) continue;
+
+                foundFiles.add(rawPath);
+            }
+
+            if (foundFiles.isEmpty()) {
+                filesContainer.setVisibility(View.GONE);
+                return;
+            }
+
+            filesContainer.setVisibility(View.VISIBLE);
+
+            for (String rawPath : foundFiles) {
+                File file = resolveFile(rawPath);
+                if (file == null || !file.exists()) continue;
+
+                String displayName = file.getName();
+                String mimeType = io.finett.droidclaw.filesystem.FileUploadManager.resolveMimeType(displayName);
+
+                Chip chip = (Chip) LayoutInflater.from(itemView.getContext())
+                        .inflate(R.layout.item_attachment_chip, filesContainer, false);
+
+                String icon = "📎";
+                if (mimeType != null) {
+                    if (mimeType.startsWith("image/")) icon = "🖼️";
+                    else if (mimeType.startsWith("text/")) icon = "📄";
+                    else if (mimeType.contains("pdf")) icon = "📕";
+                    else if (mimeType.contains("spreadsheet")) icon = "📊";
+                }
+
+                chip.setText(icon + " " + displayName);
+                chip.setOnClickListener(v -> openFile(file, displayName, mimeType));
+
+                filesContainer.addView(chip);
+            }
+        }
+
+        /**
+         * Resolves a file reference path to an actual File object.
+         */
+        private File resolveFile(String rawPath) {
+            if (rawPath.startsWith("/")) {
+                return new File(rawPath);
+            }
+
+            // Try workspace directories
+            String[] searchDirs = {"uploads", "home", "home/documents", "home/scripts", "home/notes", "tmp"};
+            File filesDir = itemView.getContext().getFilesDir();
+            File workspaceRoot = new File(filesDir, "workspace");
+
+            // Direct path under workspace
+            File directFile = new File(workspaceRoot, rawPath);
+            if (directFile.exists()) return directFile;
+
+            // Search in subdirectories
+            for (String dir : searchDirs) {
+                File file = new File(workspaceRoot, dir + "/" + rawPath);
+                if (file.exists()) return file;
+            }
+
+            // Just the filename - search uploads first
+            File uploadFile = new File(new File(workspaceRoot, "uploads"), rawPath);
+            if (uploadFile.exists()) return uploadFile;
+
+            return null;
+        }
+
+        /**
+         * Opens a file with an external app.
+         */
+        private void openFile(File file, String displayName, String mimeType) {
+            try {
+                Uri fileUri = FileProvider.getUriForFile(itemView.getContext(),
+                        itemView.getContext().getPackageName() + ".fileprovider", file);
+
+                Intent intent = new Intent(Intent.ACTION_VIEW);
+                intent.setDataAndType(fileUri, mimeType != null ? mimeType : "*/*");
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                if (intent.resolveActivity(itemView.getContext().getPackageManager()) != null) {
+                    itemView.getContext().startActivity(intent);
+                } else {
+                    Intent chooser = Intent.createChooser(intent,
+                            itemView.getContext().getString(R.string.file_viewer_open_with));
+                    if (chooser.resolveActivity(itemView.getContext().getPackageManager()) != null) {
+                        itemView.getContext().startActivity(chooser);
+                    } else {
+                        Toast.makeText(itemView.getContext(),
+                                itemView.getContext().getString(R.string.file_viewer_no_app_found, displayName),
+                                Toast.LENGTH_LONG).show();
+                    }
+                }
+            } catch (Exception e) {
+                Toast.makeText(itemView.getContext(),
+                        itemView.getContext().getString(R.string.file_viewer_open_error, displayName),
+                        Toast.LENGTH_LONG).show();
+            }
         }
     }
 
@@ -438,6 +658,94 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
                 default:
                     return "Task Result";
             }
+        }
+    }
+
+    /**
+     * ViewHolder for agent-referenced file attachment messages (TYPE_ATTACHMENT).
+     * Displays a clickable chip that opens the file in an external app.
+     */
+    static class AttachmentMessageViewHolder extends MessageViewHolder {
+        private final Chip attachmentChip;
+        private final Context context;
+
+        AttachmentMessageViewHolder(@NonNull View itemView) {
+            super(itemView);
+            attachmentChip = (Chip) itemView;
+            context = itemView.getContext();
+        }
+
+        @Override
+        void bind(ChatMessage message) {
+            String rawDisplayName = message.getDisplayName();
+            final String mimeType = message.getFileMimeType();
+            final String filePath = message.getFilePath();
+
+            final String displayName;
+            if (rawDisplayName == null || rawDisplayName.isEmpty()) {
+                if (filePath != null) {
+                    displayName = new File(filePath).getName();
+                } else {
+                    displayName = "Unknown file";
+                }
+            } else {
+                displayName = rawDisplayName;
+            }
+
+            String icon = "📎";
+            if (mimeType != null) {
+                if (mimeType.startsWith("image/")) icon = "🖼️";
+                else if (mimeType.startsWith("text/")) icon = "📄";
+                else if (mimeType.contains("pdf")) icon = "📕";
+                else if (mimeType.contains("spreadsheet") || mimeType.contains("excel")) icon = "📊";
+                else if (mimeType.contains("document")) icon = "📘";
+            }
+
+            final String finalIcon = icon;
+            attachmentChip.setText(finalIcon + " " + displayName);
+
+            attachmentChip.setOnClickListener(v -> {
+                if (filePath == null) {
+                    Toast.makeText(context, "File path not available",
+                            Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                File file = new File(filePath);
+                if (!file.exists()) {
+                    Toast.makeText(context, "File not found: " + displayName,
+                            Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                try {
+                    Uri fileUri = FileProvider.getUriForFile(context,
+                            context.getPackageName() + ".fileprovider", file);
+
+                    String actualMimeType = mimeType != null ? mimeType : "*/*";
+                    Intent intent = new Intent(Intent.ACTION_VIEW);
+                    intent.setDataAndType(fileUri, actualMimeType);
+                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                    if (intent.resolveActivity(context.getPackageManager()) != null) {
+                        context.startActivity(intent);
+                    } else {
+                        Intent chooser = Intent.createChooser(intent,
+                                context.getString(R.string.file_viewer_open_with));
+                        if (chooser.resolveActivity(context.getPackageManager()) != null) {
+                            context.startActivity(chooser);
+                        } else {
+                            Toast.makeText(context,
+                                    context.getString(R.string.file_viewer_no_app_found, displayName),
+                                    Toast.LENGTH_LONG).show();
+                        }
+                    }
+                } catch (Exception e) {
+                    Toast.makeText(context,
+                            context.getString(R.string.file_viewer_open_error, displayName),
+                            Toast.LENGTH_LONG).show();
+                }
+            });
         }
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
@@ -5,11 +5,15 @@ import android.util.Log;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.FileAttachment;
 import io.finett.droidclaw.tool.Tool;
 import io.finett.droidclaw.tool.ToolRegistry;
 import io.finett.droidclaw.tool.ToolResult;
@@ -29,6 +33,13 @@ import io.finett.droidclaw.repository.MemoryRepository;
 public class AgentLoop {
     private static final String TAG = "AgentLoop";
     private static final int DEFAULT_MAX_ITERATIONS = 20;
+
+    // Pattern to detect file paths in agent responses (workspace paths)
+    // Matches: /data/data/.../workspace/... or relative paths like uploads/filename.ext
+    // Also matches backtick-quoted paths like `filename.ext`
+    private static final Pattern FILE_PATH_PATTERN = Pattern.compile(
+        "(?:`([^`]+)`|(/data/data/[^\\s]+|uploads/[^\\s]+|home/[^\\s]+|tmp/[^\\s]+))"
+    );
 
     private final LlmApiService apiService;
     private final ToolRegistry toolRegistry;
@@ -450,7 +461,104 @@ public class AgentLoop {
         ChatMessage assistantMessage = new ChatMessage(content, ChatMessage.TYPE_ASSISTANT);
         conversationHistory.add(assistantMessage);
 
+        // Detect file references in the response and create attachment messages
+        detectAndAddFileReferences(content, conversationHistory);
+
         callback.onComplete(content, conversationHistory);
+    }
+
+    /**
+     * Scans the assistant response for file references and creates TYPE_ATTACHMENT messages.
+     * Detects backtick-quoted filenames and workspace paths.
+     */
+    private void detectAndAddFileReferences(String content, List<ChatMessage> conversationHistory) {
+        if (content == null) return;
+
+        Matcher matcher = FILE_PATH_PATTERN.matcher(content);
+        while (matcher.find()) {
+            String rawPath = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+            if (rawPath == null || rawPath.isEmpty()) continue;
+
+            // Skip if it looks like a code example (has common code markers)
+            if (rawPath.contains("```") || rawPath.contains("\n")) continue;
+
+            String displayName = rawPath;
+            String filePath = rawPath;
+            String mimeType = null;
+
+            // Resolve relative paths to absolute
+            if (!rawPath.startsWith("/")) {
+                // Try to find the file in workspace
+                File workspaceFile = findFileInWorkspace(rawPath);
+                if (workspaceFile != null && workspaceFile.exists()) {
+                    filePath = workspaceFile.getAbsolutePath();
+                    displayName = workspaceFile.getName();
+                    mimeType = io.finett.droidclaw.filesystem.FileUploadManager.resolveMimeType(displayName);
+                }
+            } else if (rawPath.startsWith("/data/data/")) {
+                // Absolute workspace path
+                File file = new File(rawPath);
+                if (file.exists()) {
+                    displayName = file.getName();
+                    mimeType = io.finett.droidclaw.filesystem.FileUploadManager.resolveMimeType(displayName);
+                }
+            }
+
+            // Only create attachment message if file exists
+            File file = new File(filePath);
+            if (file.exists()) {
+                ChatMessage attachmentMsg = ChatMessage.createAttachmentMessage(
+                    filePath, displayName, mimeType);
+                conversationHistory.add(attachmentMsg);
+                Log.d(TAG, "Detected file reference: " + displayName);
+            }
+        }
+    }
+
+    /**
+     * Attempts to find a file in the workspace directories.
+     */
+    private File findFileInWorkspace(String relativePath) {
+        // Try common workspace directories
+        String[] searchDirs = {
+            "uploads",
+            "home",
+            "home/documents",
+            "home/scripts",
+            "home/notes",
+            "tmp"
+        };
+
+        // First try direct path under workspace
+        File workspaceRoot = getWorkspaceRoot();
+        if (workspaceRoot != null) {
+            File directFile = new File(workspaceRoot, relativePath);
+            if (directFile.exists()) {
+                return directFile;
+            }
+
+            // Search in standard directories
+            for (String dir : searchDirs) {
+                File file = new File(workspaceRoot, dir + "/" + relativePath);
+                if (file.exists()) {
+                    return file;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the workspace root from the tool registry.
+     * Returns null if not available.
+     */
+    private File getWorkspaceRoot() {
+        try {
+            return toolRegistry.getWorkspaceRoot();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/filesystem/FileUploadManager.java
+++ b/app/src/main/java/io/finett/droidclaw/filesystem/FileUploadManager.java
@@ -1,0 +1,301 @@
+package io.finett.droidclaw.filesystem;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
+import android.util.Log;
+import android.webkit.MimeTypeMap;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+/**
+ * Manages file uploads from the device into the workspace uploads directory.
+ * Handles copying files from content URIs (from Storage Access Framework) to the workspace.
+ */
+public class FileUploadManager {
+    private static final String TAG = "FileUploadManager";
+    private static final long MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50MB
+
+    private final Context context;
+    private final File uploadsDir;
+
+    public FileUploadManager(Context context, WorkspaceManager workspaceManager) {
+        this.context = context;
+        this.uploadsDir = workspaceManager.getUploadsDirectory();
+        if (!uploadsDir.exists()) {
+            uploadsDir.mkdirs();
+        }
+    }
+
+    /**
+     * Uploads a file from a content URI to the workspace uploads directory.
+     *
+     * @param uri         Content URI from ACTION_OPEN_DOCUMENT or similar
+     * @param displayName Optional display name; if null, resolved from URI
+     * @return UploadResult containing the filename, path, and MIME type
+     */
+    public UploadResult uploadFile(Uri uri, String displayName) throws IOException {
+        if (uri == null) {
+            throw new IllegalArgumentException("URI cannot be null");
+        }
+
+        // Resolve display name
+        String name = displayName;
+        if (name == null || name.isEmpty()) {
+            name = resolveFileName(uri);
+        }
+
+        // Sanitize filename
+        String safeName = sanitizeFilename(name);
+
+        // Ensure unique filename by prepending UUID
+        String extension = "";
+        int dotIndex = safeName.lastIndexOf('.');
+        if (dotIndex > 0) {
+            extension = safeName.substring(dotIndex);
+            safeName = safeName.substring(0, dotIndex);
+        }
+        String uniqueName = UUID.randomUUID().toString().substring(0, 8) + "_" + safeName + extension;
+
+        File destFile = new File(uploadsDir, uniqueName);
+
+        // Check file size before copying
+        long fileSize = getFileSize(uri);
+        if (fileSize > MAX_UPLOAD_SIZE) {
+            throw new IOException("File too large: " + formatSize(fileSize) + " (max: " + formatSize(MAX_UPLOAD_SIZE) + ")");
+        }
+
+        // Copy file to uploads directory
+        copyUriToFile(uri, destFile);
+
+        String mimeType = resolveMimeType(destFile.getName());
+
+        Log.d(TAG, "File uploaded: " + name + " -> " + uniqueName + " (" + formatSize(destFile.length()) + ")");
+
+        return new UploadResult(uniqueName, destFile.getAbsolutePath(), mimeType, name);
+    }
+
+    /**
+     * Copies content from a URI to a destination file.
+     */
+    private void copyUriToFile(Uri uri, File destFile) throws IOException {
+        try (InputStream inputStream = context.getContentResolver().openInputStream(uri);
+             FileOutputStream outputStream = new FileOutputStream(destFile)) {
+
+            if (inputStream == null) {
+                throw new IOException("Could not open input stream for URI: " + uri);
+            }
+
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+        }
+    }
+
+    /**
+     * Resolves the file size from a content URI.
+     */
+    private long getFileSize(Uri uri) {
+        long size = 0;
+        if ("content".equals(uri.getScheme())) {
+            try (Cursor cursor = context.getContentResolver().query(uri, null, null, null, null)) {
+                if (cursor != null && cursor.moveToFirst()) {
+                    int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
+                    if (!cursor.isNull(sizeIndex)) {
+                        size = cursor.getLong(sizeIndex);
+                    }
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "Could not resolve file size for URI: " + uri, e);
+            }
+        }
+        return size;
+    }
+
+    /**
+     * Resolves the original file name from a content URI.
+     */
+    private String resolveFileName(Uri uri) {
+        String name = "uploaded_file";
+
+        if ("content".equals(uri.getScheme())) {
+            try (Cursor cursor = context.getContentResolver().query(uri, null, null, null, null)) {
+                if (cursor != null && cursor.moveToFirst()) {
+                    int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                    if (nameIndex != -1) {
+                        String displayName = cursor.getString(nameIndex);
+                        if (displayName != null && !displayName.isEmpty()) {
+                            name = displayName;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "Could not resolve file name for URI: " + uri, e);
+            }
+        } else if ("file".equals(uri.getScheme())) {
+            File file = new File(uri.getPath());
+            name = file.getName();
+        }
+
+        return name;
+    }
+
+    /**
+     * Resolves MIME type from filename extension.
+     */
+    public static String resolveMimeType(String filename) {
+        String extension = "";
+        int dotIndex = filename.lastIndexOf('.');
+        if (dotIndex > 0) {
+            extension = filename.substring(dotIndex + 1).toLowerCase();
+        }
+
+        // Try Android's MimeTypeMap (available on device)
+        try {
+            MimeTypeMap mimeMap = MimeTypeMap.getSingleton();
+            if (mimeMap != null) {
+                String mimeType = mimeMap.getMimeTypeFromExtension(extension);
+                if (mimeType != null && !mimeType.isEmpty()) {
+                    return mimeType;
+                }
+            }
+        } catch (Exception e) {
+            // MimeTypeMap not available (e.g., in unit tests)
+        }
+
+        // Fallback: common extensions
+        return getMimeTypeFromExtension(extension);
+    }
+
+    /**
+     * Fallback MIME type mapping for common extensions (used when MimeTypeMap is unavailable).
+     */
+    private static String getMimeTypeFromExtension(String ext) {
+        switch (ext) {
+            case "png": return "image/png";
+            case "jpg":
+            case "jpeg": return "image/jpeg";
+            case "gif": return "image/gif";
+            case "webp": return "image/webp";
+            case "bmp": return "image/bmp";
+            case "pdf": return "application/pdf";
+            case "txt":
+            case "md":
+            case "csv":
+            case "log": return "text/plain";
+            case "html":
+            case "htm": return "text/html";
+            case "json": return "application/json";
+            case "xml": return "application/xml";
+            case "zip": return "application/zip";
+            case "doc":
+            case "docx": return "application/msword";
+            case "xls":
+            case "xlsx": return "application/vnd.ms-excel";
+            case "py": return "text/x-python";
+            case "js": return "text/javascript";
+            case "java": return "text/x-java";
+            case "kt": return "text/x-kotlin";
+            case "mp3": return "audio/mpeg";
+            case "mp4":
+            case "avi":
+            case "mov": return "video/mp4";
+            default: return "application/octet-stream";
+        }
+    }
+
+    /**
+     * Sanitizes a filename to prevent path traversal and invalid characters.
+     */
+    private static String sanitizeFilename(String filename) {
+        // Remove path components
+        filename = new File(filename).getName();
+
+        // Remove null bytes and control characters
+        filename = filename.replaceAll("[\\x00-\\x1f]", "");
+
+        // Remove leading/trailing dots and spaces
+        filename = filename.replaceAll("^[.\\s]+|[.\\s]+$", "");
+
+        if (filename.isEmpty()) {
+            filename = "unnamed_file";
+        }
+
+        return filename;
+    }
+
+    /**
+     * Checks if a file is an image that can be sent directly to a vision model.
+     */
+    public static boolean isVisionImage(String mimeType) {
+        return mimeType != null && (mimeType.startsWith("image/png") ||
+                mimeType.startsWith("image/jpeg") ||
+                mimeType.startsWith("image/jpg") ||
+                mimeType.startsWith("image/gif") ||
+                mimeType.startsWith("image/webp"));
+    }
+
+    /**
+     * Checks if a file is an image (by extension).
+     */
+    public static boolean isImageFile(String filename) {
+        if (filename == null) return false;
+        String lower = filename.toLowerCase();
+        return lower.endsWith(".png") || lower.endsWith(".jpg") || lower.endsWith(".jpeg") ||
+                lower.endsWith(".gif") || lower.endsWith(".webp") || lower.endsWith(".bmp");
+    }
+
+    private static String formatSize(long bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
+        return String.format("%.1f MB", bytes / (1024.0 * 1024.0));
+    }
+
+    /**
+     * Result of a file upload operation.
+     */
+    public static class UploadResult {
+        private final String filename;       // Unique name in uploads directory
+        private final String absolutePath;   // Full path to the file
+        private final String mimeType;       // Detected MIME type
+        private final String originalName;   // Original display name from device
+
+        public UploadResult(String filename, String absolutePath, String mimeType, String originalName) {
+            this.filename = filename;
+            this.absolutePath = absolutePath;
+            this.mimeType = mimeType;
+            this.originalName = originalName;
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public String getAbsolutePath() {
+            return absolutePath;
+        }
+
+        public String getMimeType() {
+            return mimeType;
+        }
+
+        public String getOriginalName() {
+            return originalName;
+        }
+
+        public File getFile() {
+            return new File(absolutePath);
+        }
+
+        public boolean isImage() {
+            return isVisionImage(mimeType);
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/filesystem/WorkspaceManager.java
+++ b/app/src/main/java/io/finett/droidclaw/filesystem/WorkspaceManager.java
@@ -36,6 +36,7 @@ public class WorkspaceManager {
     private static final String MEMORY_DIR = ".agent/memory";
     private static final String SKILLS_DIR = ".agent/skills";
     private static final String CONFIG_DIR = ".agent/config";
+    private static final String UPLOADS_DIR = "uploads";
     
     // Identity files
     private static final String SOUL_FILE = ".agent/soul.md";
@@ -77,7 +78,8 @@ public class WorkspaceManager {
             AGENT_DIR,
             MEMORY_DIR,
             SKILLS_DIR,
-            CONFIG_DIR
+            CONFIG_DIR,
+            UPLOADS_DIR
         };
 
         for (String dirPath : standardDirs) {
@@ -334,6 +336,15 @@ public class WorkspaceManager {
      */
     public File getConfigDirectory() {
         return new File(workspaceRoot, CONFIG_DIR);
+    }
+
+    /**
+     * Gets the uploads directory where user-uploaded files are stored.
+     *
+     * @return Uploads directory file
+     */
+    public File getUploadsDirectory() {
+        return new File(workspaceRoot, UPLOADS_DIR);
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -1,6 +1,7 @@
 package io.finett.droidclaw.fragment;
 
 import android.app.AlertDialog;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -12,6 +13,8 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -21,6 +24,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.gson.JsonObject;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,8 +36,10 @@ import io.finett.droidclaw.agent.ConversationSummarizer;
 import io.finett.droidclaw.agent.IdentityManager;
 import io.finett.droidclaw.agent.MemoryContextBuilder;
 import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.filesystem.FileUploadManager;
 import io.finett.droidclaw.filesystem.WorkspaceManager;
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.FileAttachment;
 import io.finett.droidclaw.model.TaskResult;
 import io.finett.droidclaw.repository.ChatRepository;
 import io.finett.droidclaw.repository.MemoryRepository;
@@ -44,10 +50,11 @@ import io.finett.droidclaw.util.SettingsManager;
 public class ChatFragment extends Fragment {
     private static final String TAG = "ChatFragment";
     public static final String ARG_SESSION_ID = "session_id";
-    
+
     private RecyclerView recyclerView;
     private EditText messageInput;
     private ImageButton sendButton;
+    private ImageButton attachButton;
     private View statusContainer;
     private ProgressBar progressBar;
     private TextView statusText;
@@ -61,9 +68,16 @@ public class ChatFragment extends Fragment {
     private AgentLoop agentLoop;
     private IdentityManager identityManager;
     private WorkspaceManager workspaceManager;
+    private FileUploadManager fileUploadManager;
     private ChatContinuationService continuationService;
     private String currentSessionId;
     private TaskResult pendingTaskResult;
+
+    // Pending file attachments (selected but not yet sent)
+    private List<FileAttachment> pendingAttachments = new ArrayList<>();
+
+    // File picker launcher
+    private ActivityResultLauncher<String> filePickerLauncher;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -91,7 +105,20 @@ public class ChatFragment extends Fragment {
         } catch (Exception e) {
             Log.e(TAG, "Failed to initialize workspace", e);
         }
-        
+
+        // Initialize file upload manager
+        fileUploadManager = new FileUploadManager(requireContext(), workspaceManager);
+
+        // Register file picker launcher
+        filePickerLauncher = registerForActivityResult(
+            new ActivityResultContracts.GetContent(),
+            uri -> {
+                if (uri != null) {
+                    uploadSelectedFile(uri);
+                }
+            }
+        );
+
         identityManager = new IdentityManager(requireContext(), workspaceManager);
         
         // Initialize memory system
@@ -154,6 +181,7 @@ public class ChatFragment extends Fragment {
         recyclerView = view.findViewById(R.id.recyclerView);
         messageInput = view.findViewById(R.id.messageInput);
         sendButton = view.findViewById(R.id.sendButton);
+        attachButton = view.findViewById(R.id.attachButton);
         statusContainer = view.findViewById(R.id.statusContainer);
         progressBar = view.findViewById(R.id.progressBar);
         statusText = view.findViewById(R.id.statusText);
@@ -246,10 +274,65 @@ public class ChatFragment extends Fragment {
     private void setupClickListeners() {
         sendButton.setOnClickListener(v -> sendMessage());
 
+        attachButton.setOnClickListener(v -> launchFilePicker());
+
         messageInput.setOnEditorActionListener((v, actionId, event) -> {
             sendMessage();
             return true;
         });
+    }
+
+    /**
+     * Launch the system file picker to select a file for attachment.
+     */
+    private void launchFilePicker() {
+        filePickerLauncher.launch("*/*");
+    }
+
+    /**
+     * Handle the selected file from the picker. Uploads it to the workspace uploads directory.
+     */
+    private void uploadSelectedFile(Uri uri) {
+        if (fileUploadManager == null) {
+            Toast.makeText(requireContext(), "File upload not available", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        new Thread(() -> {
+            try {
+                FileUploadManager.UploadResult result = fileUploadManager.uploadFile(uri, null);
+                FileAttachment attachment = new FileAttachment(
+                    result.getFilename(),
+                    result.getOriginalName(),
+                    result.getAbsolutePath(),
+                    result.getMimeType()
+                );
+
+                requireActivity().runOnUiThread(() -> {
+                    pendingAttachments.add(attachment);
+                    Toast.makeText(requireContext(),
+                        "Attached: " + result.getOriginalName(),
+                        Toast.LENGTH_SHORT).show();
+                    Log.d(TAG, "File attached: " + result.getOriginalName() + " -> " + result.getFilename());
+                });
+            } catch (IOException e) {
+                Log.e(TAG, "Failed to upload file", e);
+                requireActivity().runOnUiThread(() ->
+                    Toast.makeText(requireContext(),
+                        "Failed to attach file: " + e.getMessage(),
+                        Toast.LENGTH_LONG).show()
+                );
+            }
+        }).start();
+    }
+
+    /**
+     * Clear pending attachments and return a copy (consumed when sending message).
+     */
+    private List<FileAttachment> consumePendingAttachments() {
+        List<FileAttachment> copy = new ArrayList<>(pendingAttachments);
+        pendingAttachments.clear();
+        return copy;
     }
 
     private void sendMessage() {
@@ -265,7 +348,15 @@ public class ChatFragment extends Fragment {
             return;
         }
 
-        ChatMessage userMessage = new ChatMessage(messageText, ChatMessage.TYPE_USER);
+        // Consume pending attachments
+        List<FileAttachment> attachments = consumePendingAttachments();
+
+        ChatMessage userMessage;
+        if (!attachments.isEmpty()) {
+            userMessage = ChatMessage.createUserMessageWithAttachments(messageText, attachments);
+        } else {
+            userMessage = new ChatMessage(messageText, ChatMessage.TYPE_USER);
+        }
         chatAdapter.addMessage(userMessage);
         scrollToBottom();
         

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -8,7 +8,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.HorizontalScrollView;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -22,6 +24,7 @@ import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.chip.Chip;
 import com.google.gson.JsonObject;
 
 import java.io.IOException;
@@ -56,6 +59,8 @@ public class ChatFragment extends Fragment {
     private ImageButton sendButton;
     private ImageButton attachButton;
     private View statusContainer;
+    private HorizontalScrollView attachmentBarContainer;
+    private LinearLayout attachmentBar;
     private ProgressBar progressBar;
     private TextView statusText;
     private TextView statusSubText;
@@ -183,6 +188,8 @@ public class ChatFragment extends Fragment {
         sendButton = view.findViewById(R.id.sendButton);
         attachButton = view.findViewById(R.id.attachButton);
         statusContainer = view.findViewById(R.id.statusContainer);
+        attachmentBarContainer = view.findViewById(R.id.attachmentBarContainer);
+        attachmentBar = view.findViewById(R.id.attachmentBar);
         progressBar = view.findViewById(R.id.progressBar);
         statusText = view.findViewById(R.id.statusText);
         statusSubText = view.findViewById(R.id.statusSubText);
@@ -310,6 +317,7 @@ public class ChatFragment extends Fragment {
 
                 requireActivity().runOnUiThread(() -> {
                     pendingAttachments.add(attachment);
+                    renderPendingAttachments();
                     Toast.makeText(requireContext(),
                         "Attached: " + result.getOriginalName(),
                         Toast.LENGTH_SHORT).show();
@@ -332,7 +340,64 @@ public class ChatFragment extends Fragment {
     private List<FileAttachment> consumePendingAttachments() {
         List<FileAttachment> copy = new ArrayList<>(pendingAttachments);
         pendingAttachments.clear();
+        renderPendingAttachments();
         return copy;
+    }
+
+    /**
+     * Renders pending attachment chips in the bar above the input.
+     */
+    private void renderPendingAttachments() {
+        if (attachmentBar == null || attachmentBarContainer == null) return;
+
+        attachmentBar.removeAllViews();
+
+        if (pendingAttachments.isEmpty()) {
+            attachmentBarContainer.setVisibility(View.GONE);
+            return;
+        }
+
+        attachmentBarContainer.setVisibility(View.VISIBLE);
+
+        for (int i = 0; i < pendingAttachments.size(); i++) {
+            final int index = i;
+            FileAttachment attachment = pendingAttachments.get(i);
+
+            Chip chip = (Chip) LayoutInflater.from(requireContext())
+                    .inflate(R.layout.item_pending_attachment_chip, attachmentBar, false);
+
+            String icon = attachment.getDisplayIcon();
+            String displayName = truncateName(attachment.getOriginalName());
+            chip.setText(icon + " " + displayName);
+
+            chip.setCloseIconVisible(true);
+            chip.setOnCloseIconClickListener(v -> removePendingAttachment(index));
+
+            attachmentBar.addView(chip);
+        }
+    }
+
+    /**
+     * Removes a pending attachment at the given index.
+     */
+    private void removePendingAttachment(int index) {
+        if (index >= 0 && index < pendingAttachments.size()) {
+            String name = pendingAttachments.get(index).getOriginalName();
+            pendingAttachments.remove(index);
+            renderPendingAttachments();
+            Toast.makeText(requireContext(), "Removed: " + name, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Truncates a filename to 15 characters with "..." if longer.
+     */
+    private String truncateName(String name) {
+        if (name == null) return "";
+        if (name.length() > 15) {
+            return name.substring(0, 15) + "...";
+        }
+        return name;
     }
 
     private void sendMessage() {

--- a/app/src/main/java/io/finett/droidclaw/model/ChatMessage.java
+++ b/app/src/main/java/io/finett/droidclaw/model/ChatMessage.java
@@ -3,6 +3,7 @@ package io.finett.droidclaw.model;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.finett.droidclaw.api.LlmApiService;
@@ -14,6 +15,7 @@ public class ChatMessage {
     public static final int TYPE_TOOL_RESULT = 3;
     public static final int TYPE_SYSTEM = 4;
     public static final int TYPE_CONTEXT_CARD = 5;
+    public static final int TYPE_ATTACHMENT = 6;
 
     private String content;
     private int type;
@@ -23,6 +25,12 @@ public class ChatMessage {
     private List<LlmApiService.ToolCall> toolCalls;
     private String toolCallId;
     private String toolName;
+
+    // For attachment messages (user uploads and agent file references)
+    private List<FileAttachment> attachments;
+    private String filePath;    // For TYPE_ATTACHMENT: path to agent-referenced file
+    private String fileMimeType; // For TYPE_ATTACHMENT
+    private String displayName; // For TYPE_ATTACHMENT: friendly name to display
 
     // For context card messages
     private boolean isContextCard;
@@ -146,6 +154,68 @@ public class ChatMessage {
         this.originalTaskId = originalTaskId;
     }
 
+    // Attachment-related methods
+
+    public List<FileAttachment> getAttachments() {
+        return attachments;
+    }
+
+    public void setAttachments(List<FileAttachment> attachments) {
+        this.attachments = attachments;
+    }
+
+    public boolean hasAttachments() {
+        return attachments != null && !attachments.isEmpty();
+    }
+
+    public boolean isAttachment() {
+        return type == TYPE_ATTACHMENT;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public String getFileMimeType() {
+        return fileMimeType;
+    }
+
+    public void setFileMimeType(String fileMimeType) {
+        this.fileMimeType = fileMimeType;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * Creates a user message with file attachments.
+     */
+    public static ChatMessage createUserMessageWithAttachments(String content, List<FileAttachment> attachments) {
+        ChatMessage message = new ChatMessage(content, TYPE_USER);
+        message.attachments = attachments != null ? new ArrayList<>(attachments) : new ArrayList<>();
+        return message;
+    }
+
+    /**
+     * Creates an attachment message for files referenced by the agent.
+     */
+    public static ChatMessage createAttachmentMessage(String filePath, String displayName, String mimeType) {
+        ChatMessage message = new ChatMessage(null, TYPE_ATTACHMENT);
+        message.filePath = filePath;
+        message.displayName = displayName;
+        message.fileMimeType = mimeType;
+        return message;
+    }
+
     /**
      * Create a context card message for task result continuation.
      */
@@ -174,7 +244,12 @@ public class ChatMessage {
 
             case TYPE_USER:
                 message.addProperty("role", "user");
-                message.addProperty("content", content);
+                if (hasAttachments()) {
+                    // Build multipart content
+                    message.add("content", buildUserContentWithAttachments());
+                } else {
+                    message.addProperty("content", content);
+                }
                 break;
 
             case TYPE_ASSISTANT:
@@ -217,12 +292,105 @@ public class ChatMessage {
             case TYPE_CONTEXT_CARD:
                 // Context card - treat as system message with task context
                 message.addProperty("role", "system");
-                String contextContent = "[Task Context: " + contextType + "]\n" + 
+                String contextContent = "[Task Context: " + contextType + "]\n" +
                                        (content != null ? content : "");
                 message.addProperty("content", contextContent);
+                break;
+
+            case TYPE_ATTACHMENT:
+                // Agent-referenced file - send as user message with file info
+                message.addProperty("role", "user");
+                String attachmentText = "File: `" + (displayName != null ? displayName : filePath) + "`\n" +
+                        "The agent mentioned or produced this file. It is available at: " +
+                        (filePath != null ? filePath : "unknown path");
+                message.addProperty("content", attachmentText);
                 break;
         }
 
         return message;
+    }
+
+    /**
+     * Builds multipart content array for user messages with attachments.
+     * Creates an array with text content and image_url content for images.
+     */
+    private JsonArray buildUserContentWithAttachments() {
+        JsonArray contentArray = new JsonArray();
+
+        // Add text content first
+        if (content != null && !content.isEmpty()) {
+            JsonObject textPart = new JsonObject();
+            textPart.addProperty("type", "text");
+            textPart.addProperty("text", content);
+            contentArray.add(textPart);
+        }
+
+        // Add each attachment as appropriate content part
+        for (FileAttachment attachment : attachments) {
+            if (attachment.isImage()) {
+                // For images: use base64 data URL for vision-capable models
+                String base64Data = encodeFileToBase64(attachment.getAbsolutePath());
+                if (base64Data != null) {
+                    JsonObject imagePart = new JsonObject();
+                    imagePart.addProperty("type", "image_url");
+
+                    JsonObject imageUrl = new JsonObject();
+                    imageUrl.addProperty("url", "data:" + attachment.getMimeType() + ";base64," + base64Data);
+                    imagePart.add("image_url", imageUrl);
+
+                    contentArray.add(imagePart);
+                }
+
+                // Always add text reference for the image
+                JsonObject textRef = new JsonObject();
+                textRef.addProperty("type", "text");
+                textRef.addProperty("text", "`" + attachment.getOriginalName() +
+                        "` file attached by user, you can find it in uploads");
+                contentArray.add(textRef);
+            } else {
+                // Non-image files: add text reference
+                String fileRef = "`" + attachment.getOriginalName() +
+                        "` file attached by user, you can find it in uploads";
+                JsonObject textPart = new JsonObject();
+                textPart.addProperty("type", "text");
+                textPart.addProperty("text", fileRef);
+                contentArray.add(textPart);
+            }
+        }
+
+        // If no content parts were added, add plain text
+        if (contentArray.size() == 0) {
+            JsonObject textPart = new JsonObject();
+            textPart.addProperty("type", "text");
+            textPart.addProperty("text", content != null ? content : "");
+            contentArray.add(textPart);
+        }
+
+        return contentArray;
+    }
+
+    /**
+     * Encodes a file's content to base64 string.
+     */
+    private static String encodeFileToBase64(String filePath) {
+        try {
+            java.io.File file = new java.io.File(filePath);
+            if (!file.exists()) {
+                android.util.Log.w("ChatMessage", "File not found for base64 encoding: " + filePath);
+                return null;
+            }
+            byte[] fileContent = new byte[(int) file.length()];
+            try (java.io.FileInputStream fis = new java.io.FileInputStream(file)) {
+                int bytesRead = fis.read(fileContent);
+                if (bytesRead != fileContent.length) {
+                    android.util.Log.w("ChatMessage", "Could not read entire file: " + filePath);
+                    return null;
+                }
+            }
+            return android.util.Base64.encodeToString(fileContent, android.util.Base64.NO_WRAP);
+        } catch (Exception e) {
+            android.util.Log.e("ChatMessage", "Failed to encode file to base64: " + filePath, e);
+            return null;
+        }
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/model/FileAttachment.java
+++ b/app/src/main/java/io/finett/droidclaw/model/FileAttachment.java
@@ -1,0 +1,69 @@
+package io.finett.droidclaw.model;
+
+/**
+ * Represents a file attachment associated with a chat message.
+ */
+public class FileAttachment {
+    private String filename;       // Name stored in uploads directory
+    private String originalName;   // Original display name
+    private String absolutePath;   // Full file path
+    private String mimeType;
+
+    public FileAttachment(String filename, String originalName, String absolutePath, String mimeType) {
+        this.filename = filename;
+        this.originalName = originalName;
+        this.absolutePath = absolutePath;
+        this.mimeType = mimeType;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    public String getOriginalName() {
+        return originalName;
+    }
+
+    public void setOriginalName(String originalName) {
+        this.originalName = originalName;
+    }
+
+    public String getAbsolutePath() {
+        return absolutePath;
+    }
+
+    public void setAbsolutePath(String absolutePath) {
+        this.absolutePath = absolutePath;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public boolean isImage() {
+        return mimeType != null && mimeType.startsWith("image/");
+    }
+
+    public String getDisplayIcon() {
+        if (mimeType == null) return "📎";
+        if (mimeType.startsWith("image/")) return "🖼️";
+        if (mimeType.startsWith("text/")) return "📄";
+        if (mimeType.contains("pdf")) return "📕";
+        if (mimeType.contains("spreadsheet") || mimeType.contains("excel")) return "📊";
+        if (mimeType.contains("document") || mimeType.contains("word")) return "📘";
+        if (mimeType.startsWith("video/")) return "🎬";
+        if (mimeType.startsWith("audio/")) return "🎵";
+        if (mimeType.contains("zip") || mimeType.contains("archive") || mimeType.contains("rar") ||
+            mimeType.contains("tar") || mimeType.contains("compressed")) return "📦";
+        if (mimeType.contains("json") || mimeType.contains("xml")) return "📋";
+        return "📎";
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/repository/ChatRepository.java
+++ b/app/src/main/java/io/finett/droidclaw/repository/ChatRepository.java
@@ -232,7 +232,34 @@ public class ChatRepository {
                         jsonObject.put("originalTaskId", message.getOriginalTaskId());
                     }
                 }
-                
+
+                // Save attachment fields (user messages with file uploads)
+                if (message.hasAttachments()) {
+                    JSONArray attachmentsArray = new JSONArray();
+                    for (io.finett.droidclaw.model.FileAttachment attachment : message.getAttachments()) {
+                        JSONObject attObj = new JSONObject();
+                        attObj.put("filename", attachment.getFilename());
+                        attObj.put("originalName", attachment.getOriginalName());
+                        attObj.put("absolutePath", attachment.getAbsolutePath());
+                        attObj.put("mimeType", attachment.getMimeType());
+                        attachmentsArray.put(attObj);
+                    }
+                    jsonObject.put("attachments", attachmentsArray);
+                }
+
+                // Save TYPE_ATTACHMENT fields
+                if (message.getType() == ChatMessage.TYPE_ATTACHMENT) {
+                    if (message.getFilePath() != null) {
+                        jsonObject.put("filePath", message.getFilePath());
+                    }
+                    if (message.getFileMimeType() != null) {
+                        jsonObject.put("fileMimeType", message.getFileMimeType());
+                    }
+                    if (message.getDisplayName() != null) {
+                        jsonObject.put("displayName", message.getDisplayName());
+                    }
+                }
+
                 jsonArray.put(jsonObject);
             }
             
@@ -312,7 +339,38 @@ public class ChatRepository {
                     } else {
                         message = new ChatMessage(content, type);
                     }
-                    
+
+                    // Restore attachments (for user messages with file uploads)
+                    if (jsonObject.has("attachments")) {
+                        JSONArray attachmentsArray = jsonObject.getJSONArray("attachments");
+                        List<io.finett.droidclaw.model.FileAttachment> attachments = new ArrayList<>();
+                        for (int j = 0; j < attachmentsArray.length(); j++) {
+                            JSONObject attObj = attachmentsArray.getJSONObject(j);
+                            io.finett.droidclaw.model.FileAttachment attachment =
+                                new io.finett.droidclaw.model.FileAttachment(
+                                    attObj.optString("filename", ""),
+                                    attObj.optString("originalName", ""),
+                                    attObj.optString("absolutePath", ""),
+                                    attObj.optString("mimeType", "")
+                                );
+                            attachments.add(attachment);
+                        }
+                        message.setAttachments(attachments);
+                    }
+
+                    // Restore TYPE_ATTACHMENT fields
+                    if (type == ChatMessage.TYPE_ATTACHMENT) {
+                        if (jsonObject.has("filePath") && !jsonObject.isNull("filePath")) {
+                            message.setFilePath(jsonObject.getString("filePath"));
+                        }
+                        if (jsonObject.has("fileMimeType") && !jsonObject.isNull("fileMimeType")) {
+                            message.setFileMimeType(jsonObject.getString("fileMimeType"));
+                        }
+                        if (jsonObject.has("displayName") && !jsonObject.isNull("displayName")) {
+                            message.setDisplayName(jsonObject.getString("displayName"));
+                        }
+                    }
+
                     message.setTimestamp(timestamp);
                     messages.add(message);
                 } catch (Exception e) {

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -241,11 +242,20 @@ public class ToolRegistry {
 
     /**
      * Get the virtual file system instance.
-     * 
+     *
      * @return VirtualFileSystem instance
      */
     public VirtualFileSystem getVirtualFileSystem() {
         return vfs;
+    }
+
+    /**
+     * Get the workspace root directory.
+     *
+     * @return Workspace root File
+     */
+    public File getWorkspaceRoot() {
+        return workspaceManager.getWorkspaceRoot();
     }
 
     /**

--- a/app/src/main/res/drawable/ic_attach.xml
+++ b/app/src/main/res/drawable/ic_attach.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M16.5,6v11.5c0,2.21 -1.79,4 -4,4s-4,-1.79 -4,-4V5c0,-1.38 1.12,-2.5 2.5,-2.5s2.5,1.12 2.5,2.5v10.5c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1V6H10v9.5c0,1.38 1.12,2.5 2.5,2.5s2.5,-1.12 2.5,-2.5V5c0,-2.21 -1.79,-4 -4,-4S7,2.79 7,5v12.5c0,3.04 2.46,5.5 5.5,5.5s5.5,-2.46 5.5,-5.5V6H16.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -85,6 +85,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
+        <ImageButton
+            android:id="@+id/attachButton"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="4dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/attach_file"
+            android:src="@drawable/ic_attach"
+            app:tint="?android:attr/textColorSecondary" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -26,7 +26,7 @@
         app:cardBackgroundColor="?android:attr/colorBackground"
         app:cardCornerRadius="16dp"
         app:cardElevation="4dp"
-        app:layout_constraintBottom_toTopOf="@id/inputContainer"
+        app:layout_constraintBottom_toTopOf="@id/attachmentBarContainer"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginBottom="8dp">
@@ -72,6 +72,28 @@
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>
+
+    <!-- Pending attachments bar (shown when files are selected) -->
+    <HorizontalScrollView
+        android:id="@+id/attachmentBarContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="6dp"
+        android:scrollbars="none"
+        app:layout_constraintBottom_toTopOf="@id/inputContainer"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <LinearLayout
+            android:id="@+id/attachmentBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical" />
+
+    </HorizontalScrollView>
 
     <LinearLayout
         android:id="@+id/inputContainer"

--- a/app/src/main/res/layout/item_attachment_chip.xml
+++ b/app/src/main/res/layout/item_attachment_chip.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:checkable="false"
+    android:clickable="true"
+    android:focusable="true"
+    android:textColor="?android:attr/textColorPrimary"
+    app:chipBackgroundColor="?attr/colorSurfaceVariant"
+    app:chipCornerRadius="8dp"
+    app:chipMinHeight="32dp"
+    app:chipIconVisible="true"
+    app:chipIconSize="16dp"
+    style="@style/Widget.MaterialComponents.Chip.Entry" />

--- a/app/src/main/res/layout/item_message_tool_result.xml
+++ b/app/src/main/res/layout/item_message_tool_result.xml
@@ -71,6 +71,15 @@
                 android:maxLines="15"
                 android:ellipsize="end" />
 
+            <!-- Container for file references detected in tool results -->
+            <LinearLayout
+                android:id="@+id/toolResultFilesContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="6dp"
+                android:visibility="gone" />
+
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_message_user.xml
+++ b/app/src/main/res/layout/item_message_user.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="vertical"
     android:paddingVertical="4dp">
+
+    <LinearLayout
+        android:id="@+id/attachmentsContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:orientation="vertical"
+        android:layout_marginBottom="4dp"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/messageText"
@@ -16,4 +26,4 @@
         android:textColor="@android:color/white"
         android:textSize="16sp" />
 
-</FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_pending_attachment_chip.xml
+++ b/app/src/main/res/layout/item_pending_attachment_chip.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="4dp"
+    android:checkable="false"
+    android:clickable="false"
+    android:focusable="false"
+    android:textColor="?android:attr/textColorPrimary"
+    app:chipBackgroundColor="?attr/colorSurfaceVariant"
+    app:chipCornerRadius="8dp"
+    app:chipMinHeight="32dp"
+    app:chipIconVisible="true"
+    app:chipIconSize="16dp"
+    app:closeIconVisible="true"
+    app:closeIcon="@drawable/ic_close"
+    style="@style/Widget.MaterialComponents.Chip.Entry" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">DroidClaw</string>
     <string name="type_message">Type a message…</string>
     <string name="send">Send</string>
+    <string name="attach_file">Attach file</string>
     <string name="menu">Menu</string>
     <string name="new_chat">New Chat</string>
     <string name="chats">Chats</string>
@@ -136,7 +137,7 @@
     <string name="file_viewer_close">Close</string>
     <string name="file_viewer_error">Error reading file: %1$s</string>
     <string name="file_viewer_file_not_found">File not found: %1$s</string>
-    <string name="file_viewer_no_app_found">No app found to open this file</string>
+    <string name="file_viewer_no_app_found">No app found to open: %1$s</string>
     <string name="file_viewer_open_error">Error opening file: %1$s</string>
     <string name="file_viewer_open_with">Open with</string>
     <string name="settings_skills">Skills</string>

--- a/app/src/test/java/io/finett/droidclaw/filesystem/FileUploadManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/filesystem/FileUploadManagerTest.java
@@ -1,0 +1,148 @@
+package io.finett.droidclaw.filesystem;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for FileUploadManager utility methods.
+ */
+public class FileUploadManagerTest {
+
+    @Test
+    public void testResolveMimeType_Png() {
+        assertEquals("image/png", FileUploadManager.resolveMimeType("test.png"));
+    }
+
+    @Test
+    public void testResolveMimeType_Jpg() {
+        assertEquals("image/jpeg", FileUploadManager.resolveMimeType("photo.jpg"));
+    }
+
+    @Test
+    public void testResolveMimeType_Jpeg() {
+        assertEquals("image/jpeg", FileUploadManager.resolveMimeType("photo.jpeg"));
+    }
+
+    @Test
+    public void testResolveMimeType_Pdf() {
+        assertEquals("application/pdf", FileUploadManager.resolveMimeType("document.pdf"));
+    }
+
+    @Test
+    public void testResolveMimeType_Text() {
+        assertEquals("text/plain", FileUploadManager.resolveMimeType("notes.txt"));
+    }
+
+    @Test
+    public void testResolveMimeType_Json() {
+        assertEquals("application/json", FileUploadManager.resolveMimeType("data.json"));
+    }
+
+    @Test
+    public void testResolveMimeType_Unknown() {
+        assertEquals("application/octet-stream", FileUploadManager.resolveMimeType("file.unknown"));
+    }
+
+    @Test
+    public void testResolveMimeType_NoExtension() {
+        assertEquals("application/octet-stream", FileUploadManager.resolveMimeType("Makefile"));
+    }
+
+    @Test
+    public void testIsVisionImage_Png() {
+        assertTrue(FileUploadManager.isVisionImage("image/png"));
+    }
+
+    @Test
+    public void testIsVisionImage_Jpeg() {
+        assertTrue(FileUploadManager.isVisionImage("image/jpeg"));
+    }
+
+    @Test
+    public void testIsVisionImage_Gif() {
+        assertTrue(FileUploadManager.isVisionImage("image/gif"));
+    }
+
+    @Test
+    public void testIsVisionImage_Webp() {
+        assertTrue(FileUploadManager.isVisionImage("image/webp"));
+    }
+
+    @Test
+    public void testIsVisionImage_Pdf() {
+        assertFalse(FileUploadManager.isVisionImage("application/pdf"));
+    }
+
+    @Test
+    public void testIsVisionImage_Text() {
+        assertFalse(FileUploadManager.isVisionImage("text/plain"));
+    }
+
+    @Test
+    public void testIsVisionImage_Null() {
+        assertFalse(FileUploadManager.isVisionImage(null));
+    }
+
+    @Test
+    public void testIsImageFile_Png() {
+        assertTrue(FileUploadManager.isImageFile("image.png"));
+    }
+
+    @Test
+    public void testIsImageFile_Jpg() {
+        assertTrue(FileUploadManager.isImageFile("photo.jpg"));
+    }
+
+    @Test
+    public void testIsImageFile_Jpeg() {
+        assertTrue(FileUploadManager.isImageFile("photo.jpeg"));
+    }
+
+    @Test
+    public void testIsImageFile_Gif() {
+        assertTrue(FileUploadManager.isImageFile("anim.gif"));
+    }
+
+    @Test
+    public void testIsImageFile_Webp() {
+        assertTrue(FileUploadManager.isImageFile("icon.webp"));
+    }
+
+    @Test
+    public void testIsImageFile_Bmp() {
+        assertTrue(FileUploadManager.isImageFile("bitmap.bmp"));
+    }
+
+    @Test
+    public void testIsImageFile_Pdf() {
+        assertFalse(FileUploadManager.isImageFile("doc.pdf"));
+    }
+
+    @Test
+    public void testIsImageFile_Null() {
+        assertFalse(FileUploadManager.isImageFile(null));
+    }
+
+    @Test
+    public void testUploadResult_IsImage() {
+        FileUploadManager.UploadResult imageResult = new FileUploadManager.UploadResult(
+            "abc_img.png", "/path/abc_img.png", "image/png", "img.png");
+        assertTrue(imageResult.isImage());
+
+        FileUploadManager.UploadResult pdfResult = new FileUploadManager.UploadResult(
+            "def_doc.pdf", "/path/def_doc.pdf", "application/pdf", "doc.pdf");
+        assertFalse(pdfResult.isImage());
+    }
+
+    @Test
+    public void testUploadResult_Getters() {
+        FileUploadManager.UploadResult result = new FileUploadManager.UploadResult(
+            "abc_test.txt", "/path/abc_test.txt", "text/plain", "test.txt");
+
+        assertEquals("abc_test.txt", result.getFilename());
+        assertEquals("test.txt", result.getOriginalName());
+        assertEquals("/path/abc_test.txt", result.getAbsolutePath());
+        assertEquals("text/plain", result.getMimeType());
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/model/ChatMessageAttachmentTest.java
+++ b/app/src/test/java/io/finett/droidclaw/model/ChatMessageAttachmentTest.java
@@ -1,0 +1,192 @@
+package io.finett.droidclaw.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for ChatMessage attachment handling.
+ */
+public class ChatMessageAttachmentTest {
+
+    private FileAttachment imageAttachment;
+    private FileAttachment pdfAttachment;
+    private FileAttachment textAttachment;
+
+    @Before
+    public void setUp() {
+        imageAttachment = new FileAttachment(
+            "abc12345_test.png",
+            "test.png",
+            "/data/data/io.finett.droidclaw/files/workspace/uploads/abc12345_test.png",
+            "image/png"
+        );
+
+        pdfAttachment = new FileAttachment(
+            "def67890_report.pdf",
+            "report.pdf",
+            "/data/data/io.finett.droidclaw/files/workspace/uploads/def67890_report.pdf",
+            "application/pdf"
+        );
+
+        textAttachment = new FileAttachment(
+            "ghi11111_notes.txt",
+            "notes.txt",
+            "/data/data/io.finett.droidclaw/files/workspace/uploads/ghi11111_notes.txt",
+            "text/plain"
+        );
+    }
+
+    @Test
+    public void testCreateUserMessageWithAttachments() {
+        List<FileAttachment> attachments = new ArrayList<>();
+        attachments.add(imageAttachment);
+        attachments.add(pdfAttachment);
+
+        ChatMessage message = ChatMessage.createUserMessageWithAttachments(
+            "Check these files", attachments);
+
+        assertEquals(ChatMessage.TYPE_USER, message.getType());
+        assertEquals("Check these files", message.getContent());
+        assertTrue(message.hasAttachments());
+        assertEquals(2, message.getAttachments().size());
+    }
+
+    @Test
+    public void testCreateUserMessageWithNullAttachments() {
+        ChatMessage message = ChatMessage.createUserMessageWithAttachments("Hello", null);
+
+        assertEquals(ChatMessage.TYPE_USER, message.getType());
+        assertEquals("Hello", message.getContent());
+        assertFalse(message.hasAttachments());
+    }
+
+    @Test
+    public void testCreateAttachmentMessage() {
+        ChatMessage message = ChatMessage.createAttachmentMessage(
+            "/workspace/uploads/file.txt",
+            "My File",
+            "text/plain"
+        );
+
+        assertEquals(ChatMessage.TYPE_ATTACHMENT, message.getType());
+        assertEquals("/workspace/uploads/file.txt", message.getFilePath());
+        assertEquals("My File", message.getDisplayName());
+        assertEquals("text/plain", message.getFileMimeType());
+        assertTrue(message.isAttachment());
+    }
+
+    @Test
+    public void testToApiMessage_UserMessageWithoutAttachments() {
+        ChatMessage message = new ChatMessage("Hello world", ChatMessage.TYPE_USER);
+        JsonObject result = message.toApiMessage();
+
+        assertEquals("user", result.get("role").getAsString());
+        assertEquals("Hello world", result.get("content").getAsString());
+    }
+
+    @Test
+    public void testToApiMessage_UserMessageWithNonImageAttachments() {
+        List<FileAttachment> attachments = new ArrayList<>();
+        attachments.add(textAttachment);
+
+        ChatMessage message = ChatMessage.createUserMessageWithAttachments("Read this", attachments);
+        JsonObject result = message.toApiMessage();
+
+        assertEquals("user", result.get("role").getAsString());
+        assertTrue("Content should be an array for attachments",
+                result.get("content").isJsonArray());
+
+        JsonArray contentArray = result.getAsJsonArray("content");
+        assertEquals("Should have text + file reference parts", 2, contentArray.size());
+
+        // First part: text content
+        JsonObject textPart = contentArray.get(0).getAsJsonObject();
+        assertEquals("text", textPart.get("type").getAsString());
+        assertEquals("Read this", textPart.get("text").getAsString());
+
+        // Second part: file reference
+        JsonObject filePart = contentArray.get(1).getAsJsonObject();
+        assertEquals("text", filePart.get("type").getAsString());
+        String fileText = filePart.get("text").getAsString();
+        assertTrue("Should mention filename", fileText.contains("notes.txt"));
+        assertTrue("Should say attached", fileText.contains("file attached by user"));
+    }
+
+    @Test
+    public void testToApiMessage_OnlyAttachmentNoText() {
+        List<FileAttachment> attachments = new ArrayList<>();
+        attachments.add(imageAttachment);
+
+        ChatMessage message = ChatMessage.createUserMessageWithAttachments(null, attachments);
+        JsonObject result = message.toApiMessage();
+
+        assertEquals("user", result.get("role").getAsString());
+        JsonArray contentArray = result.getAsJsonArray("content");
+
+        // Should have at least a text reference for the file
+        // (image_url part may be missing since the file doesn't exist in unit tests)
+        boolean hasFileReference = false;
+        for (int i = 0; i < contentArray.size(); i++) {
+            JsonObject part = contentArray.get(i).getAsJsonObject();
+            if (part.has("text") && part.get("text").getAsString().contains("test.png")) {
+                hasFileReference = true;
+                break;
+            }
+        }
+        assertTrue("Should contain file reference text", hasFileReference);
+    }
+
+    @Test
+    public void testToApiMessage_ToolCallUnchanged() {
+        ChatMessage message = ChatMessage.createToolCallMessage(new ArrayList<>());
+        JsonObject result = message.toApiMessage();
+
+        assertEquals("assistant", result.get("role").getAsString());
+        assertTrue(result.has("tool_calls"));
+    }
+
+    @Test
+    public void testToApiMessage_ToolResultUnchanged() {
+        ChatMessage message = ChatMessage.createToolResultMessage("call_1", "read_file", "file content");
+        JsonObject result = message.toApiMessage();
+
+        assertEquals("tool", result.get("role").getAsString());
+        assertEquals("call_1", result.get("tool_call_id").getAsString());
+        assertEquals("file content", result.get("content").getAsString());
+    }
+
+    @Test
+    public void testToApiMessage_AttachmentType() {
+        ChatMessage message = ChatMessage.createAttachmentMessage(
+            "/workspace/uploads/report.pdf", "Report", "application/pdf");
+        JsonObject result = message.toApiMessage();
+
+        assertEquals("user", result.get("role").getAsString());
+        String content = result.get("content").getAsString();
+        assertTrue(content.contains("Report"));
+        assertTrue(content.contains("/workspace/uploads/report.pdf"));
+    }
+
+    @Test
+    public void testFileAttachment_IsImage() {
+        assertTrue(imageAttachment.isImage());
+        assertFalse(pdfAttachment.isImage());
+        assertFalse(textAttachment.isImage());
+    }
+
+    @Test
+    public void testFileAttachment_DisplayIcons() {
+        assertEquals("🖼️", imageAttachment.getDisplayIcon());
+        assertEquals("📕", pdfAttachment.getDisplayIcon());
+        assertEquals("📄", textAttachment.getDisplayIcon());
+    }
+}


### PR DESCRIPTION
- Add FileUploadManager for handling file uploads with type detection
- Introduce FileAttachment model for structured attachment metadata
- Update ChatMessage to support multiple attachments per message
- Enhance ChatAdapter to render attachment chips in chat messages
- Add file upload UI to user message input area
- Update AgentLoop to process attachments in tool execution context
- Extend WorkspaceManager to manage uploaded files in sandbox
- Add attachment-related string resources and UI layouts
- Add FileUploadManager unit tests
- Add ChatMessage attachment test coverage

This enables users to attach files to their messages, which are then processed by the agent alongside text input. Files are stored in a sandboxed workspace and can be referenced by tools.