### PR TITLE
Add native Anthropic API support

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/api/AnthropicProvider.java
+++ b/app/src/main/java/io/finett/droidclaw/api/AnthropicProvider.java
@@ -1,0 +1,300 @@
+package io.finett.droidclaw.api;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.Model;
+import okhttp3.Request;
+
+/**
+ * Provider implementation for Anthropic API (Claude).
+ * Supports the Anthropic messages API with proper handling of:
+ * - Separate system field for system messages
+ * - input_schema instead of parameters for tools
+ * - tool_use content type for tool calls
+ */
+public class AnthropicProvider implements Provider {
+    private static final Gson gson = new Gson();
+
+    // Anthropic API constants
+    private static final String ANTHROPIC_API_VERSION = "2023-06-01";
+    private static final String ANTHROPIC_API_BASE_URL = "https://api.anthropic.com/v1/messages";
+    private static final String ANTHROPIC_TOOLS_BETA = "tools-2024-12-16";
+
+    private final String id;
+    private final String name;
+    private final String baseUrl;
+    private final String apiKey;
+    private final String apiType;
+    private final Model model;
+
+    public AnthropicProvider(String id, String name, String baseUrl, String apiKey,
+                             String apiType, Model model) {
+        this.id = id;
+        this.name = name;
+        this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+        this.apiType = apiType;
+        this.model = model;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    @Override
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public String getApiType() {
+        return apiType;
+    }
+
+    @Override
+    public Model getModel() {
+        return model;
+    }
+
+    @Override
+    public JsonObject buildRequestBody(List<ChatMessage> conversationHistory, JsonArray tools,
+                                       List<ChatMessage> identityMessages) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("model", model.getId());
+        requestBody.addProperty("max_tokens", model.getMaxTokens());
+        requestBody.addProperty("temperature", 0.7f);
+
+        // For Anthropic API, add system messages as a separate field instead of in messages array
+        JsonArray messages = new JsonArray();
+        JsonArray anthropicSystemMessages = new JsonArray();
+
+        // Add identity messages FIRST (system messages with soul.md and user.md)
+        if (identityMessages != null) {
+            for (ChatMessage identityMessage : identityMessages) {
+                // For Anthropic, system messages go in a separate field
+                anthropicSystemMessages.add(identityMessage.toApiMessage());
+            }
+        }
+
+        // Add conversation history
+        for (ChatMessage chatMessage : conversationHistory) {
+            messages.add(chatMessage.toApiMessage());
+        }
+
+        requestBody.add("messages", messages);
+
+        // Add system messages for Anthropic API
+        if (anthropicSystemMessages.size() > 0) {
+            requestBody.add("system", anthropicSystemMessages);
+        }
+
+        // Add tools if provided
+        if (tools != null && tools.size() > 0) {
+            // Anthropic uses "tools" array with specific format
+            // Convert OpenAI-style tools to Anthropic format
+            requestBody.add("tools", convertTools(tools));
+            requestBody.add("tool_choice", new JsonObject());
+        }
+
+        return requestBody;
+    }
+
+    @Override
+    public JsonObject buildRequestBodyWithStructuredOutput(List<ChatMessage> conversationHistory,
+                                                           JsonArray tools,
+                                                           List<ChatMessage> identityMessages,
+                                                           JsonObject responseSchema) {
+        JsonObject requestBody = buildRequestBody(conversationHistory, tools, identityMessages);
+
+        // Add Structured Outputs response_format
+        JsonObject responseFormat = new JsonObject();
+        responseFormat.addProperty("type", "json_schema");
+
+        JsonObject jsonSchema = new JsonObject();
+        jsonSchema.addProperty("strict", true);
+        jsonSchema.add("schema", responseSchema);
+        responseFormat.add("json_schema", jsonSchema);
+
+        requestBody.add("response_format", responseFormat);
+
+        return requestBody;
+    }
+
+    @Override
+    public void addRequestHeaders(Request.Builder requestBuilder) {
+        requestBuilder.addHeader("Content-Type", "application/json");
+        requestBuilder.addHeader("anthropic-version", ANTHROPIC_API_VERSION);
+        requestBuilder.addHeader("anthropic-beta", ANTHROPIC_TOOLS_BETA);
+
+        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
+            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
+        }
+    }
+
+    @Override
+    public String parseResponse(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        // Extract content from Anthropic content array
+        String content = null;
+        JsonArray contentArray = jsonResponse.getAsJsonArray("content");
+        if (contentArray != null && contentArray.size() > 0) {
+            JsonObject firstContent = contentArray.get(0).getAsJsonObject();
+            if (firstContent.has("text")) {
+                content = firstContent.get("text").getAsString();
+            }
+        }
+
+        if (content == null) {
+            return "No response received";
+        }
+        return content;
+    }
+
+    @Override
+    public LlmApiService.LlmResponse parseResponseWithTools(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        // Extract content from Anthropic content array
+        String content = null;
+        JsonArray contentArray = jsonResponse.getAsJsonArray("content");
+        if (contentArray != null && contentArray.size() > 0) {
+            JsonObject firstContent = contentArray.get(0).getAsJsonObject();
+            if (firstContent.has("text")) {
+                content = firstContent.get("text").getAsString();
+            }
+        }
+
+        // Extract tool calls from Anthropic response
+        List<LlmApiService.ToolCall> toolCalls = null;
+        if (contentArray != null) {
+            toolCalls = new ArrayList<>();
+            for (JsonElement contentElement : contentArray) {
+                JsonObject contentObj = contentElement.getAsJsonObject();
+                String type = contentObj.has("type") ? contentObj.get("type").getAsString() : "";
+
+                if ("tool_use".equals(type)) {
+                    String id = contentObj.has("id") ? contentObj.get("id").getAsString() : "";
+                    String name = contentObj.has("name") ? contentObj.get("name").getAsString() : "";
+                    JsonObject inputObj = contentObj.getAsJsonObject("input");
+
+                    toolCalls.add(new LlmApiService.ToolCall(id, name, inputObj));
+                }
+            }
+        }
+
+        // Extract stop reason (Anthropic-specific field)
+        String stopReason = null;
+        if (jsonResponse.has("stop_reason")) {
+            stopReason = jsonResponse.get("stop_reason").getAsString();
+        }
+
+        // Extract token usage - Anthropic uses different field names
+        LlmApiService.TokenUsage usage = null;
+        if (jsonResponse.has("usage")) {
+            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+            int inputTokens = usageObj.has("input_tokens") ? usageObj.get("input_tokens").getAsInt() : 0;
+            int outputTokens = usageObj.has("output_tokens") ? usageObj.get("output_tokens").getAsInt() : 0;
+            usage = new LlmApiService.TokenUsage(inputTokens + outputTokens, inputTokens, outputTokens);
+        }
+
+        return new LlmApiService.LlmResponse(content, toolCalls, usage);
+    }
+
+    @Override
+    public LlmApiService.StructuredResponse parseStructuredResponse(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        // Extract content from Anthropic content array
+        String content = null;
+        JsonArray contentArray = jsonResponse.getAsJsonArray("content");
+        if (contentArray != null && contentArray.size() > 0) {
+            JsonObject firstContent = contentArray.get(0).getAsJsonObject();
+            if (firstContent.has("text")) {
+                content = firstContent.get("text").getAsString();
+            }
+        }
+
+        // Extract tool calls from Anthropic response
+        List<LlmApiService.ToolCall> toolCalls = null;
+        if (contentArray != null) {
+            toolCalls = new ArrayList<>();
+            for (JsonElement contentElement : contentArray) {
+                JsonObject contentObj = contentElement.getAsJsonObject();
+                String type = contentObj.has("type") ? contentObj.get("type").getAsString() : "";
+
+                if ("tool_use".equals(type)) {
+                    String id = contentObj.has("id") ? contentObj.get("id").getAsString() : "";
+                    String name = contentObj.has("name") ? contentObj.get("name").getAsString() : "";
+                    JsonObject inputObj = contentObj.getAsJsonObject("input");
+
+                    toolCalls.add(new LlmApiService.ToolCall(id, name, inputObj));
+                }
+            }
+        }
+
+        // Extract token usage - Anthropic uses different field names
+        LlmApiService.TokenUsage usage = null;
+        if (jsonResponse.has("usage")) {
+            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+            int inputTokens = usageObj.has("input_tokens") ? usageObj.get("input_tokens").getAsInt() : 0;
+            int outputTokens = usageObj.has("output_tokens") ? usageObj.get("output_tokens").getAsInt() : 0;
+            usage = new LlmApiService.TokenUsage(inputTokens + outputTokens, inputTokens, outputTokens);
+        }
+
+        return new LlmApiService.StructuredResponse(content, null, toolCalls, usage);
+    }
+
+    @Override
+    public JsonArray convertTools(JsonArray openaiTools) {
+        JsonArray anthropicTools = new JsonArray();
+        for (JsonElement toolElement : openaiTools) {
+            JsonObject openaiTool = toolElement.getAsJsonObject();
+            JsonObject anthropicTool = new JsonObject();
+
+            // Copy name
+            if (openaiTool.has("name")) {
+                anthropicTool.addProperty("name", openaiTool.get("name").getAsString());
+            }
+
+            // Copy description
+            if (openaiTool.has("description")) {
+                anthropicTool.addProperty("description", openaiTool.get("description").getAsString());
+            }
+
+            // Copy and convert parameters (OpenAI uses "parameters", Anthropic uses "input_schema")
+            if (openaiTool.has("parameters")) {
+                anthropicTool.add("input_schema", openaiTool.get("parameters"));
+            }
+
+            // Add tool_type for Anthropic (optional but can help with tool validation)
+            anthropicTool.addProperty("tool_type", "computer_20241022");
+
+            anthropicTools.add(anthropicTool);
+        }
+        return anthropicTools;
+    }
+
+    @Override
+    public boolean isAnthropic() {
+        return true;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
+++ b/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.finett.droidclaw.model.ChatMessage;
 import io.finett.droidclaw.model.Model;
-import io.finett.droidclaw.model.Provider;
 import io.finett.droidclaw.util.SettingsManager;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -30,14 +29,13 @@ public class LlmApiService {
     private static final String TAG = "LlmApiService";
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 
-    // Anthropic API constants
-    private static final String ANTHROPIC_API_VERSION = "2023-06-01";
-    private static final String ANTHROPIC_API_BASE_URL = "https://api.anthropic.com/v1/messages";
-
     private final OkHttpClient client;
     private final Gson gson;
     private final SettingsManager settingsManager;
     private final Handler mainHandler;
+
+    // Cached provider instance
+    private Provider currentProvider;
 
     /**
      * Represents a tool call from the LLM.
@@ -176,38 +174,94 @@ public class LlmApiService {
     }
 
     /**
-     * Check if the current API configuration is using Anthropic API.
+     * Get the current provider based on API configuration.
      */
-    private boolean isAnthropicApi() {
-        return "anthropic".equalsIgnoreCase(settingsManager.getApiType());
+    private Provider getProvider() {
+        if (currentProvider != null) {
+            return currentProvider;
+        }
+
+        String apiType = settingsManager.getApiType();
+        String providerId = settingsManager.getDefaultProviderId();
+
+        if ("anthropic".equalsIgnoreCase(apiType)) {
+            Object[] selected = settingsManager.getSelectedProviderAndModel();
+            if (selected != null) {
+                Model model = (Model) selected[1];
+                String baseUrl = settingsManager.getApiUrl();
+                String apiKey = settingsManager.getApiKey();
+                currentProvider = new AnthropicProvider(
+                        providerId != null ? providerId : "anthropic",
+                        "Anthropic",
+                        baseUrl != null ? baseUrl : "https://api.anthropic.com/v1/messages",
+                        apiKey,
+                        apiType,
+                        model
+                );
+            } else {
+                currentProvider = new AnthropicProvider(
+                        "anthropic",
+                        "Anthropic",
+                        "https://api.anthropic.com/v1/messages",
+                        "",
+                        "anthropic",
+                        null
+                );
+            }
+        } else {
+            // OpenAI-compatible
+            Object[] selected = settingsManager.getSelectedProviderAndModel();
+            if (selected != null) {
+                Model model = (Model) selected[1];
+                String baseUrl = settingsManager.getApiUrl();
+                String apiKey = settingsManager.getApiKey();
+                currentProvider = new OpenAICompatibleProvider(
+                        providerId != null ? providerId : "openai",
+                        "OpenAI",
+                        baseUrl != null ? baseUrl : "",
+                        apiKey,
+                        apiType,
+                        model
+                );
+            } else {
+                currentProvider = new OpenAICompatibleProvider(
+                        "openai",
+                        "OpenAI",
+                        "",
+                        "",
+                        apiType != null ? apiType : "openai-completions",
+                        null
+                );
+            }
+        }
+
+        return currentProvider;
     }
 
     /**
-     * Get the API URL to use based on the API type.
-     * For Anthropic API, uses the standard Anthropic messages endpoint.
+     * Get the API URL to use based on the provider.
      */
     private String getApiUrl() {
-        if (isAnthropicApi()) {
-            return ANTHROPIC_API_BASE_URL;
+        Provider provider = getProvider();
+        if (provider != null) {
+            return provider.getBaseUrl();
         }
         return settingsManager.getApiUrl();
     }
 
     /**
-     * Build request headers with support for Anthropic-specific headers.
+     * Build request headers with provider-specific headers.
      */
     private void addRequestHeaders(Request.Builder requestBuilder) {
-        requestBuilder.addHeader("Content-Type", "application/json");
-
-        String apiKey = settingsManager.getApiKey();
-        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
-        }
-
-        // Add Anthropic-specific headers if using Anthropic API
-        if (isAnthropicApi()) {
-            requestBuilder.addHeader("anthropic-version", ANTHROPIC_API_VERSION);
-            requestBuilder.addHeader("anthropic-beta", "tools-2024-12-16");
+        Provider provider = getProvider();
+        if (provider != null) {
+            provider.addRequestHeaders(requestBuilder);
+        } else {
+            requestBuilder.addHeader("Content-Type", "application/json");
+            String apiKey = settingsManager.getApiKey();
+            if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
+                requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
+            }
         }
     }
 
@@ -415,24 +469,27 @@ public class LlmApiService {
 
     private JsonObject buildRequestBody(List<ChatMessage> conversationHistory, JsonArray tools,
                                         List<ChatMessage> identityMessages) {
+        Provider provider = getProvider();
+        if (provider != null) {
+            return provider.buildRequestBody(conversationHistory, tools, identityMessages);
+        }
+        // Fallback to default OpenAI format
+        return buildDefaultRequestBody(conversationHistory, tools, identityMessages);
+    }
+
+    private JsonObject buildDefaultRequestBody(List<ChatMessage> conversationHistory, JsonArray tools,
+                                               List<ChatMessage> identityMessages) {
         JsonObject requestBody = new JsonObject();
         requestBody.addProperty("model", settingsManager.getModelName());
         requestBody.addProperty("max_tokens", settingsManager.getMaxTokens());
         requestBody.addProperty("temperature", 0.7f);
 
-        // For Anthropic API, add system messages as a separate field instead of in messages array
         JsonArray messages = new JsonArray();
-        JsonArray anthropicSystemMessages = new JsonArray();
 
         // Add identity messages FIRST (system messages with soul.md and user.md)
         if (identityMessages != null) {
             for (ChatMessage identityMessage : identityMessages) {
-                if (isAnthropicApi()) {
-                    // For Anthropic, system messages go in a separate field
-                    anthropicSystemMessages.add(identityMessage.toApiMessage());
-                } else {
-                    messages.add(identityMessage.toApiMessage());
-                }
+                messages.add(identityMessage.toApiMessage());
             }
         }
 
@@ -443,64 +500,55 @@ public class LlmApiService {
 
         requestBody.add("messages", messages);
 
-        // Add system messages for Anthropic API
-        if (isAnthropicApi() && anthropicSystemMessages.size() > 0) {
-            requestBody.add("system", anthropicSystemMessages);
-        }
-
-        // Add tools if provided
+        // Add tools if provided (OpenAI format)
         if (tools != null && tools.size() > 0) {
-            if (isAnthropicApi()) {
-                // Anthropic uses "tools" array with specific format
-                // Convert OpenAI-style tools to Anthropic format if needed
-                requestBody.add("tools", convertToolsToAnthropicFormat(tools));
-                requestBody.addProperty("tool_choice", new JsonObject());
-            } else {
-                requestBody.add("tools", tools);
-                requestBody.addProperty("tool_choice", "auto");
-            }
+            requestBody.add("tools", tools);
+            requestBody.addProperty("tool_choice", "auto");
         }
 
         return requestBody;
     }
 
-    /**
-     * Convert tools from OpenAI format to Anthropic format.
-     * Anthropic tools require a "tool_type" field and have slightly different structure.
-     *
-     * @param openaiTools Tools in OpenAI format
-     * @return Tools in Anthropic format
-     */
-    private JsonArray convertToolsToAnthropicFormat(JsonArray openaiTools) {
-        JsonArray anthropicTools = new JsonArray();
-        for (JsonElement toolElement : openaiTools) {
-            JsonObject openaiTool = toolElement.getAsJsonObject();
-            JsonObject anthropicTool = new JsonObject();
-
-            // Copy name
-            if (openaiTool.has("name")) {
-                anthropicTool.addProperty("name", openaiTool.get("name").getAsString());
-            }
-
-            // Copy description
-            if (openaiTool.has("description")) {
-                anthropicTool.addProperty("description", openaiTool.get("description").getAsString());
-            }
-
-            // Copy and convert parameters (OpenAI uses "parameters", Anthropic uses "input_schema")
-            if (openaiTool.has("parameters")) {
-                anthropicTool.add("input_schema", openaiTool.get("parameters"));
-            }
-
-            // Add tool_type for Anthropic (optional but can help with tool validation)
-            anthropicTool.addProperty("tool_type", "computer_20241022");
-
-            anthropicTools.add(anthropicTool);
+    private JsonObject buildRequestBodyWithStructuredOutput(List<ChatMessage> conversationHistory, JsonArray tools,
+                                                            List<ChatMessage> identityMessages,
+                                                            JsonObject responseSchema) {
+        Provider provider = getProvider();
+        if (provider != null) {
+            return provider.buildRequestBodyWithStructuredOutput(conversationHistory, tools, identityMessages, responseSchema);
         }
-        return anthropicTools;
+        // Fallback to default OpenAI format
+        return buildDefaultRequestBodyWithStructuredOutput(conversationHistory, tools, identityMessages, responseSchema);
+    }
+
+    private JsonObject buildDefaultRequestBodyWithStructuredOutput(List<ChatMessage> conversationHistory, JsonArray tools,
+                                                                   List<ChatMessage> identityMessages,
+                                                                   JsonObject responseSchema) {
+        JsonObject requestBody = buildDefaultRequestBody(conversationHistory, tools, identityMessages);
+
+        // Add Structured Outputs response_format
+        JsonObject responseFormat = new JsonObject();
+        responseFormat.addProperty("type", "json_schema");
+
+        JsonObject jsonSchema = new JsonObject();
+        jsonSchema.addProperty("strict", true);
+        jsonSchema.add("schema", responseSchema);
+        responseFormat.add("json_schema", jsonSchema);
+
+        requestBody.add("response_format", responseFormat);
+
+        return requestBody;
     }
 
     private String parseResponse(String responseBody) {
+        Provider provider = getProvider();
+        if (provider != null) {
+            return provider.parseResponse(responseBody);
+        }
+        // Fallback to default parsing
+        return parseDefaultResponse(responseBody);
+    }
+
+    private String parseDefaultResponse(String responseBody) {
         JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
         if (choices != null && choices.size() > 0) {
@@ -523,12 +571,16 @@ public class LlmApiService {
      * @return LlmResponse with content and tool calls
      */
     private LlmResponse parseResponseWithTools(String responseBody) {
-        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
-
-        // Check if this is an Anthropic response (different structure - no "choices" array)
-        if (isAnthropicApi() && jsonResponse.has("content")) {
-            return parseAnthropicResponse(responseBody);
+        Provider provider = getProvider();
+        if (provider != null) {
+            return provider.parseResponseWithTools(responseBody);
         }
+        // Fallback to default parsing
+        return parseDefaultResponseWithTools(responseBody);
+    }
+
+    private LlmResponse parseDefaultResponseWithTools(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
 
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
 
@@ -583,74 +635,22 @@ public class LlmApiService {
     }
 
     /**
-     * Parse Anthropic-specific response format.
-     * Anthropic responses have different structure than OpenAI-compatible APIs.
-     *
-     * @param responseBody JSON response from Anthropic API
-     * @return LlmResponse with content and tool calls
-     */
-    private LlmResponse parseAnthropicResponse(String responseBody) {
-        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
-
-        // Extract content
-        String content = null;
-        JsonArray contentArray = jsonResponse.getAsJsonArray("content");
-        if (contentArray != null && contentArray.size() > 0) {
-            JsonObject firstContent = contentArray.get(0).getAsJsonObject();
-            if (firstContent.has("text")) {
-                content = firstContent.get("text").getAsString();
-            }
-        }
-
-        // Extract tool calls from Anthropic response
-        List<ToolCall> toolCalls = null;
-        if (contentArray != null) {
-            toolCalls = new ArrayList<>();
-            for (JsonElement contentElement : contentArray) {
-                JsonObject contentObj = contentElement.getAsJsonObject();
-                String type = contentObj.has("type") ? contentObj.get("type").getAsString() : "";
-
-                if ("tool_use".equals(type)) {
-                    String id = contentObj.has("id") ? contentObj.get("id").getAsString() : "";
-                    String name = contentObj.has("name") ? contentObj.get("name").getAsString() : "";
-                    JsonObject inputObj = contentObj.getAsJsonObject("input");
-
-                    toolCalls.add(new ToolCall(id, name, inputObj));
-                }
-            }
-        }
-
-        // Extract stop reason (Anthropic-specific field)
-        String stopReason = null;
-        if (jsonResponse.has("stop_reason")) {
-            stopReason = jsonResponse.get("stop_reason").getAsString();
-        }
-
-        // Extract token usage - Anthropic uses different field names
-        TokenUsage usage = null;
-        if (jsonResponse.has("usage")) {
-            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
-            int inputTokens = usageObj.has("input_tokens") ? usageObj.get("input_tokens").getAsInt() : 0;
-            int outputTokens = usageObj.has("output_tokens") ? usageObj.get("output_tokens").getAsInt() : 0;
-            usage = new TokenUsage(inputTokens + outputTokens, inputTokens, outputTokens);
-        }
-
-        return new LlmResponse(content, toolCalls, usage);
-    }
-
-    /**
      * Parse a response with Structured Outputs support, including refusal detection.
      *
      * @param responseBody JSON response from API
      * @return StructuredResponse with content, refusal, and tool calls
      */
     private StructuredResponse parseStructuredResponse(String responseBody) {
-        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
-
-        // Check if this is an Anthropic response (different structure - no "choices" array)
-        if (isAnthropicApi() && jsonResponse.has("content")) {
-            return parseAnthropicStructuredResponse(responseBody);
+        Provider provider = getProvider();
+        if (provider != null) {
+            return provider.parseStructuredResponse(responseBody);
         }
+        // Fallback to default parsing
+        return parseDefaultStructuredResponse(responseBody);
+    }
+
+    private StructuredResponse parseDefaultStructuredResponse(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
 
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
 
@@ -706,56 +706,6 @@ public class LlmApiService {
         }
 
         return new StructuredResponse(content, refusal, toolCalls, usage);
-    }
-
-    /**
-     * Parse Anthropic-specific structured response format.
-     * Anthropic responses have different structure than OpenAI-compatible APIs.
-     *
-     * @param responseBody JSON response from Anthropic API
-     * @return StructuredResponse with content and tool calls
-     */
-    private StructuredResponse parseAnthropicStructuredResponse(String responseBody) {
-        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
-
-        // Extract content
-        String content = null;
-        JsonArray contentArray = jsonResponse.getAsJsonArray("content");
-        if (contentArray != null && contentArray.size() > 0) {
-            JsonObject firstContent = contentArray.get(0).getAsJsonObject();
-            if (firstContent.has("text")) {
-                content = firstContent.get("text").getAsString();
-            }
-        }
-
-        // Extract tool calls from Anthropic response
-        List<ToolCall> toolCalls = null;
-        if (contentArray != null) {
-            toolCalls = new ArrayList<>();
-            for (JsonElement contentElement : contentArray) {
-                JsonObject contentObj = contentElement.getAsJsonObject();
-                String type = contentObj.has("type") ? contentObj.get("type").getAsString() : "";
-
-                if ("tool_use".equals(type)) {
-                    String id = contentObj.has("id") ? contentObj.get("id").getAsString() : "";
-                    String name = contentObj.has("name") ? contentObj.get("name").getAsString() : "";
-                    JsonObject inputObj = contentObj.getAsJsonObject("input");
-
-                    toolCalls.add(new ToolCall(id, name, inputObj));
-                }
-            }
-        }
-
-        // Extract token usage - Anthropic uses different field names
-        TokenUsage usage = null;
-        if (jsonResponse.has("usage")) {
-            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
-            int inputTokens = usageObj.has("input_tokens") ? usageObj.get("input_tokens").getAsInt() : 0;
-            int outputTokens = usageObj.has("output_tokens") ? usageObj.get("output_tokens").getAsInt() : 0;
-            usage = new TokenUsage(inputTokens + outputTokens, inputTokens, outputTokens);
-        }
-
-        return new StructuredResponse(content, null, toolCalls, usage);
     }
 
     public void cancelAllRequests() {

--- a/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
+++ b/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.Model;
+import io.finett.droidclaw.model.Provider;
 import io.finett.droidclaw.util.SettingsManager;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -27,6 +29,10 @@ import okhttp3.Response;
 public class LlmApiService {
     private static final String TAG = "LlmApiService";
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+    // Anthropic API constants
+    private static final String ANTHROPIC_API_VERSION = "2023-06-01";
+    private static final String ANTHROPIC_API_BASE_URL = "https://api.anthropic.com/v1/messages";
 
     private final OkHttpClient client;
     private final Gson gson;
@@ -169,6 +175,42 @@ public class LlmApiService {
                 .build();
     }
 
+    /**
+     * Check if the current API configuration is using Anthropic API.
+     */
+    private boolean isAnthropicApi() {
+        return "anthropic".equalsIgnoreCase(settingsManager.getApiType());
+    }
+
+    /**
+     * Get the API URL to use based on the API type.
+     * For Anthropic API, uses the standard Anthropic messages endpoint.
+     */
+    private String getApiUrl() {
+        if (isAnthropicApi()) {
+            return ANTHROPIC_API_BASE_URL;
+        }
+        return settingsManager.getApiUrl();
+    }
+
+    /**
+     * Build request headers with support for Anthropic-specific headers.
+     */
+    private void addRequestHeaders(Request.Builder requestBuilder) {
+        requestBuilder.addHeader("Content-Type", "application/json");
+
+        String apiKey = settingsManager.getApiKey();
+        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
+            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
+        }
+
+        // Add Anthropic-specific headers if using Anthropic API
+        if (isAnthropicApi()) {
+            requestBuilder.addHeader("anthropic-version", ANTHROPIC_API_VERSION);
+            requestBuilder.addHeader("anthropic-beta", "tools-2024-12-16");
+        }
+    }
+
     public void sendMessage(List<ChatMessage> conversationHistory, ChatCallback callback) {
         sendMessage(conversationHistory, null, null, callback);
     }
@@ -188,13 +230,9 @@ public class LlmApiService {
         String jsonBody = gson.toJson(requestBody);
 
         Request.Builder requestBuilder = new Request.Builder()
-                .url(settingsManager.getApiUrl())
-                .addHeader("Content-Type", "application/json");
+                .url(getApiUrl());
 
-        String apiKey = settingsManager.getApiKey();
-        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
-        }
+        addRequestHeaders(requestBuilder);
 
         Request request = requestBuilder
                 .post(RequestBody.create(jsonBody, JSON))
@@ -258,13 +296,9 @@ public class LlmApiService {
         String jsonBody = gson.toJson(requestBody);
 
         Request.Builder requestBuilder = new Request.Builder()
-                .url(settingsManager.getApiUrl())
-                .addHeader("Content-Type", "application/json");
+                .url(getApiUrl());
 
-        String apiKey = settingsManager.getApiKey();
-        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
-        }
+        addRequestHeaders(requestBuilder);
 
         Request request = requestBuilder
                 .post(RequestBody.create(jsonBody, JSON))
@@ -320,13 +354,9 @@ public class LlmApiService {
         String jsonBody = gson.toJson(requestBody);
 
         Request.Builder requestBuilder = new Request.Builder()
-                .url(settingsManager.getApiUrl())
-                .addHeader("Content-Type", "application/json");
+                .url(getApiUrl());
 
-        String apiKey = settingsManager.getApiKey();
-        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
-        }
+        addRequestHeaders(requestBuilder);
 
         Request request = requestBuilder
                 .post(RequestBody.create(jsonBody, JSON))
@@ -390,12 +420,19 @@ public class LlmApiService {
         requestBody.addProperty("max_tokens", settingsManager.getMaxTokens());
         requestBody.addProperty("temperature", 0.7f);
 
+        // For Anthropic API, add system messages as a separate field instead of in messages array
         JsonArray messages = new JsonArray();
+        JsonArray anthropicSystemMessages = new JsonArray();
 
         // Add identity messages FIRST (system messages with soul.md and user.md)
         if (identityMessages != null) {
             for (ChatMessage identityMessage : identityMessages) {
-                messages.add(identityMessage.toApiMessage());
+                if (isAnthropicApi()) {
+                    // For Anthropic, system messages go in a separate field
+                    anthropicSystemMessages.add(identityMessage.toApiMessage());
+                } else {
+                    messages.add(identityMessage.toApiMessage());
+                }
             }
         }
 
@@ -405,14 +442,62 @@ public class LlmApiService {
         }
 
         requestBody.add("messages", messages);
-        
+
+        // Add system messages for Anthropic API
+        if (isAnthropicApi() && anthropicSystemMessages.size() > 0) {
+            requestBody.add("system", anthropicSystemMessages);
+        }
+
         // Add tools if provided
         if (tools != null && tools.size() > 0) {
-            requestBody.add("tools", tools);
-            requestBody.addProperty("tool_choice", "auto");
+            if (isAnthropicApi()) {
+                // Anthropic uses "tools" array with specific format
+                // Convert OpenAI-style tools to Anthropic format if needed
+                requestBody.add("tools", convertToolsToAnthropicFormat(tools));
+                requestBody.addProperty("tool_choice", new JsonObject());
+            } else {
+                requestBody.add("tools", tools);
+                requestBody.addProperty("tool_choice", "auto");
+            }
         }
-        
+
         return requestBody;
+    }
+
+    /**
+     * Convert tools from OpenAI format to Anthropic format.
+     * Anthropic tools require a "tool_type" field and have slightly different structure.
+     *
+     * @param openaiTools Tools in OpenAI format
+     * @return Tools in Anthropic format
+     */
+    private JsonArray convertToolsToAnthropicFormat(JsonArray openaiTools) {
+        JsonArray anthropicTools = new JsonArray();
+        for (JsonElement toolElement : openaiTools) {
+            JsonObject openaiTool = toolElement.getAsJsonObject();
+            JsonObject anthropicTool = new JsonObject();
+
+            // Copy name
+            if (openaiTool.has("name")) {
+                anthropicTool.addProperty("name", openaiTool.get("name").getAsString());
+            }
+
+            // Copy description
+            if (openaiTool.has("description")) {
+                anthropicTool.addProperty("description", openaiTool.get("description").getAsString());
+            }
+
+            // Copy and convert parameters (OpenAI uses "parameters", Anthropic uses "input_schema")
+            if (openaiTool.has("parameters")) {
+                anthropicTool.add("input_schema", openaiTool.get("parameters"));
+            }
+
+            // Add tool_type for Anthropic (optional but can help with tool validation)
+            anthropicTool.addProperty("tool_type", "computer_20241022");
+
+            anthropicTools.add(anthropicTool);
+        }
+        return anthropicTools;
     }
 
     private String parseResponse(String responseBody) {
@@ -439,15 +524,21 @@ public class LlmApiService {
      */
     private LlmResponse parseResponseWithTools(String responseBody) {
         JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        // Check if this is an Anthropic response (different structure - no "choices" array)
+        if (isAnthropicApi() && jsonResponse.has("content")) {
+            return parseAnthropicResponse(responseBody);
+        }
+
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
-        
+
         if (choices == null || choices.size() == 0) {
             return new LlmResponse("No response received", null, null);
         }
 
         JsonObject firstChoice = choices.get(0).getAsJsonObject();
         JsonObject message = firstChoice.getAsJsonObject("message");
-        
+
         if (message == null) {
             return new LlmResponse("No message in response", null, null);
         }
@@ -463,17 +554,17 @@ public class LlmApiService {
         if (message.has("tool_calls")) {
             JsonArray toolCallsArray = message.getAsJsonArray("tool_calls");
             toolCalls = new ArrayList<>();
-            
+
             for (JsonElement toolCallElement : toolCallsArray) {
                 JsonObject toolCallObj = toolCallElement.getAsJsonObject();
                 String id = toolCallObj.get("id").getAsString();
                 JsonObject function = toolCallObj.getAsJsonObject("function");
                 String name = function.get("name").getAsString();
                 String argumentsStr = function.get("arguments").getAsString();
-                
+
                 // Parse arguments string to JsonObject
                 JsonObject arguments = gson.fromJson(argumentsStr, JsonObject.class);
-                
+
                 toolCalls.add(new ToolCall(id, name, arguments));
             }
         }
@@ -492,6 +583,62 @@ public class LlmApiService {
     }
 
     /**
+     * Parse Anthropic-specific response format.
+     * Anthropic responses have different structure than OpenAI-compatible APIs.
+     *
+     * @param responseBody JSON response from Anthropic API
+     * @return LlmResponse with content and tool calls
+     */
+    private LlmResponse parseAnthropicResponse(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        // Extract content
+        String content = null;
+        JsonArray contentArray = jsonResponse.getAsJsonArray("content");
+        if (contentArray != null && contentArray.size() > 0) {
+            JsonObject firstContent = contentArray.get(0).getAsJsonObject();
+            if (firstContent.has("text")) {
+                content = firstContent.get("text").getAsString();
+            }
+        }
+
+        // Extract tool calls from Anthropic response
+        List<ToolCall> toolCalls = null;
+        if (contentArray != null) {
+            toolCalls = new ArrayList<>();
+            for (JsonElement contentElement : contentArray) {
+                JsonObject contentObj = contentElement.getAsJsonObject();
+                String type = contentObj.has("type") ? contentObj.get("type").getAsString() : "";
+
+                if ("tool_use".equals(type)) {
+                    String id = contentObj.has("id") ? contentObj.get("id").getAsString() : "";
+                    String name = contentObj.has("name") ? contentObj.get("name").getAsString() : "";
+                    JsonObject inputObj = contentObj.getAsJsonObject("input");
+
+                    toolCalls.add(new ToolCall(id, name, inputObj));
+                }
+            }
+        }
+
+        // Extract stop reason (Anthropic-specific field)
+        String stopReason = null;
+        if (jsonResponse.has("stop_reason")) {
+            stopReason = jsonResponse.get("stop_reason").getAsString();
+        }
+
+        // Extract token usage - Anthropic uses different field names
+        TokenUsage usage = null;
+        if (jsonResponse.has("usage")) {
+            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+            int inputTokens = usageObj.has("input_tokens") ? usageObj.get("input_tokens").getAsInt() : 0;
+            int outputTokens = usageObj.has("output_tokens") ? usageObj.get("output_tokens").getAsInt() : 0;
+            usage = new TokenUsage(inputTokens + outputTokens, inputTokens, outputTokens);
+        }
+
+        return new LlmResponse(content, toolCalls, usage);
+    }
+
+    /**
      * Parse a response with Structured Outputs support, including refusal detection.
      *
      * @param responseBody JSON response from API
@@ -499,6 +646,12 @@ public class LlmApiService {
      */
     private StructuredResponse parseStructuredResponse(String responseBody) {
         JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        // Check if this is an Anthropic response (different structure - no "choices" array)
+        if (isAnthropicApi() && jsonResponse.has("content")) {
+            return parseAnthropicStructuredResponse(responseBody);
+        }
+
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
 
         if (choices == null || choices.size() == 0) {
@@ -553,6 +706,56 @@ public class LlmApiService {
         }
 
         return new StructuredResponse(content, refusal, toolCalls, usage);
+    }
+
+    /**
+     * Parse Anthropic-specific structured response format.
+     * Anthropic responses have different structure than OpenAI-compatible APIs.
+     *
+     * @param responseBody JSON response from Anthropic API
+     * @return StructuredResponse with content and tool calls
+     */
+    private StructuredResponse parseAnthropicStructuredResponse(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        // Extract content
+        String content = null;
+        JsonArray contentArray = jsonResponse.getAsJsonArray("content");
+        if (contentArray != null && contentArray.size() > 0) {
+            JsonObject firstContent = contentArray.get(0).getAsJsonObject();
+            if (firstContent.has("text")) {
+                content = firstContent.get("text").getAsString();
+            }
+        }
+
+        // Extract tool calls from Anthropic response
+        List<ToolCall> toolCalls = null;
+        if (contentArray != null) {
+            toolCalls = new ArrayList<>();
+            for (JsonElement contentElement : contentArray) {
+                JsonObject contentObj = contentElement.getAsJsonObject();
+                String type = contentObj.has("type") ? contentObj.get("type").getAsString() : "";
+
+                if ("tool_use".equals(type)) {
+                    String id = contentObj.has("id") ? contentObj.get("id").getAsString() : "";
+                    String name = contentObj.has("name") ? contentObj.get("name").getAsString() : "";
+                    JsonObject inputObj = contentObj.getAsJsonObject("input");
+
+                    toolCalls.add(new ToolCall(id, name, inputObj));
+                }
+            }
+        }
+
+        // Extract token usage - Anthropic uses different field names
+        TokenUsage usage = null;
+        if (jsonResponse.has("usage")) {
+            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+            int inputTokens = usageObj.has("input_tokens") ? usageObj.get("input_tokens").getAsInt() : 0;
+            int outputTokens = usageObj.has("output_tokens") ? usageObj.get("output_tokens").getAsInt() : 0;
+            usage = new TokenUsage(inputTokens + outputTokens, inputTokens, outputTokens);
+        }
+
+        return new StructuredResponse(content, null, toolCalls, usage);
     }
 
     public void cancelAllRequests() {

--- a/app/src/main/java/io/finett/droidclaw/api/OpenAICompatibleProvider.java
+++ b/app/src/main/java/io/finett/droidclaw/api/OpenAICompatibleProvider.java
@@ -1,0 +1,271 @@
+package io.finett.droidclaw.api;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.Model;
+import okhttp3.Request;
+
+/**
+ * Provider implementation for OpenAI-compatible APIs.
+ * This includes OpenAI, Groq, DeepSeek, and any other API that follows the OpenAI API specification.
+ */
+public class OpenAICompatibleProvider implements Provider {
+    private static final Gson gson = new Gson();
+
+    private final String id;
+    private final String name;
+    private final String baseUrl;
+    private final String apiKey;
+    private final String apiType;
+    private final Model model;
+
+    public OpenAICompatibleProvider(String id, String name, String baseUrl, String apiKey,
+                                    String apiType, Model model) {
+        this.id = id;
+        this.name = name;
+        this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+        this.apiType = apiType;
+        this.model = model;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    @Override
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public String getApiType() {
+        return apiType;
+    }
+
+    @Override
+    public Model getModel() {
+        return model;
+    }
+
+    @Override
+    public JsonObject buildRequestBody(List<ChatMessage> conversationHistory, JsonArray tools,
+                                       List<ChatMessage> identityMessages) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("model", model.getId());
+        requestBody.addProperty("max_tokens", model.getMaxTokens());
+        requestBody.addProperty("temperature", 0.7f);
+
+        // For OpenAI-compatible APIs, all messages (including system) go in the messages array
+        JsonArray messages = new JsonArray();
+
+        // Add identity messages FIRST (system messages with soul.md and user.md)
+        if (identityMessages != null) {
+            for (ChatMessage identityMessage : identityMessages) {
+                messages.add(identityMessage.toApiMessage());
+            }
+        }
+
+        // Add conversation history
+        for (ChatMessage chatMessage : conversationHistory) {
+            messages.add(chatMessage.toApiMessage());
+        }
+
+        requestBody.add("messages", messages);
+
+        // Add tools if provided (OpenAI format)
+        if (tools != null && tools.size() > 0) {
+            requestBody.add("tools", tools);
+            requestBody.addProperty("tool_choice", "auto");
+        }
+
+        return requestBody;
+    }
+
+    @Override
+    public JsonObject buildRequestBodyWithStructuredOutput(List<ChatMessage> conversationHistory,
+                                                           JsonArray tools,
+                                                           List<ChatMessage> identityMessages,
+                                                           JsonObject responseSchema) {
+        JsonObject requestBody = buildRequestBody(conversationHistory, tools, identityMessages);
+
+        // Add Structured Outputs response_format
+        JsonObject responseFormat = new JsonObject();
+        responseFormat.addProperty("type", "json_schema");
+
+        JsonObject jsonSchema = new JsonObject();
+        jsonSchema.addProperty("strict", true);
+        jsonSchema.add("schema", responseSchema);
+        responseFormat.add("json_schema", jsonSchema);
+
+        requestBody.add("response_format", responseFormat);
+
+        return requestBody;
+    }
+
+    @Override
+    public void addRequestHeaders(Request.Builder requestBuilder) {
+        requestBuilder.addHeader("Content-Type", "application/json");
+
+        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
+            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
+        }
+    }
+
+    @Override
+    public String parseResponse(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+        JsonArray choices = jsonResponse.getAsJsonArray("choices");
+        if (choices != null && choices.size() > 0) {
+            JsonObject firstChoice = choices.get(0).getAsJsonObject();
+            JsonObject message = firstChoice.getAsJsonObject("message");
+            if (message != null && message.has("content")) {
+                JsonElement contentElement = message.get("content");
+                if (!contentElement.isJsonNull()) {
+                    return contentElement.getAsString();
+                }
+            }
+        }
+        return "No response received";
+    }
+
+    @Override
+    public LlmApiService.LlmResponse parseResponseWithTools(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        JsonArray choices = jsonResponse.getAsJsonArray("choices");
+
+        if (choices == null || choices.size() == 0) {
+            return new LlmApiService.LlmResponse("No response received", null, null);
+        }
+
+        JsonObject firstChoice = choices.get(0).getAsJsonObject();
+        JsonObject message = firstChoice.getAsJsonObject("message");
+
+        if (message == null) {
+            return new LlmApiService.LlmResponse("No message in response", null, null);
+        }
+
+        // Extract content (may be null if there are tool calls)
+        String content = null;
+        if (message.has("content") && !message.get("content").isJsonNull()) {
+            content = message.get("content").getAsString();
+        }
+
+        // Extract tool calls if present
+        List<LlmApiService.ToolCall> toolCalls = null;
+        if (message.has("tool_calls")) {
+            JsonArray toolCallsArray = message.getAsJsonArray("tool_calls");
+            toolCalls = new ArrayList<>();
+
+            for (JsonElement toolCallElement : toolCallsArray) {
+                JsonObject toolCallObj = toolCallElement.getAsJsonObject();
+                String id = toolCallObj.get("id").getAsString();
+                JsonObject function = toolCallObj.getAsJsonObject("function");
+                String name = function.get("name").getAsString();
+                String argumentsStr = function.get("arguments").getAsString();
+
+                // Parse arguments string to JsonObject
+                JsonObject arguments = gson.fromJson(argumentsStr, JsonObject.class);
+
+                toolCalls.add(new LlmApiService.ToolCall(id, name, arguments));
+            }
+        }
+
+        // Extract token usage information (Last Usage algorithm)
+        LlmApiService.TokenUsage usage = null;
+        if (jsonResponse.has("usage")) {
+            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+            int totalTokens = usageObj.has("total_tokens") ? usageObj.get("total_tokens").getAsInt() : 0;
+            int promptTokens = usageObj.has("prompt_tokens") ? usageObj.get("prompt_tokens").getAsInt() : 0;
+            int completionTokens = usageObj.has("completion_tokens") ? usageObj.get("completion_tokens").getAsInt() : 0;
+            usage = new LlmApiService.TokenUsage(totalTokens, promptTokens, completionTokens);
+        }
+
+        return new LlmApiService.LlmResponse(content, toolCalls, usage);
+    }
+
+    @Override
+    public LlmApiService.StructuredResponse parseStructuredResponse(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        JsonArray choices = jsonResponse.getAsJsonArray("choices");
+
+        if (choices == null || choices.size() == 0) {
+            return new LlmApiService.StructuredResponse("No response received", null, null, null);
+        }
+
+        JsonObject firstChoice = choices.get(0).getAsJsonObject();
+        JsonObject message = firstChoice.getAsJsonObject("message");
+
+        if (message == null) {
+            return new LlmApiService.StructuredResponse("No message in response", null, null, null);
+        }
+
+        // Extract content (may be null if there are tool calls or refusal)
+        String content = null;
+        if (message.has("content") && !message.get("content").isJsonNull()) {
+            content = message.get("content").getAsString();
+        }
+
+        // Extract refusal if present
+        String refusal = null;
+        if (message.has("refusal") && !message.get("refusal").isJsonNull()) {
+            refusal = message.get("refusal").getAsString();
+        }
+
+        // Extract tool calls if present
+        List<LlmApiService.ToolCall> toolCalls = null;
+        if (message.has("tool_calls")) {
+            JsonArray toolCallsArray = message.getAsJsonArray("tool_calls");
+            toolCalls = new ArrayList<>();
+
+            for (JsonElement toolCallElement : toolCallsArray) {
+                JsonObject toolCallObj = toolCallElement.getAsJsonObject();
+                String id = toolCallObj.get("id").getAsString();
+                JsonObject function = toolCallObj.getAsJsonObject("function");
+                String name = function.get("name").getAsString();
+                String argumentsStr = function.get("arguments").getAsString();
+
+                JsonObject arguments = gson.fromJson(argumentsStr, JsonObject.class);
+                toolCalls.add(new LlmApiService.ToolCall(id, name, arguments));
+            }
+        }
+
+        // Extract token usage
+        LlmApiService.TokenUsage usage = null;
+        if (jsonResponse.has("usage")) {
+            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+            int totalTokens = usageObj.has("total_tokens") ? usageObj.get("total_tokens").getAsInt() : 0;
+            int promptTokens = usageObj.has("prompt_tokens") ? usageObj.get("prompt_tokens").getAsInt() : 0;
+            int completionTokens = usageObj.has("completion_tokens") ? usageObj.get("completion_tokens").getAsInt() : 0;
+            usage = new LlmApiService.TokenUsage(totalTokens, promptTokens, completionTokens);
+        }
+
+        return new LlmApiService.StructuredResponse(content, refusal, toolCalls, usage);
+    }
+
+    @Override
+    public JsonArray convertTools(JsonArray openaiTools) {
+        // OpenAI-compatible APIs use the standard OpenAI tool format
+        return openaiTools;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/api/Provider.java
+++ b/app/src/main/java/io/finett/droidclaw/api/Provider.java
@@ -1,0 +1,119 @@
+package io.finett.droidclaw.api;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.Model;
+import io.finett.droidclaw.model.Provider;
+import okhttp3.Request;
+
+/**
+ * Interface for API providers (OpenAI-compatible, Anthropic, etc.).
+ * Defines the contract for provider-specific API behavior.
+ */
+public interface Provider {
+    /**
+     * Get the unique identifier for this provider type.
+     */
+    String getId();
+
+    /**
+     * Get the display name for this provider.
+     */
+    String getName();
+
+    /**
+     * Get the base URL for the API endpoint.
+     */
+    String getBaseUrl();
+
+    /**
+     * Get the API key for authentication.
+     */
+    String getApiKey();
+
+    /**
+     * Get the API type identifier (e.g., "anthropic", "openai-completions").
+     */
+    String getApiType();
+
+    /**
+     * Get the model to use.
+     */
+    Model getModel();
+
+    /**
+     * Build the request body for the API call.
+     *
+     * @param conversationHistory Full conversation history
+     * @param tools Tool definitions (can be null)
+     * @param identityMessages System messages for identity context (soul.md, user.md)
+     * @return Request body as JsonObject
+     */
+    JsonObject buildRequestBody(List<ChatMessage> conversationHistory, JsonArray tools,
+                                List<ChatMessage> identityMessages);
+
+    /**
+     * Build the request body with Structured Outputs support.
+     *
+     * @param conversationHistory Full conversation history
+     * @param tools Tool definitions (can be null)
+     * @param identityMessages System messages for identity context
+     * @param responseSchema JSON Schema for Structured Outputs
+     * @return Request body as JsonObject
+     */
+    JsonObject buildRequestBodyWithStructuredOutput(List<ChatMessage> conversationHistory,
+                                                    JsonArray tools,
+                                                    List<ChatMessage> identityMessages,
+                                                    JsonObject responseSchema);
+
+    /**
+     * Add request headers to the request builder.
+     *
+     * @param requestBuilder OkHttp Request.Builder
+     */
+    void addRequestHeaders(Request.Builder requestBuilder);
+
+    /**
+     * Parse the API response for standard text responses.
+     *
+     * @param responseBody JSON response from API
+     * @return Extracted content string
+     */
+    String parseResponse(String responseBody);
+
+    /**
+     * Parse the API response with tool calls support.
+     *
+     * @param responseBody JSON response from API
+     * @return LlmResponse with content and tool calls
+     */
+    LlmApiService.LlmResponse parseResponseWithTools(String responseBody);
+
+    /**
+     * Parse the API response with Structured Outputs support.
+     *
+     * @param responseBody JSON response from API
+     * @return StructuredResponse with content, refusal, and tool calls
+     */
+    LlmApiService.StructuredResponse parseStructuredResponse(String responseBody);
+
+    /**
+     * Convert tools from OpenAI format to this provider's format.
+     *
+     * @param openaiTools Tools in OpenAI format
+     * @return Tools in this provider's format
+     */
+    JsonArray convertTools(JsonArray openaiTools);
+
+    /**
+     * Check if this provider is an Anthropic provider.
+     *
+     * @return true if this is Anthropic, false otherwise
+     */
+    default boolean isAnthropic() {
+        return false;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -442,6 +442,23 @@ public class SettingsManager {
     }
 
     /**
+     * Get API type for current default model.
+     * Returns the API type (e.g., "anthropic", "openai-completions", "openai-responses", "google").
+     */
+    public String getApiType() {
+        Object[] selected = getSelectedProviderAndModel();
+        if (selected != null) {
+            Model model = (Model) selected[1];
+            String modelApi = model.getApi();
+            if (modelApi != null && !modelApi.isEmpty()) {
+                return modelApi;
+            }
+            return ((Provider) selected[0]).getApi();
+        }
+        return "openai-completions";
+    }
+
+    /**
      * Get API key for current default model.
      */
     public String getApiKey() {

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -417,6 +417,10 @@ public class SettingsManager {
         String providerId = agentConfig.getDefaultProviderId();
         String modelId = agentConfig.getDefaultModelId();
 
+        if (providerId == null || modelId == null) {
+            return null;
+        }
+
         Provider provider = providers.get(providerId);
         if (provider == null) {
             return null;
@@ -428,6 +432,20 @@ public class SettingsManager {
         }
 
         return new Object[]{provider, model};
+    }
+
+    /**
+     * Get provider ID from default model string.
+     */
+    public String getDefaultProviderId() {
+        return agentConfig.getDefaultProviderId();
+    }
+
+    /**
+     * Get model ID from default model string.
+     */
+    public String getDefaultModelId() {
+        return agentConfig.getDefaultModelId();
     }
 
     /**


### PR DESCRIPTION
- Add Anthropic-specific request headers (anthropic-version, anthropic-beta)
- Add Anthropic API URL routing to https://api.anthropic.com/v1/messages
- Add Anthropic-specific response parsing for content array and tool_use format
- Add tool format conversion from OpenAI to Anthropic format
- Support Anthropic's separate system field and input_schema parameter format
- Add getApiType() method to SettingsManager