### PR TITLE
Adopt Material Design 3 theming and add custom Application class

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
+        android:name=".DroidClawApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/io/finett/droidclaw/DroidClawApplication.java
+++ b/app/src/main/java/io/finett/droidclaw/DroidClawApplication.java
@@ -1,0 +1,14 @@
+package io.finett.droidclaw;
+
+import android.app.Application;
+
+import com.google.android.material.color.DynamicColors;
+
+public class DroidClawApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        DynamicColors.applyToActivitiesIfAvailable(this);
+        super.onCreate();
+    }
+}

--- a/app/src/main/res/drawable/bg_message_assistant.xml
+++ b/app/src/main/res/drawable/bg_message_assistant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/assistant_message_bg" />
+    <solid android:color="?attr/colorSecondaryContainer" />
     <corners android:radius="16dp" />
 </shape>

--- a/app/src/main/res/drawable/bg_message_user.xml
+++ b/app/src/main/res/drawable/bg_message_user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="?attr/colorPrimary" />
+    <solid android:color="?attr/colorPrimaryContainer" />
     <corners android:radius="16dp" />
 </shape>

--- a/app/src/main/res/drawable/ic_attach.xml
+++ b/app/src/main/res/drawable/ic_attach.xml
@@ -2,8 +2,9 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
     <path
-        android:fillColor="#000000"
+        android:fillColor="@android:color/white"
         android:pathData="M16.5,6v11.5c0,2.21 -1.79,4 -4,4s-4,-1.79 -4,-4V5c0,-1.38 1.12,-2.5 2.5,-2.5s2.5,1.12 2.5,2.5v10.5c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1V6H10v9.5c0,1.38 1.12,2.5 2.5,2.5s2.5,-1.12 2.5,-2.5V5c0,-2.21 -1.79,-4 -4,-4S7,2.79 7,5v12.5c0,3.04 2.46,5.5 5.5,5.5s5.5,-2.46 5.5,-5.5V6H16.5z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -2,8 +2,9 @@
     android:width="18dp"
     android:height="18dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
     <path
-        android:fillColor="#000000"
+        android:fillColor="@android:color/white"
         android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -3,7 +3,7 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="#FFFFFF">
+    android:tint="?attr/colorOnPrimary">
     <path
         android:fillColor="@android:color/white"
         android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>

--- a/app/src/main/res/drawable/ic_send.xml
+++ b/app/src/main/res/drawable/ic_send.xml
@@ -3,7 +3,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnPrimary">
     <path
         android:fillColor="@android:color/white"
         android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z" />

--- a/app/src/main/res/layout/item_message_tool_call.xml
+++ b/app/src/main/res/layout/item_message_tool_call.xml
@@ -43,7 +43,7 @@
                     android:layout_height="wrap_content"
                     android:textSize="14sp"
                     android:textStyle="bold"
-                    android:textColor="#1976D2" />
+                    android:textColor="?attr/colorPrimary" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/item_message_tool_result.xml
+++ b/app/src/main/res/layout/item_message_tool_result.xml
@@ -46,7 +46,7 @@
                     android:text="Tool result"
                     android:textSize="12sp"
                     android:textStyle="bold"
-                    android:textColor="#388E3C" />
+                    android:textColor="?attr/colorPrimary" />
 
                 <TextView
                     android:id="@+id/toolResultToggle"

--- a/app/src/main/res/layout/item_message_user.xml
+++ b/app/src/main/res/layout/item_message_user.xml
@@ -23,7 +23,7 @@
         android:maxWidth="280dp"
         android:paddingHorizontal="20dp"
         android:paddingVertical="10dp"
-        android:textColor="@android:color/white"
+        android:textColor="?attr/colorOnPrimaryContainer"
         android:textSize="16sp" />
 
 </LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,4 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="user_message_bg">#FF6200EE</color>
-    <color name="assistant_message_bg">#FFE0E0E0</color>
 </resources>


### PR DESCRIPTION
- Replace hardcoded colors with theme attributes (colorPrimary, colorPrimaryContainer, etc.)
- Add android:tint attributes to vector drawables for proper theming support
- Remove obsolete color constants from colors.xml
- Add DroidClawApplication class to enable DynamicColors (Material 3 theming)
- Update message background drawables to use theme-aware colors
- Update text colors in message layouts for better light/dark theme support