### PR TITLE
feat: Add automatic LLM-based chat session title generation

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/MainActivity.java
+++ b/app/src/main/java/io/finett/droidclaw/MainActivity.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 
 import io.finett.droidclaw.adapter.ChatSessionAdapter;
 import io.finett.droidclaw.fragment.ChatFragment;
+import io.finett.droidclaw.model.ChatMessage;
 import io.finett.droidclaw.model.ChatSession;
 import io.finett.droidclaw.model.SessionType;
 import io.finett.droidclaw.model.TaskResult;
@@ -457,6 +458,61 @@ public class MainActivity extends AppCompatActivity {
         super.onResume();
         // Reload chat sessions when returning to the activity
         loadPersistedChatSessions();
+    }
+
+    /**
+     * Update the toolbar title to reflect the current chat session name.
+     * Called from ChatFragment when a session is loaded or renamed.
+     */
+    public void setToolbarTitle(String title) {
+        if (title != null && !title.isEmpty()) {
+            getSupportActionBar().setTitle(title);
+        } else {
+            getSupportActionBar().setTitle(R.string.app_name);
+        }
+    }
+
+    /**
+     * Get the title of the current chat session for LLM-based title generation.
+     */
+    public String getCurrentSessionTitle() {
+        if (currentSessionId == null) return null;
+        for (ChatSession session : chatSessions) {
+            if (session.getId().equals(currentSessionId)) {
+                return session.getTitle();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the messages of the current chat session for LLM-based title generation.
+     */
+    public List<ChatMessage> getCurrentSessionMessages() {
+        if (currentSessionId == null) return null;
+        return chatRepository.loadMessages(currentSessionId);
+    }
+
+    /**
+     * Update the title of a specific session and notify the adapter.
+     */
+    public void updateSessionTitle(String sessionId, String newTitle) {
+        if (sessionId == null || newTitle == null || newTitle.trim().isEmpty()) {
+            return;
+        }
+
+        for (ChatSession session : chatSessions) {
+            if (session.getId().equals(sessionId)) {
+                session.setTitle(newTitle.trim());
+                session.setUpdatedAt(System.currentTimeMillis());
+                break;
+            }
+        }
+
+        Collections.sort(chatSessions, (s1, s2) -> Long.compare(s2.getUpdatedAt(), s1.getUpdatedAt()));
+        chatRepository.saveSessions(chatSessions);
+        chatSessionAdapter.submitList(new ArrayList<>(chatSessions));
+        Log.d(TAG, "Updated session title: " + sessionId + " -> " + newTitle);
     }
 
     @Override

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -218,16 +218,33 @@ public class ChatFragment extends Fragment {
             chatAdapter.setMessages(savedMessages);
             Log.d(TAG, "loadChatHistory: Loaded " + savedMessages.size() + " messages for session: " + currentSessionId);
             scrollToBottom();
+
+            // Update toolbar with session title
+            updateToolbarTitle();
         } else {
             Log.d(TAG, "loadChatHistory: No saved messages for session: " + currentSessionId);
-            
+
             // If we have a pending task result, add context messages
             if (pendingTaskResult != null) {
                 Log.d(TAG, "loadChatHistory: Adding task result context messages");
                 addTaskResultContext(pendingTaskResult);
                 pendingTaskResult = null; // Clear after use
             }
+
+            // Update toolbar with session title (likely "New Chat")
+            updateToolbarTitle();
         }
+    }
+
+    /**
+     * Update the toolbar title with the current session's title.
+     */
+    private void updateToolbarTitle() {
+        if (!(requireActivity() instanceof MainActivity)) {
+            return;
+        }
+        String title = ((MainActivity) requireActivity()).getCurrentSessionTitle();
+        ((MainActivity) requireActivity()).setToolbarTitle(title);
     }
 
     /**
@@ -276,6 +293,64 @@ public class ChatFragment extends Fragment {
                 firstUserMessage,
                 System.currentTimeMillis()
         );
+    }
+
+    /**
+     * Generate an LLM-based title if the session still has a default title.
+     * Called after the first assistant response.
+     */
+    private void generateTitleIfNeeded(List<ChatMessage> updatedHistory) {
+        if (!(requireActivity() instanceof MainActivity)) {
+            return;
+        }
+
+        MainActivity activity = (MainActivity) requireActivity();
+        String currentTitle = activity.getCurrentSessionTitle();
+
+        // Only generate if still using a default title
+        boolean isDefaultTitle = currentTitle == null
+                || currentTitle.trim().isEmpty()
+                || getString(R.string.new_chat).equals(currentTitle);
+
+        if (!isDefaultTitle) {
+            return;
+        }
+
+        String fallbackTitle = chatRepository.generateTitleFromMessage(
+                getFirstUserMessageContent(updatedHistory)
+        );
+
+        chatRepository.generateTitleWithLLM(apiService, updatedHistory, fallbackTitle,
+                new ChatRepository.TitleGenerationCallback() {
+                    @Override
+                    public void onTitleGenerated(String title) {
+                        if (isAdded() && getContext() != null) {
+                            // Update the session title directly in the activity
+                            activity.updateSessionTitle(currentSessionId, title);
+                            // Update the toolbar
+                            updateToolbarTitle();
+                        }
+                    }
+
+                    @Override
+                    public void onError(String error) {
+                        // Fallback already applied in callback
+                        Log.w(TAG, "Title generation error: " + error);
+                    }
+                });
+    }
+
+    /**
+     * Get the content of the first user message from the history.
+     */
+    private String getFirstUserMessageContent(List<ChatMessage> messages) {
+        if (messages == null) return null;
+        for (ChatMessage msg : messages) {
+            if (msg.getType() == ChatMessage.TYPE_USER) {
+                return msg.getContent();
+            }
+        }
+        return null;
     }
 
     private void setupClickListeners() {
@@ -466,15 +541,21 @@ public class ChatFragment extends Fragment {
             @Override
             public void onComplete(String finalResponse, List<ChatMessage> updatedHistory) {
                 setLoading(false);
-                
+
                 // Update adapter with the full conversation history from the agent
                 chatAdapter.setMessages(updatedHistory);
                 scrollToBottom();
-                
+
                 // Save after adding assistant message
                 saveMessages();
                 updateSessionMetadata(null);
                 Log.d(TAG, "onComplete: Agent completed. Total messages: " + chatAdapter.getItemCount());
+
+                // Generate LLM-based title if this is the first assistant response
+                generateTitleIfNeeded(updatedHistory);
+
+                // Update toolbar title in case the session was renamed
+                updateToolbarTitle();
             }
 
             @Override

--- a/app/src/main/java/io/finett/droidclaw/repository/ChatRepository.java
+++ b/app/src/main/java/io/finett/droidclaw/repository/ChatRepository.java
@@ -25,8 +25,16 @@ public class ChatRepository {
     private static final String PREFS_NAME = "chat_messages";
     private static final String KEY_PREFIX = "session_";
     private static final String KEY_SESSIONS = "chat_sessions";
-    
+
     private final SharedPreferences prefs;
+
+    /**
+     * Callback interface for async title generation.
+     */
+    public interface TitleGenerationCallback {
+        void onTitleGenerated(String title);
+        void onError(String error);
+    }
 
     public ChatRepository(Context context) {
         prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
@@ -180,7 +188,88 @@ public class ChatRepository {
         
         return trimmed.substring(0, 27) + "...";
     }
-    
+
+    /**
+     * Generate a chat title using the LLM to summarize the conversation.
+     * Falls back to generateTitleFromMessage if the LLM call fails.
+     *
+     * @param apiService   The LLM API service
+     * @param messages     The conversation messages to summarize
+     * @param fallbackTitle Title to use if LLM generation fails
+     * @param callback     Callback for the generated title
+     */
+    public void generateTitleWithLLM(LlmApiService apiService, List<ChatMessage> messages,
+                                     String fallbackTitle, TitleGenerationCallback callback) {
+        if (messages == null || messages.isEmpty()) {
+            callback.onTitleGenerated(fallbackTitle);
+            return;
+        }
+
+        // Build a concise message list for title generation (first user message + first assistant response)
+        List<ChatMessage> titleMessages = new ArrayList<>();
+
+        // Find the first user message
+        ChatMessage firstUserMessage = null;
+        for (ChatMessage msg : messages) {
+            if (msg.getType() == ChatMessage.TYPE_USER) {
+                firstUserMessage = msg;
+                break;
+            }
+        }
+
+        if (firstUserMessage == null) {
+            callback.onTitleGenerated(fallbackTitle);
+            return;
+        }
+
+        // Create a system prompt for title generation
+        ChatMessage systemPrompt = new ChatMessage(
+            "Generate a concise, descriptive title for this conversation. " +
+            "The title must be at most 50 characters. " +
+            "Respond with ONLY the title text, nothing else.",
+            ChatMessage.TYPE_SYSTEM
+        );
+        titleMessages.add(systemPrompt);
+        titleMessages.add(new ChatMessage(firstUserMessage.getContent(), ChatMessage.TYPE_USER));
+
+        // Use low temperature for deterministic output
+        apiService.sendMessage(titleMessages, new LlmApiService.ChatCallback() {
+            @Override
+            public void onSuccess(String response) {
+                if (response != null && !response.isEmpty() && !response.equals("No response received")) {
+                    String title = response.trim();
+                    // Remove surrounding quotes if present
+                    if (title.startsWith("\"") && title.endsWith("\"")) {
+                        title = title.substring(1, title.length() - 1);
+                    }
+                    // Enforce 50 character limit
+                    if (title.length() > 50) {
+                        int lastSpace = title.lastIndexOf(' ', 47);
+                        if (lastSpace > 20) {
+                            title = title.substring(0, lastSpace);
+                        } else {
+                            title = title.substring(0, 47) + "...";
+                        }
+                    }
+                    if (title.isEmpty()) {
+                        title = fallbackTitle;
+                    }
+                    Log.d(TAG, "LLM-generated title: " + title);
+                    callback.onTitleGenerated(title);
+                } else {
+                    Log.w(TAG, "LLM returned empty response, using fallback");
+                    callback.onTitleGenerated(fallbackTitle);
+                }
+            }
+
+            @Override
+            public void onError(String error) {
+                Log.w(TAG, "LLM title generation failed: " + error + ", using fallback");
+                callback.onTitleGenerated(fallbackTitle);
+            }
+        });
+    }
+
     // ==================== MESSAGE PERSISTENCE ====================
 
     /**

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
     <fragment
         android:id="@+id/chatFragment"
         android:name="io.finett.droidclaw.fragment.ChatFragment"
-        android:label="DroidClaw">
+        android:label="">
         <argument
             android:name="task_result"
             app:argType="java.io.Serializable"


### PR DESCRIPTION
- Implemented automatic title generation for new chat sessions using LLM
- Toolbar now displays current session title (updated on load/renaming)
- Added generateTitleWithLLM() to ChatRepository with fallback to message-based generation
- Added TitleGenerationCallback interface for async title generation
- Added helper methods in MainActivity for session title management
- ChatFragment generates titles after first assistant response
- Reduced nav_graph label for cleaner toolbar display

The title generation uses the first user message + system prompt, limits output to 50 chars, and gracefully falls back to message-based generation if LLM calls fail.