### PR TITLE
feat(api): add Anthropic Messages API support with tool calling

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
+++ b/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -15,6 +16,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.Model;
+import io.finett.droidclaw.model.Provider;
 import io.finett.droidclaw.util.SettingsManager;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -24,17 +27,37 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
+/**
+ * Unified LLM API service supporting both OpenAI Chat Completions and Anthropic Messages APIs.
+ *
+ * <p>The API type is determined at runtime from {@link SettingsManager#getApiType()}.
+ * Use {@link #API_OPENAI} for OpenAI-compatible endpoints and {@link #API_ANTHROPIC}
+ * for Anthropic's Messages API.</p>
+ */
 public class LlmApiService {
     private static final String TAG = "LlmApiService";
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+    /** Anthropic-version header value required by the Anthropic Messages API. */
+    private static final String ANTHROPIC_VERSION = "2023-06-01";
+
+    /** API type constant for OpenAI Chat Completions (and compatible) endpoints. */
+    public static final String API_OPENAI = "openai-completions";
+
+    /** API type constant for Anthropic Messages API. Matches the value stored by ProviderDetailFragment. */
+    public static final String API_ANTHROPIC = "anthropic";
 
     private final OkHttpClient client;
     private final Gson gson;
     private final SettingsManager settingsManager;
     private final Handler mainHandler;
 
+    // =========================================================================
+    // Public data types
+    // =========================================================================
+
     /**
-     * Represents a tool call from the LLM.
+     * Represents a single tool call requested by the LLM.
      */
     public static class ToolCall {
         private final String id;
@@ -61,7 +84,8 @@ public class LlmApiService {
     }
 
     /**
-     * Represents the response from the LLM.
+     * Represents the parsed response from the LLM, containing either text content
+     * or tool calls (or both for some providers).
      */
     public static class LlmResponse {
         private final String content;
@@ -97,13 +121,9 @@ public class LlmApiService {
         }
     }
 
-    public interface ChatCallback {
-        void onSuccess(String response);
-        void onError(String error);
-    }
-
     /**
-     * Represents a refusal from the LLM when using Structured Outputs.
+     * Represents a response that may contain a refusal (OpenAI Structured Outputs).
+     * Anthropic does not have explicit refusals; that field will always be null.
      */
     public static class StructuredResponse {
         private final String content;
@@ -145,11 +165,12 @@ public class LlmApiService {
         }
     }
 
-    /**
-     * Callback for structured response with refusals and tool calls.
-     */
-    public interface StructuredResponseCallback {
-        void onSuccess(StructuredResponse response);
+    // =========================================================================
+    // Callback interfaces
+    // =========================================================================
+
+    public interface ChatCallback {
+        void onSuccess(String response);
         void onError(String error);
     }
 
@@ -158,16 +179,33 @@ public class LlmApiService {
         void onError(String error);
     }
 
+    /**
+     * Callback for structured response with refusals and tool calls.
+     */
+    public interface StructuredResponseCallback {
+        void onSuccess(StructuredResponse response);
+        void onError(String error);
+    }
+
+    // =========================================================================
+    // Constructor
+    // =========================================================================
+
     public LlmApiService(SettingsManager settingsManager) {
         this.settingsManager = settingsManager;
         this.gson = new Gson();
         this.mainHandler = new Handler(Looper.getMainLooper());
         this.client = new OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(60, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)
                 .writeTimeout(30, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
                 .build();
     }
+
+    // =========================================================================
+    // Public API methods
+    // =========================================================================
 
     public void sendMessage(List<ChatMessage> conversationHistory, ChatCallback callback) {
         sendMessage(conversationHistory, null, null, callback);
@@ -178,27 +216,37 @@ public class LlmApiService {
     }
 
     public void sendMessage(List<ChatMessage> conversationHistory, JsonArray tools,
-                           List<ChatMessage> identityMessages, ChatCallback callback) {
+                            List<ChatMessage> identityMessages, ChatCallback callback) {
         if (!settingsManager.isConfigured()) {
+            Log.w(TAG, "sendMessage: isConfigured() returned false");
             mainHandler.post(() -> callback.onError("API key not configured. Please set it in Settings."));
             return;
         }
 
-        JsonObject requestBody = buildRequestBody(conversationHistory, tools, identityMessages);
-        String jsonBody = gson.toJson(requestBody);
-
-        Request.Builder requestBuilder = new Request.Builder()
-                .url(settingsManager.getApiUrl())
-                .addHeader("Content-Type", "application/json");
-
+        String apiType = settingsManager.getApiType();
+        String apiUrl = settingsManager.getApiUrl();
         String apiKey = settingsManager.getApiKey();
-        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
+        Log.d(TAG, "sendMessage: apiType=" + apiType + ", apiUrl=" + apiUrl
+                + ", apiKey=" + (apiKey != null && !apiKey.isEmpty() ? "(set)" : "(empty)")
+                + ", model=" + settingsManager.getModelName());
+
+        if (apiUrl == null || apiUrl.isEmpty()) {
+            mainHandler.post(() -> callback.onError("No API URL configured for selected model. Please check Settings."));
+            return;
+        }
+        String jsonBody;
+        Request.Builder requestBuilder;
+
+        if (API_ANTHROPIC.equals(apiType)) {
+            jsonBody = gson.toJson(buildAnthropicRequestBody(conversationHistory, tools, identityMessages));
+            requestBuilder = buildAnthropicRequestBuilder(jsonBody);
+        } else {
+            jsonBody = gson.toJson(buildOpenAiRequestBody(conversationHistory, tools, identityMessages));
+            requestBuilder = buildOpenAiRequestBuilder(jsonBody);
         }
 
-        Request request = requestBuilder
-                .post(RequestBody.create(jsonBody, JSON))
-                .build();
+        Request request = requestBuilder.build();
+        Log.d(TAG, "sendMessage: HTTP " + request.method() + " " + request.url());
 
         client.newCall(request).enqueue(new Callback() {
             @Override
@@ -211,14 +259,20 @@ public class LlmApiService {
             public void onResponse(Call call, Response response) throws IOException {
                 try {
                     String responseBody = response.body() != null ? response.body().string() : "";
-                    
+
                     if (!response.isSuccessful()) {
+                        String errMsg = parseApiError(responseBody, response.code(), apiType);
                         Log.e(TAG, "API error: " + response.code() + " - " + responseBody);
-                        mainHandler.post(() -> callback.onError("API error: " + response.code() + " - " + responseBody));
+                        mainHandler.post(() -> callback.onError(errMsg));
                         return;
                     }
 
-                    String assistantMessage = parseResponse(responseBody);
+                    String assistantMessage;
+                    if (API_ANTHROPIC.equals(apiType)) {
+                        assistantMessage = parseAnthropicResponseText(responseBody);
+                    } else {
+                        assistantMessage = parseOpenAiResponseText(responseBody);
+                    }
                     mainHandler.post(() -> callback.onSuccess(assistantMessage));
                 } catch (Exception e) {
                     Log.e(TAG, "Parse error", e);
@@ -229,46 +283,57 @@ public class LlmApiService {
     }
 
     /**
-     * Send message with tool support and get structured response.
+     * Send message with tool support and get a structured response.
      *
      * @param conversationHistory Full conversation history
-     * @param tools Tool definitions (can be null)
-     * @param callback Callback with LlmResponse containing content and tool calls
+     * @param tools               Tool definitions (can be null)
+     * @param callback            Callback with {@link LlmResponse} containing content and tool calls
      */
-    public void sendMessageWithTools(List<ChatMessage> conversationHistory, JsonArray tools, ChatCallbackWithTools callback) {
+    public void sendMessageWithTools(List<ChatMessage> conversationHistory, JsonArray tools,
+                                     ChatCallbackWithTools callback) {
         sendMessageWithTools(conversationHistory, tools, null, callback);
     }
 
     /**
-     * Send message with tool support, identity context, and get structured response.
+     * Send message with tool support, identity context, and get a structured response.
      *
      * @param conversationHistory Full conversation history
-     * @param tools Tool definitions (can be null)
-     * @param identityMessages System messages for identity context (soul.md, user.md)
-     * @param callback Callback with LlmResponse containing content and tool calls
+     * @param tools               Tool definitions (can be null)
+     * @param identityMessages    System messages for identity context (soul.md, user.md)
+     * @param callback            Callback with {@link LlmResponse} containing content and tool calls
      */
     public void sendMessageWithTools(List<ChatMessage> conversationHistory, JsonArray tools,
                                      List<ChatMessage> identityMessages, ChatCallbackWithTools callback) {
         if (!settingsManager.isConfigured()) {
+            Log.w(TAG, "sendMessageWithTools: isConfigured() returned false");
             mainHandler.post(() -> callback.onError("API key not configured. Please set it in Settings."));
             return;
         }
 
-        JsonObject requestBody = buildRequestBody(conversationHistory, tools, identityMessages);
-        String jsonBody = gson.toJson(requestBody);
-
-        Request.Builder requestBuilder = new Request.Builder()
-                .url(settingsManager.getApiUrl())
-                .addHeader("Content-Type", "application/json");
-
+        String apiType = settingsManager.getApiType();
+        String apiUrl = settingsManager.getApiUrl();
         String apiKey = settingsManager.getApiKey();
-        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
+        Log.d(TAG, "sendMessageWithTools: apiType=" + apiType + ", apiUrl=" + apiUrl
+                + ", apiKey=" + (apiKey != null && !apiKey.isEmpty() ? "(set)" : "(empty)")
+                + ", model=" + settingsManager.getModelName());
+
+        if (apiUrl == null || apiUrl.isEmpty()) {
+            mainHandler.post(() -> callback.onError("No API URL configured for selected model. Please check Settings."));
+            return;
+        }
+        String jsonBody;
+        Request.Builder requestBuilder;
+
+        if (API_ANTHROPIC.equals(apiType)) {
+            jsonBody = gson.toJson(buildAnthropicRequestBody(conversationHistory, tools, identityMessages));
+            requestBuilder = buildAnthropicRequestBuilder(jsonBody);
+        } else {
+            jsonBody = gson.toJson(buildOpenAiRequestBody(conversationHistory, tools, identityMessages));
+            requestBuilder = buildOpenAiRequestBuilder(jsonBody);
         }
 
-        Request request = requestBuilder
-                .post(RequestBody.create(jsonBody, JSON))
-                .build();
+        Request request = requestBuilder.build();
+        Log.d(TAG, "sendMessageWithTools: HTTP " + request.method() + " " + request.url());
 
         client.newCall(request).enqueue(new Callback() {
             @Override
@@ -281,14 +346,20 @@ public class LlmApiService {
             public void onResponse(Call call, Response response) throws IOException {
                 try {
                     String responseBody = response.body() != null ? response.body().string() : "";
-                    
+
                     if (!response.isSuccessful()) {
+                        String errMsg = parseApiError(responseBody, response.code(), apiType);
                         Log.e(TAG, "API error: " + response.code() + " - " + responseBody);
-                        mainHandler.post(() -> callback.onError("API error: " + response.code() + " - " + responseBody));
+                        mainHandler.post(() -> callback.onError(errMsg));
                         return;
                     }
 
-                    LlmResponse llmResponse = parseResponseWithTools(responseBody);
+                    LlmResponse llmResponse;
+                    if (API_ANTHROPIC.equals(apiType)) {
+                        llmResponse = parseAnthropicResponseWithTools(responseBody);
+                    } else {
+                        llmResponse = parseOpenAiResponseWithTools(responseBody);
+                    }
                     mainHandler.post(() -> callback.onSuccess(llmResponse));
                 } catch (Exception e) {
                     Log.e(TAG, "Parse error", e);
@@ -300,39 +371,54 @@ public class LlmApiService {
 
     /**
      * Send a message with structured outputs support.
-     * Uses OpenAI's Structured Outputs feature to guarantee JSON schema adherence.
+     *
+     * <p>For OpenAI: uses {@code response_format} with {@code json_schema} and {@code strict: true}
+     * to guarantee JSON schema adherence.</p>
+     * <p>For Anthropic: structured output schema is not natively supported; the schema is injected
+     * as a system instruction instead.</p>
      *
      * @param conversationHistory Full conversation history
-     * @param tools Tool definitions (can be null)
-     * @param identityMessages System messages for identity context (soul.md, user.md)
-     * @param responseSchema JSON Schema for Structured Outputs
-     * @param callback Callback with StructuredResponse containing content, tool calls, and refusal
+     * @param tools               Tool definitions (can be null)
+     * @param identityMessages    System messages for identity context (soul.md, user.md)
+     * @param responseSchema      JSON Schema for Structured Outputs
+     * @param callback            Callback with {@link StructuredResponse}
      */
     public void sendMessageStructured(List<ChatMessage> conversationHistory, JsonArray tools,
                                       List<ChatMessage> identityMessages,
                                       JsonObject responseSchema, StructuredResponseCallback callback) {
         if (!settingsManager.isConfigured()) {
+            Log.w(TAG, "sendMessageStructured: isConfigured() returned false");
             mainHandler.post(() -> callback.onError("API key not configured. Please set it in Settings."));
             return;
         }
 
-        JsonObject requestBody = buildRequestBodyWithStructuredOutput(conversationHistory, tools, identityMessages, responseSchema);
-        String jsonBody = gson.toJson(requestBody);
+        String apiType = settingsManager.getApiType();
+        String apiUrl = settingsManager.getApiUrl();
+        Log.d(TAG, "sendMessageStructured: apiType=" + apiType + ", apiUrl=" + apiUrl
+                + ", model=" + settingsManager.getModelName());
 
-        Request.Builder requestBuilder = new Request.Builder()
-                .url(settingsManager.getApiUrl())
-                .addHeader("Content-Type", "application/json");
-
-        String apiKey = settingsManager.getApiKey();
-        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiKey);
+        if (apiUrl == null || apiUrl.isEmpty()) {
+            mainHandler.post(() -> callback.onError("No API URL configured for selected model. Please check Settings."));
+            return;
         }
 
-        Request request = requestBuilder
-                .post(RequestBody.create(jsonBody, JSON))
-                .build();
+        String jsonBody;
+        Request.Builder requestBuilder;
 
-        client.newCall(request).enqueue(new Callback() {
+        if (API_ANTHROPIC.equals(apiType)) {
+            // Inject schema as a system instruction appended to identity messages
+            List<ChatMessage> augmentedIdentity = buildAnthropicSchemaInstructions(
+                    identityMessages, responseSchema);
+            jsonBody = gson.toJson(buildAnthropicRequestBody(conversationHistory, tools, augmentedIdentity));
+            requestBuilder = buildAnthropicRequestBuilder(jsonBody);
+        } else {
+            JsonObject body = buildOpenAiRequestBodyWithStructuredOutput(
+                    conversationHistory, tools, identityMessages, responseSchema);
+            jsonBody = gson.toJson(body);
+            requestBuilder = buildOpenAiRequestBuilder(jsonBody);
+        }
+
+        client.newCall(requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
                 Log.e(TAG, "Network error", e);
@@ -345,12 +431,21 @@ public class LlmApiService {
                     String responseBody = response.body() != null ? response.body().string() : "";
 
                     if (!response.isSuccessful()) {
+                        String errMsg = parseApiError(responseBody, response.code(), apiType);
                         Log.e(TAG, "API error: " + response.code() + " - " + responseBody);
-                        mainHandler.post(() -> callback.onError("API error: " + response.code() + " - " + responseBody));
+                        mainHandler.post(() -> callback.onError(errMsg));
                         return;
                     }
 
-                    StructuredResponse structuredResponse = parseStructuredResponse(responseBody);
+                    StructuredResponse structuredResponse;
+                    if (API_ANTHROPIC.equals(apiType)) {
+                        // Anthropic has no explicit refusal; wrap LlmResponse
+                        LlmResponse llmResp = parseAnthropicResponseWithTools(responseBody);
+                        structuredResponse = new StructuredResponse(
+                                llmResp.getContent(), null, llmResp.getToolCalls(), llmResp.getUsage());
+                    } else {
+                        structuredResponse = parseOpenAiStructuredResponse(responseBody);
+                    }
                     mainHandler.post(() -> callback.onSuccess(structuredResponse));
                 } catch (Exception e) {
                     Log.e(TAG, "Parse error", e);
@@ -360,31 +455,60 @@ public class LlmApiService {
         });
     }
 
-    /**
-     * Build request body with Structured Outputs support.
-     * Adds response_format with json_schema and strict: true.
-     */
-    private JsonObject buildRequestBodyWithStructuredOutput(List<ChatMessage> conversationHistory, JsonArray tools,
-                                                             List<ChatMessage> identityMessages,
-                                                             JsonObject responseSchema) {
-        JsonObject requestBody = buildRequestBody(conversationHistory, tools, identityMessages);
-
-        // Add Structured Outputs response_format
-        JsonObject responseFormat = new JsonObject();
-        responseFormat.addProperty("type", "json_schema");
-
-        JsonObject jsonSchema = new JsonObject();
-        jsonSchema.addProperty("strict", true);
-        jsonSchema.add("schema", responseSchema);
-        responseFormat.add("json_schema", jsonSchema);
-
-        requestBody.add("response_format", responseFormat);
-
-        return requestBody;
+    public void cancelAllRequests() {
+        client.dispatcher().cancelAll();
     }
 
-    private JsonObject buildRequestBody(List<ChatMessage> conversationHistory, JsonArray tools,
-                                        List<ChatMessage> identityMessages) {
+    // =========================================================================
+    // Request builder helpers
+    // =========================================================================
+
+    /**
+     * Build an OkHttp {@link Request.Builder} pre-configured for the OpenAI API.
+     */
+    private Request.Builder buildOpenAiRequestBuilder(String jsonBody) {
+        Request.Builder builder = new Request.Builder()
+                .url(settingsManager.getApiUrl())
+                .addHeader("Content-Type", "application/json");
+
+        String apiKey = settingsManager.getApiKey();
+        if (apiKey != null && !apiKey.trim().isEmpty() && !"lm-studio".equalsIgnoreCase(apiKey.trim())) {
+            builder.addHeader("Authorization", "Bearer " + apiKey);
+        }
+
+        builder.post(RequestBody.create(jsonBody, JSON));
+        return builder;
+    }
+
+    /**
+     * Build an OkHttp {@link Request.Builder} pre-configured for the Anthropic Messages API.
+     * Uses {@code x-api-key} and {@code anthropic-version} headers instead of {@code Authorization}.
+     */
+    private Request.Builder buildAnthropicRequestBuilder(String jsonBody) {
+        String apiKey = settingsManager.getApiKey();
+        Request.Builder builder = new Request.Builder()
+                .url(settingsManager.getApiUrl())
+                .addHeader("Content-Type", "application/json")
+                .addHeader("anthropic-version", ANTHROPIC_VERSION);
+
+        if (apiKey != null && !apiKey.trim().isEmpty()) {
+            builder.addHeader("x-api-key", apiKey);
+        }
+
+        builder.post(RequestBody.create(jsonBody, JSON));
+        return builder;
+    }
+
+    // =========================================================================
+    // OpenAI request body builders
+    // =========================================================================
+
+    /**
+     * Build the JSON request body for OpenAI Chat Completions API.
+     */
+    private JsonObject buildOpenAiRequestBody(List<ChatMessage> conversationHistory,
+                                              JsonArray tools,
+                                              List<ChatMessage> identityMessages) {
         JsonObject requestBody = new JsonObject();
         requestBody.addProperty("model", settingsManager.getModelName());
         requestBody.addProperty("max_tokens", settingsManager.getMaxTokens());
@@ -392,10 +516,10 @@ public class LlmApiService {
 
         JsonArray messages = new JsonArray();
 
-        // Add identity messages FIRST (system messages with soul.md and user.md)
+        // Add identity messages first (system messages with soul.md and user.md)
         if (identityMessages != null) {
-            for (ChatMessage identityMessage : identityMessages) {
-                messages.add(identityMessage.toApiMessage());
+            for (ChatMessage msg : identityMessages) {
+                messages.add(msg.toApiMessage());
             }
         }
 
@@ -405,17 +529,251 @@ public class LlmApiService {
         }
 
         requestBody.add("messages", messages);
-        
+
         // Add tools if provided
         if (tools != null && tools.size() > 0) {
             requestBody.add("tools", tools);
             requestBody.addProperty("tool_choice", "auto");
         }
-        
+
         return requestBody;
     }
 
-    private String parseResponse(String responseBody) {
+    /**
+     * Build the JSON request body for OpenAI Chat Completions API with Structured Outputs.
+     * Adds {@code response_format} with {@code json_schema} and {@code strict: true}.
+     */
+    private JsonObject buildOpenAiRequestBodyWithStructuredOutput(List<ChatMessage> conversationHistory,
+                                                                   JsonArray tools,
+                                                                   List<ChatMessage> identityMessages,
+                                                                   JsonObject responseSchema) {
+        JsonObject requestBody = buildOpenAiRequestBody(conversationHistory, tools, identityMessages);
+
+        JsonObject responseFormat = new JsonObject();
+        responseFormat.addProperty("type", "json_schema");
+
+        JsonObject jsonSchema = new JsonObject();
+        jsonSchema.addProperty("strict", true);
+        jsonSchema.add("schema", responseSchema);
+        responseFormat.add("json_schema", jsonSchema);
+
+        requestBody.add("response_format", responseFormat);
+        return requestBody;
+    }
+
+    // =========================================================================
+    // Anthropic request body builders
+    // =========================================================================
+
+    /**
+     * Build the JSON request body for the Anthropic Messages API.
+     *
+     * <p>Key differences from OpenAI:
+     * <ul>
+     *   <li>System content goes in the top-level {@code system} field (string or array)</li>
+     *   <li>Messages only contain {@code user} and {@code assistant} roles</li>
+     *   <li>Tool results are sent as {@code user} messages with {@code tool_result} content blocks</li>
+     *   <li>Tool definitions use {@code input_schema} instead of {@code parameters}</li>
+     * </ul>
+     * </p>
+     */
+    private JsonObject buildAnthropicRequestBody(List<ChatMessage> conversationHistory,
+                                                  JsonArray openAiTools,
+                                                  List<ChatMessage> identityMessages) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("model", settingsManager.getModelName());
+        requestBody.addProperty("max_tokens", settingsManager.getMaxTokens());
+
+        // Build system prompt from identity messages
+        StringBuilder systemBuilder = new StringBuilder();
+        if (identityMessages != null) {
+            for (ChatMessage msg : identityMessages) {
+                if (msg.getType() == ChatMessage.TYPE_SYSTEM && msg.getContent() != null) {
+                    if (systemBuilder.length() > 0) systemBuilder.append("\n\n");
+                    systemBuilder.append(msg.getContent());
+                }
+            }
+        }
+        if (systemBuilder.length() > 0) {
+            requestBody.addProperty("system", systemBuilder.toString());
+        }
+
+        // Convert conversation history to Anthropic format
+        JsonArray messages = new JsonArray();
+        for (ChatMessage chatMessage : conversationHistory) {
+            JsonObject anthropicMsg = chatMessage.toAnthropicApiMessage();
+            if (anthropicMsg != null) {
+                messages.add(anthropicMsg);
+            }
+        }
+
+        // Anthropic requires messages to start with a user turn and alternate roles.
+        // Merge consecutive same-role messages to satisfy this constraint.
+        messages = mergeConsecutiveSameRoleMessages(messages);
+
+        requestBody.add("messages", messages);
+
+        // Convert OpenAI-format tools to Anthropic format
+        if (openAiTools != null && openAiTools.size() > 0) {
+            JsonArray anthropicTools = convertToolsToAnthropicFormat(openAiTools);
+            if (anthropicTools.size() > 0) {
+                requestBody.add("tools", anthropicTools);
+                // tool_choice: {"type": "auto"} is the default; explicit for clarity
+                JsonObject toolChoice = new JsonObject();
+                toolChoice.addProperty("type", "auto");
+                requestBody.add("tool_choice", toolChoice);
+            }
+        }
+
+        return requestBody;
+    }
+
+    /**
+     * Augment identity messages with a schema instruction for structured output
+     * when using the Anthropic API (which has no native structured output support).
+     */
+    private List<ChatMessage> buildAnthropicSchemaInstructions(List<ChatMessage> identityMessages,
+                                                                JsonObject responseSchema) {
+        List<ChatMessage> augmented = new ArrayList<>();
+        if (identityMessages != null) {
+            augmented.addAll(identityMessages);
+        }
+        if (responseSchema != null) {
+            String schemaInstruction = "IMPORTANT: Your final response MUST be valid JSON that conforms " +
+                    "to the following JSON Schema. Output ONLY the JSON object, no other text:\n" +
+                    responseSchema.toString();
+            augmented.add(new ChatMessage(schemaInstruction, ChatMessage.TYPE_SYSTEM));
+        }
+        return augmented;
+    }
+
+    /**
+     * Convert OpenAI-format tool definitions to Anthropic format.
+     *
+     * <p>OpenAI: {@code {type:"function", function:{name, description, parameters, strict}}}</p>
+     * <p>Anthropic: {@code {name, description, input_schema}}</p>
+     */
+    private JsonArray convertToolsToAnthropicFormat(JsonArray openAiTools) {
+        JsonArray anthropicTools = new JsonArray();
+        for (JsonElement toolEl : openAiTools) {
+            try {
+                JsonObject openAiTool = toolEl.getAsJsonObject();
+                // Only handle function-type tools
+                if (!openAiTool.has("function")) continue;
+                JsonObject function = openAiTool.getAsJsonObject("function");
+
+                JsonObject anthropicTool = new JsonObject();
+                anthropicTool.addProperty("name", function.get("name").getAsString());
+                if (function.has("description")) {
+                    anthropicTool.addProperty("description", function.get("description").getAsString());
+                }
+                // Anthropic uses "input_schema" where OpenAI uses "parameters"
+                if (function.has("parameters")) {
+                    anthropicTool.add("input_schema", function.get("parameters"));
+                } else {
+                    // Minimal valid schema
+                    JsonObject emptySchema = new JsonObject();
+                    emptySchema.addProperty("type", "object");
+                    anthropicTool.add("input_schema", emptySchema);
+                }
+
+                anthropicTools.add(anthropicTool);
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to convert tool to Anthropic format", e);
+            }
+        }
+        return anthropicTools;
+    }
+
+    /**
+     * Anthropic requires strictly alternating user/assistant roles.
+     * This merges consecutive same-role messages into a single message with multiple content blocks.
+     */
+    private JsonArray mergeConsecutiveSameRoleMessages(JsonArray messages) {
+        if (messages.size() == 0) return messages;
+
+        JsonArray merged = new JsonArray();
+        String currentRole = null;
+        JsonArray currentContent = null;
+
+        for (JsonElement el : messages) {
+            JsonObject msg = el.getAsJsonObject();
+            String role = msg.has("role") ? msg.get("role").getAsString() : "user";
+
+            if (role.equals(currentRole)) {
+                // Merge content into the current message
+                appendContentToArray(currentContent, msg);
+            } else {
+                // Flush previous message
+                if (currentRole != null && currentContent != null) {
+                    JsonObject mergedMsg = new JsonObject();
+                    mergedMsg.addProperty("role", currentRole);
+                    if (currentContent.size() == 1 && currentContent.get(0).getAsJsonObject().has("text")
+                            && currentContent.get(0).getAsJsonObject().get("type").getAsString().equals("text")) {
+                        // Single text block: use string shorthand for cleaner JSON
+                        mergedMsg.addProperty("content",
+                                currentContent.get(0).getAsJsonObject().get("text").getAsString());
+                    } else {
+                        mergedMsg.add("content", currentContent);
+                    }
+                    merged.add(mergedMsg);
+                }
+                currentRole = role;
+                currentContent = new JsonArray();
+                appendContentToArray(currentContent, msg);
+            }
+        }
+
+        // Flush last message
+        if (currentRole != null && currentContent != null) {
+            JsonObject mergedMsg = new JsonObject();
+            mergedMsg.addProperty("role", currentRole);
+            if (currentContent.size() == 1 && currentContent.get(0).getAsJsonObject().has("type")
+                    && currentContent.get(0).getAsJsonObject().get("type").getAsString().equals("text")) {
+                mergedMsg.addProperty("content",
+                        currentContent.get(0).getAsJsonObject().get("text").getAsString());
+            } else {
+                mergedMsg.add("content", currentContent);
+            }
+            merged.add(mergedMsg);
+        }
+
+        return merged;
+    }
+
+    /**
+     * Append the content from {@code msg} into {@code contentArray} as content blocks.
+     */
+    private void appendContentToArray(JsonArray contentArray, JsonObject msg) {
+        if (msg.has("content")) {
+            JsonElement contentEl = msg.get("content");
+            if (contentEl.isJsonArray()) {
+                // Already an array of blocks
+                for (JsonElement block : contentEl.getAsJsonArray()) {
+                    contentArray.add(block);
+                }
+            } else if (!contentEl.isJsonNull()) {
+                // String content — wrap in a text block
+                JsonObject textBlock = new JsonObject();
+                textBlock.addProperty("type", "text");
+                textBlock.addProperty("text", contentEl.getAsString());
+                contentArray.add(textBlock);
+            }
+        }
+        // For tool_use / tool_result blocks already stored as content arrays
+        if (msg.has("tool_calls")) {
+            // Already handled via toAnthropicApiMessage(); content should be tool_use blocks
+        }
+    }
+
+    // =========================================================================
+    // OpenAI response parsers
+    // =========================================================================
+
+    /**
+     * Parse a plain text response from the OpenAI API.
+     */
+    private String parseOpenAiResponseText(String responseBody) {
         JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
         if (choices != null && choices.size() > 0) {
@@ -432,72 +790,42 @@ public class LlmApiService {
     }
 
     /**
-     * Parse response with tool calls support.
-     *
-     * @param responseBody JSON response from API
-     * @return LlmResponse with content and tool calls
+     * Parse an OpenAI response that may contain tool calls.
      */
-    private LlmResponse parseResponseWithTools(String responseBody) {
+    private LlmResponse parseOpenAiResponseWithTools(String responseBody) {
         JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
-        
+
         if (choices == null || choices.size() == 0) {
             return new LlmResponse("No response received", null, null);
         }
 
         JsonObject firstChoice = choices.get(0).getAsJsonObject();
         JsonObject message = firstChoice.getAsJsonObject("message");
-        
+
         if (message == null) {
             return new LlmResponse("No message in response", null, null);
         }
 
-        // Extract content (may be null if there are tool calls)
+        // Extract text content (may be null when there are tool calls)
         String content = null;
         if (message.has("content") && !message.get("content").isJsonNull()) {
             content = message.get("content").getAsString();
         }
 
-        // Extract tool calls if present
-        List<ToolCall> toolCalls = null;
-        if (message.has("tool_calls")) {
-            JsonArray toolCallsArray = message.getAsJsonArray("tool_calls");
-            toolCalls = new ArrayList<>();
-            
-            for (JsonElement toolCallElement : toolCallsArray) {
-                JsonObject toolCallObj = toolCallElement.getAsJsonObject();
-                String id = toolCallObj.get("id").getAsString();
-                JsonObject function = toolCallObj.getAsJsonObject("function");
-                String name = function.get("name").getAsString();
-                String argumentsStr = function.get("arguments").getAsString();
-                
-                // Parse arguments string to JsonObject
-                JsonObject arguments = gson.fromJson(argumentsStr, JsonObject.class);
-                
-                toolCalls.add(new ToolCall(id, name, arguments));
-            }
-        }
+        // Extract tool calls
+        List<ToolCall> toolCalls = parseOpenAiToolCalls(message);
 
-        // Extract token usage information (Last Usage algorithm)
-        TokenUsage usage = null;
-        if (jsonResponse.has("usage")) {
-            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
-            int totalTokens = usageObj.has("total_tokens") ? usageObj.get("total_tokens").getAsInt() : 0;
-            int promptTokens = usageObj.has("prompt_tokens") ? usageObj.get("prompt_tokens").getAsInt() : 0;
-            int completionTokens = usageObj.has("completion_tokens") ? usageObj.get("completion_tokens").getAsInt() : 0;
-            usage = new TokenUsage(totalTokens, promptTokens, completionTokens);
-        }
+        // Extract token usage
+        TokenUsage usage = parseOpenAiUsage(jsonResponse);
 
         return new LlmResponse(content, toolCalls, usage);
     }
 
     /**
-     * Parse a response with Structured Outputs support, including refusal detection.
-     *
-     * @param responseBody JSON response from API
-     * @return StructuredResponse with content, refusal, and tool calls
+     * Parse an OpenAI Structured Outputs response (with optional refusal).
      */
-    private StructuredResponse parseStructuredResponse(String responseBody) {
+    private StructuredResponse parseOpenAiStructuredResponse(String responseBody) {
         JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
         JsonArray choices = jsonResponse.getAsJsonArray("choices");
 
@@ -512,50 +840,188 @@ public class LlmApiService {
             return new StructuredResponse("No message in response", null, null, null);
         }
 
-        // Extract content (may be null if there are tool calls or refusal)
         String content = null;
         if (message.has("content") && !message.get("content").isJsonNull()) {
             content = message.get("content").getAsString();
         }
 
-        // Extract refusal if present
         String refusal = null;
         if (message.has("refusal") && !message.get("refusal").isJsonNull()) {
             refusal = message.get("refusal").getAsString();
         }
 
-        // Extract tool calls if present
-        List<ToolCall> toolCalls = null;
-        if (message.has("tool_calls")) {
-            JsonArray toolCallsArray = message.getAsJsonArray("tool_calls");
-            toolCalls = new ArrayList<>();
+        List<ToolCall> toolCalls = parseOpenAiToolCalls(message);
+        TokenUsage usage = parseOpenAiUsage(jsonResponse);
 
-            for (JsonElement toolCallElement : toolCallsArray) {
+        return new StructuredResponse(content, refusal, toolCalls, usage);
+    }
+
+    /**
+     * Extract tool calls from an OpenAI {@code message} JSON object.
+     */
+    private List<ToolCall> parseOpenAiToolCalls(JsonObject message) {
+        if (!message.has("tool_calls")) return null;
+
+        JsonArray toolCallsArray = message.getAsJsonArray("tool_calls");
+        List<ToolCall> toolCalls = new ArrayList<>();
+
+        for (JsonElement toolCallElement : toolCallsArray) {
+            try {
                 JsonObject toolCallObj = toolCallElement.getAsJsonObject();
                 String id = toolCallObj.get("id").getAsString();
                 JsonObject function = toolCallObj.getAsJsonObject("function");
                 String name = function.get("name").getAsString();
                 String argumentsStr = function.get("arguments").getAsString();
-
                 JsonObject arguments = gson.fromJson(argumentsStr, JsonObject.class);
                 toolCalls.add(new ToolCall(id, name, arguments));
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to parse OpenAI tool call", e);
             }
         }
 
-        // Extract token usage
-        TokenUsage usage = null;
-        if (jsonResponse.has("usage")) {
-            JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
-            int totalTokens = usageObj.has("total_tokens") ? usageObj.get("total_tokens").getAsInt() : 0;
-            int promptTokens = usageObj.has("prompt_tokens") ? usageObj.get("prompt_tokens").getAsInt() : 0;
-            int completionTokens = usageObj.has("completion_tokens") ? usageObj.get("completion_tokens").getAsInt() : 0;
-            usage = new TokenUsage(totalTokens, promptTokens, completionTokens);
-        }
-
-        return new StructuredResponse(content, refusal, toolCalls, usage);
+        return toolCalls.isEmpty() ? null : toolCalls;
     }
 
-    public void cancelAllRequests() {
-        client.dispatcher().cancelAll();
+    /**
+     * Extract {@link TokenUsage} from an OpenAI response JSON using prompt/completion token keys.
+     */
+    private TokenUsage parseOpenAiUsage(JsonObject jsonResponse) {
+        if (!jsonResponse.has("usage")) return null;
+        JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+        int promptTokens = usageObj.has("prompt_tokens") ? usageObj.get("prompt_tokens").getAsInt() : 0;
+        int completionTokens = usageObj.has("completion_tokens") ? usageObj.get("completion_tokens").getAsInt() : 0;
+        int totalTokens = usageObj.has("total_tokens") ? usageObj.get("total_tokens").getAsInt()
+                : promptTokens + completionTokens;
+        return new TokenUsage(totalTokens, promptTokens, completionTokens);
+    }
+
+    // =========================================================================
+    // Anthropic response parsers
+    // =========================================================================
+
+    /**
+     * Parse a plain text response from the Anthropic Messages API.
+     *
+     * <p>Anthropic format: {@code {content: [{type:"text", text:"..."}, ...], stop_reason: "end_turn"}}</p>
+     */
+    private String parseAnthropicResponseText(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+        return extractAnthropicTextContent(jsonResponse);
+    }
+
+    /**
+     * Parse an Anthropic Messages API response that may contain tool use blocks.
+     *
+     * <p>Anthropic format for tool use:
+     * {@code {content: [{type:"tool_use", id, name, input: {...}}, ...], stop_reason: "tool_use"}}</p>
+     */
+    private LlmResponse parseAnthropicResponseWithTools(String responseBody) {
+        JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
+        if (!jsonResponse.has("content")) {
+            return new LlmResponse("No response received", null, null);
+        }
+
+        JsonArray contentBlocks = jsonResponse.getAsJsonArray("content");
+        String stopReason = jsonResponse.has("stop_reason")
+                ? jsonResponse.get("stop_reason").getAsString() : "";
+
+        StringBuilder textContent = new StringBuilder();
+        List<ToolCall> toolCalls = new ArrayList<>();
+
+        for (JsonElement blockEl : contentBlocks) {
+            try {
+                JsonObject block = blockEl.getAsJsonObject();
+                String blockType = block.has("type") ? block.get("type").getAsString() : "";
+
+                if ("text".equals(blockType)) {
+                    String text = block.has("text") ? block.get("text").getAsString() : "";
+                    if (!text.isEmpty()) {
+                        if (textContent.length() > 0) textContent.append("\n");
+                        textContent.append(text);
+                    }
+                } else if ("tool_use".equals(blockType)) {
+                    String id = block.has("id") ? block.get("id").getAsString() : "";
+                    String name = block.has("name") ? block.get("name").getAsString() : "";
+                    JsonObject input = block.has("input") ? block.getAsJsonObject("input") : new JsonObject();
+                    toolCalls.add(new ToolCall(id, name, input));
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to parse Anthropic content block", e);
+            }
+        }
+
+        String content = textContent.length() > 0 ? textContent.toString() : null;
+        TokenUsage usage = parseAnthropicUsage(jsonResponse);
+
+        return new LlmResponse(content, toolCalls.isEmpty() ? null : toolCalls, usage);
+    }
+
+    /**
+     * Extract concatenated text from an Anthropic response's content array.
+     */
+    private String extractAnthropicTextContent(JsonObject jsonResponse) {
+        if (!jsonResponse.has("content")) return "No response received";
+
+        StringBuilder sb = new StringBuilder();
+        for (JsonElement blockEl : jsonResponse.getAsJsonArray("content")) {
+            try {
+                JsonObject block = blockEl.getAsJsonObject();
+                if ("text".equals(block.get("type").getAsString()) && block.has("text")) {
+                    if (sb.length() > 0) sb.append("\n");
+                    sb.append(block.get("text").getAsString());
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to parse Anthropic text block", e);
+            }
+        }
+        return sb.length() > 0 ? sb.toString() : "No response received";
+    }
+
+    /**
+     * Extract {@link TokenUsage} from an Anthropic response JSON.
+     * Anthropic uses {@code input_tokens} / {@code output_tokens} (not prompt/completion).
+     */
+    private TokenUsage parseAnthropicUsage(JsonObject jsonResponse) {
+        if (!jsonResponse.has("usage")) return null;
+        JsonObject usageObj = jsonResponse.getAsJsonObject("usage");
+        int inputTokens = usageObj.has("input_tokens") ? usageObj.get("input_tokens").getAsInt() : 0;
+        int outputTokens = usageObj.has("output_tokens") ? usageObj.get("output_tokens").getAsInt() : 0;
+        int total = inputTokens + outputTokens;
+        // Map to TokenUsage(total, prompt=input, completion=output)
+        return new TokenUsage(total, inputTokens, outputTokens);
+    }
+
+    // =========================================================================
+    // Error parsing
+    // =========================================================================
+
+    /**
+     * Parse a human-readable error message from an API error response body.
+     * Handles both OpenAI and Anthropic error formats.
+     */
+    private String parseApiError(String responseBody, int httpCode, String apiType) {
+        try {
+            JsonObject errorJson = gson.fromJson(responseBody, JsonObject.class);
+            if (API_ANTHROPIC.equals(apiType)) {
+                // Anthropic: {"type":"error","error":{"type":"...","message":"..."}}
+                if (errorJson.has("error")) {
+                    JsonObject err = errorJson.getAsJsonObject("error");
+                    String msg = err.has("message") ? err.get("message").getAsString() : responseBody;
+                    String type = err.has("type") ? err.get("type").getAsString() : "";
+                    return "Anthropic API error (" + httpCode + "): " + type + " - " + msg;
+                }
+            } else {
+                // OpenAI: {"error":{"message":"...","type":"...","code":"..."}}
+                if (errorJson.has("error")) {
+                    JsonObject err = errorJson.getAsJsonObject("error");
+                    String msg = err.has("message") ? err.get("message").getAsString() : responseBody;
+                    return "API error (" + httpCode + "): " + msg;
+                }
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Could not parse API error body", e);
+        }
+        return "API error: " + httpCode + " - " + responseBody;
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -704,6 +704,23 @@ public class ChatFragment extends Fragment {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        // Reload settings in case the user changed provider/model in the Settings screen
+        settingsManager = new SettingsManager(requireContext());
+        apiService = new LlmApiService(settingsManager);
+        // Propagate the refreshed service to the agent loop components
+        // (ConversationSummarizer and AgentLoop hold their own apiService reference)
+        int contextWindow = getModelContextWindow();
+        io.finett.droidclaw.agent.ConversationSummarizer summarizer =
+                new io.finett.droidclaw.agent.ConversationSummarizer(apiService, memoryRepository, contextWindow);
+        io.finett.droidclaw.agent.MemoryContextBuilder memoryContext =
+                new io.finett.droidclaw.agent.MemoryContextBuilder(memoryRepository);
+        agentLoop = new AgentLoop(apiService, toolRegistry, settingsManager, summarizer, memoryContext);
+        loadIdentityContext();
+    }
+
+    @Override
     public void onDestroyView() {
         super.onDestroyView();
         apiService.cancelAllRequests();

--- a/app/src/main/java/io/finett/droidclaw/model/ChatMessage.java
+++ b/app/src/main/java/io/finett/droidclaw/model/ChatMessage.java
@@ -229,7 +229,7 @@ public class ChatMessage {
     }
 
     /**
-     * Convert this message to the API format required by OpenAI.
+     * Convert this message to the API format required by OpenAI Chat Completions.
      *
      * @return JsonObject representing the message
      */
@@ -263,18 +263,18 @@ public class ChatMessage {
                 // Assistant message with tool calls
                 message.addProperty("role", "assistant");
                 message.add("content", com.google.gson.JsonNull.INSTANCE);
-                
+
                 JsonArray toolCallsArray = new JsonArray();
                 if (toolCalls != null) {
                     for (LlmApiService.ToolCall toolCall : toolCalls) {
                         JsonObject toolCallObj = new JsonObject();
                         toolCallObj.addProperty("id", toolCall.getId());
                         toolCallObj.addProperty("type", "function");
-                        
+
                         JsonObject function = new JsonObject();
                         function.addProperty("name", toolCall.getName());
                         function.addProperty("arguments", toolCall.getArguments().toString());
-                        
+
                         toolCallObj.add("function", function);
                         toolCallsArray.add(toolCallObj);
                     }
@@ -308,6 +308,171 @@ public class ChatMessage {
         }
 
         return message;
+    }
+
+    /**
+     * Convert this message to the Anthropic Messages API format.
+     *
+     * <p>Key differences from OpenAI format:
+     * <ul>
+     *   <li>No {@code system} role in messages array – system content is handled separately</li>
+     *   <li>Tool calls from the assistant are {@code tool_use} content blocks</li>
+     *   <li>Tool results are {@code user} messages with {@code tool_result} content blocks</li>
+     *   <li>Content is always an array of typed blocks (text, tool_use, tool_result, image)</li>
+     * </ul>
+     * </p>
+     *
+     * @return JsonObject for the Anthropic messages array, or {@code null} if this message
+     *         type should be omitted from the Anthropic messages array (e.g. system messages,
+     *         which go in the top-level {@code system} field instead).
+     */
+    public JsonObject toAnthropicApiMessage() {
+        JsonObject message = new JsonObject();
+
+        switch (type) {
+            case TYPE_SYSTEM:
+            case TYPE_CONTEXT_CARD:
+                // System messages are handled at the top-level "system" field in Anthropic API.
+                // Context cards become system context – also omitted from the messages array here
+                // (the caller injects them into the system field or as user messages if needed).
+                // Return null to signal the caller should skip this message.
+                return null;
+
+            case TYPE_USER:
+                message.addProperty("role", "user");
+                if (hasAttachments()) {
+                    message.add("content", buildAnthropicUserContentWithAttachments());
+                } else {
+                    // Single text block
+                    JsonArray userContent = new JsonArray();
+                    JsonObject textBlock = new JsonObject();
+                    textBlock.addProperty("type", "text");
+                    textBlock.addProperty("text", content != null ? content : "");
+                    userContent.add(textBlock);
+                    message.add("content", userContent);
+                }
+                break;
+
+            case TYPE_ASSISTANT:
+                message.addProperty("role", "assistant");
+                JsonArray assistantContent = new JsonArray();
+                if (content != null && !content.isEmpty()) {
+                    JsonObject textBlock = new JsonObject();
+                    textBlock.addProperty("type", "text");
+                    textBlock.addProperty("text", content);
+                    assistantContent.add(textBlock);
+                }
+                message.add("content", assistantContent);
+                break;
+
+            case TYPE_TOOL_CALL:
+                // Assistant message containing tool_use blocks
+                message.addProperty("role", "assistant");
+                JsonArray toolUseContent = new JsonArray();
+                if (toolCalls != null) {
+                    for (LlmApiService.ToolCall toolCall : toolCalls) {
+                        JsonObject toolUseBlock = new JsonObject();
+                        toolUseBlock.addProperty("type", "tool_use");
+                        toolUseBlock.addProperty("id", toolCall.getId());
+                        toolUseBlock.addProperty("name", toolCall.getName());
+                        toolUseBlock.add("input", toolCall.getArguments());
+                        toolUseContent.add(toolUseBlock);
+                    }
+                }
+                message.add("content", toolUseContent);
+                break;
+
+            case TYPE_TOOL_RESULT:
+                // In Anthropic API, tool results are sent as user messages with tool_result blocks
+                message.addProperty("role", "user");
+                JsonArray toolResultContent = new JsonArray();
+                JsonObject toolResultBlock = new JsonObject();
+                toolResultBlock.addProperty("type", "tool_result");
+                toolResultBlock.addProperty("tool_use_id", toolCallId != null ? toolCallId : "");
+                // Content inside tool_result can be a string or array of blocks
+                toolResultBlock.addProperty("content", content != null ? content : "");
+                toolResultContent.add(toolResultBlock);
+                message.add("content", toolResultContent);
+                break;
+
+            case TYPE_ATTACHMENT:
+                // Agent-referenced file – send as user text message
+                message.addProperty("role", "user");
+                JsonArray attachContent = new JsonArray();
+                JsonObject attachBlock = new JsonObject();
+                attachBlock.addProperty("type", "text");
+                String attachText = "File: `" + (displayName != null ? displayName : filePath) + "`\n" +
+                        "The agent mentioned or produced this file. It is available at: " +
+                        (filePath != null ? filePath : "unknown path");
+                attachBlock.addProperty("text", attachText);
+                attachContent.add(attachBlock);
+                message.add("content", attachContent);
+                break;
+
+            default:
+                return null;
+        }
+
+        return message;
+    }
+
+    /**
+     * Builds Anthropic-format multipart content array for user messages with attachments.
+     * Images are sent as base64 image blocks; other files are referenced as text.
+     */
+    private JsonArray buildAnthropicUserContentWithAttachments() {
+        JsonArray contentArray = new JsonArray();
+
+        // Add text content first
+        if (content != null && !content.isEmpty()) {
+            JsonObject textPart = new JsonObject();
+            textPart.addProperty("type", "text");
+            textPart.addProperty("text", content);
+            contentArray.add(textPart);
+        }
+
+        // Add each attachment
+        for (FileAttachment attachment : attachments) {
+            if (attachment.isImage()) {
+                String base64Data = encodeFileToBase64(attachment.getAbsolutePath());
+                if (base64Data != null) {
+                    // Anthropic image block format
+                    JsonObject imagePart = new JsonObject();
+                    imagePart.addProperty("type", "image");
+
+                    JsonObject source = new JsonObject();
+                    source.addProperty("type", "base64");
+                    source.addProperty("media_type", attachment.getMimeType());
+                    source.addProperty("data", base64Data);
+                    imagePart.add("source", source);
+
+                    contentArray.add(imagePart);
+                }
+
+                // Also add a text reference
+                JsonObject textRef = new JsonObject();
+                textRef.addProperty("type", "text");
+                textRef.addProperty("text", "`" + attachment.getOriginalName() +
+                        "` file attached by user, you can find it in uploads");
+                contentArray.add(textRef);
+            } else {
+                // Non-image files: add text reference
+                JsonObject textPart = new JsonObject();
+                textPart.addProperty("type", "text");
+                textPart.addProperty("text", "`" + attachment.getOriginalName() +
+                        "` file attached by user, you can find it in uploads");
+                contentArray.add(textPart);
+            }
+        }
+
+        if (contentArray.size() == 0) {
+            JsonObject textPart = new JsonObject();
+            textPart.addProperty("type", "text");
+            textPart.addProperty("text", content != null ? content : "");
+            contentArray.add(textPart);
+        }
+
+        return contentArray;
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -453,6 +453,22 @@ public class SettingsManager {
     }
 
     /**
+     * Get the API type string for the currently selected provider.
+     * Returns {@code "anthropic-messages"} for Anthropic providers,
+     * or {@code "openai-completions"} for OpenAI-compatible providers.
+     */
+    public String getApiType() {
+        Object[] selected = getSelectedProviderAndModel();
+        if (selected != null) {
+            String api = ((Provider) selected[0]).getApi();
+            if (api != null && !api.isEmpty()) {
+                return api;
+            }
+        }
+        return "openai-completions";
+    }
+
+    /**
      * Get model name for current default model.
      */
     public String getModelName() {


### PR DESCRIPTION
Add full Anthropic API support alongside existing OpenAI-compatible providers. API type is detected at runtime from the provider's `api` field ("anthropic" vs "openai-completions").

Key changes:
- LlmApiService: dual-path routing for request building, response parsing, and error handling per API type; Anthropic uses x-api-key
  + anthropic-version headers, content blocks, tool_use/tool_result format, and input_schema for tools; readTimeout raised to 120s with retryOnConnectionFailure enabled; URL validation with clear errors; debug logging of apiType, apiUrl, model, and full HTTP URL per call
- ChatMessage: add toAnthropicApiMessage() converting all message types to Anthropic content-block format (tool_use, tool_result, image); system messages return null to be placed in top-level system field
- SettingsManager: add getApiType() returning the selected provider's api field, defaulting to "openai-completions"
- ChatFragment: add onResume() to reload SettingsManager, LlmApiService, and AgentLoop so provider/model changes take effect immediately without restarting the app

Closes #65 