### PR TITLE
fix(ui): remove settingsFragment from top-level navigation

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/MainActivity.java
+++ b/app/src/main/java/io/finett/droidclaw/MainActivity.java
@@ -71,7 +71,6 @@ public class MainActivity extends AppCompatActivity {
             navController = navHostFragment.getNavController();
             appBarConfiguration = new AppBarConfiguration.Builder(
                     R.id.chatFragment,
-                    R.id.settingsFragment,
                     R.id.fileBrowserFragment,
                     R.id.memoryBrowserFragment,
                     R.id.cronJobListFragment


### PR DESCRIPTION
- Exclude settingsFragment from AppBarConfiguration to prevent it from appearing as a drawer menu item (settings accessed via chat menu button instead)