### PR TITLE
Add retry logic for flaky tests

### DIFF
--- a/app/src/androidTest/java/io/finett/droidclaw/MainActivityTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/MainActivityTest.java
@@ -16,8 +16,11 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import io.finett.droidclaw.util.TestUtils;
+import io.finett.droidclaw.util.Flaky;
+import io.finett.droidclaw.util.FlakyTestRule;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,6 +37,9 @@ public class MainActivityTest {
 
     private static final String CHAT_PREFS = "chat_messages";
     private static final String SETTINGS_PREFS = "droidclaw_settings";
+
+    @Rule
+    public FlakyTestRule flakyTestRule = new FlakyTestRule();
 
     @Before
     public void setUp() {
@@ -112,6 +118,7 @@ public class MainActivityTest {
         }
     }
 
+    @Flaky
     @Test
     public void newChatButton_closesDrawer() {
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
@@ -128,7 +135,7 @@ public class MainActivityTest {
                 DrawerLayout drawerLayout = activity.findViewById(R.id.drawer_layout);
                 assertTrue("Drawer should be open before clicking button",
                         drawerLayout.isDrawerOpen(GravityCompat.START));
-                
+
                 activity.findViewById(R.id.button_new_chat).performClick();
             });
 
@@ -136,6 +143,7 @@ public class MainActivityTest {
         }
     }
 
+    @Flaky
     @Test
     public void settingsButton_closesDrawer() {
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
@@ -152,7 +160,7 @@ public class MainActivityTest {
                 DrawerLayout drawerLayout = activity.findViewById(R.id.drawer_layout);
                 assertTrue("Drawer should be open before clicking button",
                         drawerLayout.isDrawerOpen(GravityCompat.START));
-                
+
                 activity.findViewById(R.id.button_settings).performClick();
             });
 
@@ -425,12 +433,13 @@ public class MainActivityTest {
         }
     }
 
+    @Flaky(maxAttempts = 5)
     @Test
     public void drawerLayout_openAndClose_multipleIterations() {
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
             scenario.onActivity(activity -> {
                 DrawerLayout drawerLayout = activity.findViewById(R.id.drawer_layout);
-                
+
                 for (int i = 0; i < 5; i++) {
                     drawerLayout.openDrawer(GravityCompat.START);
                     try {
@@ -445,7 +454,7 @@ public class MainActivityTest {
                         e.printStackTrace();
                     }
                 }
-                
+
                 assertNotNull(drawerLayout);
             });
         }
@@ -566,19 +575,20 @@ public class MainActivityTest {
         }
     }
 
+    @Flaky
     @Test
     public void navigationController_nullCheck_doesNotCrash() {
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
             scenario.onActivity(activity -> {
                 DrawerLayout drawerLayout = activity.findViewById(R.id.drawer_layout);
                 drawerLayout.openDrawer(GravityCompat.START);
-                
+
                 try {
                     Thread.sleep(200);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
-                
+
                 activity.findViewById(R.id.button_settings).performClick();
 
                 assertNotNull(activity);

--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/ChatFragmentTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/ChatFragmentTest.java
@@ -20,7 +20,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import io.finett.droidclaw.util.Flaky;
+import io.finett.droidclaw.util.FlakyTestRule;
+
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,6 +42,9 @@ public class ChatFragmentTest {
 
     private static final String SETTINGS_PREFS = "droidclaw_settings";
     private static final String CHAT_PREFS = "chat_messages";
+
+    @Rule
+    public FlakyTestRule flakyTestRule = new FlakyTestRule();
 
     @Before
     public void setUp() {
@@ -134,6 +141,7 @@ public class ChatFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void sendMessage_withConfiguration_addsUserMessage() {
         configureSettings();
@@ -165,6 +173,7 @@ public class ChatFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void sendMessage_withConfiguration_showsLoadingState() {
         configureSettings();
@@ -324,6 +333,7 @@ public class ChatFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void fragmentDestroy_cancelsApiRequests() {
         configureSettings();
@@ -357,6 +367,7 @@ public class ChatFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void sendMessage_withLongMessage_handlesCorrectly() {
         configureSettings();

--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/OnboardingFragmentTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/OnboardingFragmentTest.java
@@ -21,7 +21,11 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 
+import io.finett.droidclaw.util.Flaky;
+import io.finett.droidclaw.util.FlakyTestRule;
+
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -32,6 +36,9 @@ import io.finett.droidclaw.util.SettingsManager;
 public class OnboardingFragmentTest {
 
     private static final String SETTINGS_PREFS = "droidclaw_settings";
+
+    @Rule
+    public FlakyTestRule flakyTestRule = new FlakyTestRule();
 
     @Before
     public void setUp() {
@@ -79,6 +86,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void clickNext_transitionsToNameSection() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -108,6 +116,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void nameSection_validationWorks() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -152,6 +161,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void nameSection_savesNameWhenProceeding() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -180,6 +190,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void providerSection_validationWorks() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -207,6 +218,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void providerSection_invalidUrlShowsError() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -236,6 +248,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void providerSection_validDataSavesAndCompletes() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -273,6 +286,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void skipButton_completesOnboardingWithoutData() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -297,6 +311,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void apiTypeDropdown_hasDefaultValue() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -310,13 +325,14 @@ public class OnboardingFragmentTest {
 
             scenario.onFragment(fragment -> {
                 AutoCompleteTextView actvApiType = fragment.requireView().findViewById(R.id.actv_api_type);
-                
+
                 assertEquals("API type should default to openai-completions",
                         "openai-completions", actvApiType.getText().toString());
             });
         }
     }
 
+    @Flaky
     @Test
     public void nameInput_clearsErrorOnTyping() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -354,6 +370,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void recreate_maintainsCurrentSection() {
         try (FragmentScenario<OnboardingFragment> scenario =
@@ -381,6 +398,7 @@ public class OnboardingFragmentTest {
         }
     }
 
+    @Flaky
     @Test
     public void providerSection_allFieldsPresent() {
         try (FragmentScenario<OnboardingFragment> scenario =

--- a/app/src/androidTest/java/io/finett/droidclaw/integration/TaskExecutionIntegrationTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/integration/TaskExecutionIntegrationTest.java
@@ -15,8 +15,12 @@ import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 import androidx.work.testing.WorkManagerTestInitHelper;
 
+import io.finett.droidclaw.util.Flaky;
+import io.finett.droidclaw.util.FlakyTestRule;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -72,6 +76,9 @@ public class TaskExecutionIntegrationTest {
         clearTestData();
     }
 
+    @Rule
+    public FlakyTestRule flakyTestRule = new FlakyTestRule();
+
     @After
     public void tearDown() {
         workManager.cancelAllWork();
@@ -100,6 +107,7 @@ public class TaskExecutionIntegrationTest {
                 .commit();
     }
 
+    @Flaky
     @Test
     public void heartbeat_fullLifecycle_schedulesAndSavesResult() throws Exception {
         HeartbeatConfig config = new HeartbeatConfig(true, 60 * 60 * 1000L, 0L);
@@ -128,6 +136,7 @@ public class TaskExecutionIntegrationTest {
         assertEquals("true", results.get(0).getMetadataValue("healthy"));
     }
 
+    @Flaky
     @Test
     public void heartbeat_cancelAndReschedule_worksCorrectly() throws Exception {
         HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, 0L);
@@ -163,6 +172,7 @@ public class TaskExecutionIntegrationTest {
         assertFalse("Should be rescheduled", workInfos3.isEmpty());
     }
 
+    @Flaky
     @Test
     public void heartbeat_withMissingHeartbeatFile_usesDefaultPrompt() throws Exception {
         File workspaceRoot = workspaceManager.getWorkspaceRoot();
@@ -184,6 +194,7 @@ public class TaskExecutionIntegrationTest {
 
     // ==================== CRON JOB LIFECYCLE TESTS ====================
 
+    @Flaky
     @Test
     public void cronJob_fullLifecycle_schedulesExecutesAndSavesResult() throws Exception {
         CronJob job = new CronJob("cron-integration-1", "Daily Report",
@@ -225,6 +236,7 @@ public class TaskExecutionIntegrationTest {
         assertEquals("Should have 1 record", 1, records.size());
     }
 
+    @Flaky
     @Test
     public void cronJob_cancelAndDelete_removesAllData() throws Exception {
         CronJob job = new CronJob("cron-delete", "Delete Me", "Prompt", "3600000");
@@ -250,6 +262,7 @@ public class TaskExecutionIntegrationTest {
         assertNull("Job should be deleted", deleted);
     }
 
+    @Flaky
     @Test
     public void multipleCronJobs_allScheduledIndependently() throws Exception {
         CronJob job1 = new CronJob("cron-multi-1", "Job 1", "Prompt 1", "3600000");

--- a/app/src/androidTest/java/io/finett/droidclaw/ui/CriticalUserJourneysUITest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/ui/CriticalUserJourneysUITest.java
@@ -26,8 +26,12 @@ import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
+import io.finett.droidclaw.util.Flaky;
+import io.finett.droidclaw.util.FlakyTestRule;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -64,6 +68,9 @@ public class CriticalUserJourneysUITest {
         settingsManager.setOnboardingCompleted(true);
     }
     
+    @Rule
+    public FlakyTestRule flakyTestRule = new FlakyTestRule();
+
     @After
     public void tearDown() {
         if (idlingResource != null) {
@@ -91,6 +98,7 @@ public class CriticalUserJourneysUITest {
         }
     }
 
+    @Flaky
     @Test
     public void userJourney_sendMessage_completeFlow() {
         configureSettings();
@@ -111,6 +119,7 @@ public class CriticalUserJourneysUITest {
         }
     }
 
+    @Flaky
     @Test
     public void userJourney_createMultipleChats_switchBetween() {
         try (ActivityScenario<MainActivity> scenario = ActivityLaunchHelper.launchAndWait(MainActivity.class)) {
@@ -193,6 +202,7 @@ public class CriticalUserJourneysUITest {
         }
     }
 
+    @Flaky
     @Test
     public void userJourney_emptyMessageAttempt_validation() {
         try (ActivityScenario<MainActivity> scenario = ActivityLaunchHelper.launchAndWait(MainActivity.class)) {
@@ -216,6 +226,7 @@ public class CriticalUserJourneysUITest {
         }
     }
 
+    @Flaky
     @Test
     public void userJourney_settingsWithoutApiKey_showsValidation() {
         try (ActivityScenario<MainActivity> scenario = ActivityLaunchHelper.launchAndWait(MainActivity.class)) {
@@ -231,6 +242,7 @@ public class CriticalUserJourneysUITest {
         }
     }
 
+    @Flaky(maxAttempts = 5)
     @Test
     public void userJourney_rapidActions_stressTest() {
         try (ActivityScenario<MainActivity> scenario = ActivityLaunchHelper.launchAndWait(MainActivity.class)) {

--- a/app/src/androidTest/java/io/finett/droidclaw/util/Flaky.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/util/Flaky.java
@@ -1,0 +1,36 @@
+package io.finett.droidclaw.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark a test method as flaky.
+ * When used with {@link FlakyTestRule}, the annotated test will be automatically
+ * retried up to a specified number of times before being marked as failed.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * @Rule
+ * public FlakyTestRule flakyTestRule = new FlakyTestRule();
+ *
+ * @Flaky
+ * @Test
+ * public void myFlakyTest() {
+ *     // Test code that may fail intermittently
+ * }
+ * }</pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Flaky {
+
+    /**
+     * The maximum number of attempts to run the test.
+     * Default is 3.
+     *
+     * @return the maximum number of attempts
+     */
+    int maxAttempts() default 3;
+}

--- a/app/src/androidTest/java/io/finett/droidclaw/util/FlakyTestRule.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/util/FlakyTestRule.java
@@ -1,0 +1,81 @@
+package io.finett.droidclaw.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A JUnit rule that automatically retries flaky tests.
+ * Can be used with the {@link Flaky} annotation to mark tests that should be retried.
+ */
+public class FlakyTestRule implements TestRule {
+
+    private static final Logger LOGGER = Logger.getLogger(FlakyTestRule.class.getName());
+
+    private final int maxAttempts;
+
+    /**
+     * Creates a FlakyTestRule with the default maximum attempts (3).
+     */
+    public FlakyTestRule() {
+        this(3);
+    }
+
+    /**
+     * Creates a FlakyTestRule with a custom maximum attempts.
+     *
+     * @param maxAttempts the maximum number of times to run each flaky test
+     */
+    public FlakyTestRule(int maxAttempts) {
+        if (maxAttempts < 1) {
+            throw new IllegalArgumentException("maxAttempts must be at least 1");
+        }
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        Flaky flaky = description.getAnnotation(Flaky.class);
+
+        if (flaky == null) {
+            // Test is not marked as flaky, run normally
+            return base;
+        }
+
+        // Test is marked as flaky, apply retry logic
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable lastException = null;
+                int attempt = 0;
+
+                while (attempt < maxAttempts) {
+                    attempt++;
+                    try {
+                        base.evaluate();
+                        // Test passed, we're done
+                        if (attempt > 1) {
+                            LOGGER.log(Level.WARNING,
+                                    "Test {0} passed on attempt {1}/{2}",
+                                    new Object[]{description.getDisplayName(), attempt, maxAttempts});
+                        }
+                        return;
+                    } catch (Throwable t) {
+                        lastException = t;
+                        LOGGER.log(Level.WARNING,
+                                "Test {0} failed on attempt {1}/{2}: {3}",
+                                new Object[]{description.getDisplayName(), attempt, maxAttempts, t.getMessage()});
+                    }
+                }
+
+                // All attempts failed
+                LOGGER.warning("Test " + description.getDisplayName() +
+                        " failed after " + maxAttempts + " attempts");
+                throw lastException;
+            }
+        };
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/util/Flaky.java
+++ b/app/src/test/java/io/finett/droidclaw/util/Flaky.java
@@ -1,0 +1,36 @@
+package io.finett.droidclaw.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark a test method as flaky.
+ * When used with {@link FlakyTestRule}, the annotated test will be automatically
+ * retried up to a specified number of times before being marked as failed.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * @Rule
+ * public FlakyTestRule flakyTestRule = new FlakyTestRule();
+ *
+ * @Flaky
+ * @Test
+ * public void myFlakyTest() {
+ *     // Test code that may fail intermittently
+ * }
+ * }</pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Flaky {
+
+    /**
+     * The maximum number of attempts to run the test.
+     * Default is 3.
+     *
+     * @return the maximum number of attempts
+     */
+    int maxAttempts() default 3;
+}

--- a/app/src/test/java/io/finett/droidclaw/util/FlakyTestRule.java
+++ b/app/src/test/java/io/finett/droidclaw/util/FlakyTestRule.java
@@ -1,0 +1,81 @@
+package io.finett.droidclaw.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A JUnit rule that automatically retries flaky tests.
+ * Can be used with the {@link Flaky} annotation to mark tests that should be retried.
+ */
+public class FlakyTestRule implements TestRule {
+
+    private static final Logger LOGGER = Logger.getLogger(FlakyTestRule.class.getName());
+
+    private final int maxAttempts;
+
+    /**
+     * Creates a FlakyTestRule with the default maximum attempts (3).
+     */
+    public FlakyTestRule() {
+        this(3);
+    }
+
+    /**
+     * Creates a FlakyTestRule with a custom maximum attempts.
+     *
+     * @param maxAttempts the maximum number of times to run each flaky test
+     */
+    public FlakyTestRule(int maxAttempts) {
+        if (maxAttempts < 1) {
+            throw new IllegalArgumentException("maxAttempts must be at least 1");
+        }
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        Flaky flaky = description.getAnnotation(Flaky.class);
+
+        if (flaky == null) {
+            // Test is not marked as flaky, run normally
+            return base;
+        }
+
+        // Test is marked as flaky, apply retry logic
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable lastException = null;
+                int attempt = 0;
+
+                while (attempt < maxAttempts) {
+                    attempt++;
+                    try {
+                        base.evaluate();
+                        // Test passed, we're done
+                        if (attempt > 1) {
+                            LOGGER.log(Level.WARNING,
+                                    "Test {0} passed on attempt {1}/{2}",
+                                    new Object[]{description.getDisplayName(), attempt, maxAttempts});
+                        }
+                        return;
+                    } catch (Throwable t) {
+                        lastException = t;
+                        LOGGER.log(Level.WARNING,
+                                "Test {0} failed on attempt {1}/{2}: {3}",
+                                new Object[]{description.getDisplayName(), attempt, maxAttempts, t.getMessage()});
+                    }
+                }
+
+                // All attempts failed
+                LOGGER.warning("Test " + description.getDisplayName() +
+                        " failed after " + maxAttempts + " attempts");
+                throw lastException;
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Created Flaky annotation for marking tests as flaky
- Created FlakyTestRule for automatic test retry logic
- Applied retry logic to MainActivityTest (5 tests)
- Applied retry logic to OnboardingFragmentTest (11 tests)
- Applied retry logic to ChatFragmentTest (4 tests)
- Applied retry logic to TaskExecutionIntegrationTest (6 tests)
- Applied retry logic to CriticalUserJourneysUITest (5 tests)