### PR TITLE
fix(ui): move scheduled tasks into settings

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/MainActivity.java
+++ b/app/src/main/java/io/finett/droidclaw/MainActivity.java
@@ -82,8 +82,7 @@ public class MainActivity extends AppCompatActivity {
             appBarConfiguration = new AppBarConfiguration.Builder(
                     R.id.chatFragment,
                     R.id.fileBrowserFragment,
-                    R.id.memoryBrowserFragment,
-                    R.id.cronJobListFragment
+                    R.id.memoryBrowserFragment
             )
                     .setOpenableLayout(drawerLayout)
                     .build();
@@ -219,7 +218,6 @@ public class MainActivity extends AppCompatActivity {
         MaterialButton newChatButton = findViewById(R.id.button_new_chat);
         MaterialButton filesButton = findViewById(R.id.button_files);
         MaterialButton memoryButton = findViewById(R.id.button_memory);
-        MaterialButton scheduledTasksButton = findViewById(R.id.button_scheduled_tasks);
         MaterialButton settingsButton = findViewById(R.id.button_settings);
         RecyclerView chatSessionsRecyclerView = findViewById(R.id.recycler_chat_sessions);
 
@@ -273,13 +271,6 @@ public class MainActivity extends AppCompatActivity {
         memoryButton.setOnClickListener(v -> {
             if (navController != null) {
                 navController.navigate(R.id.memoryBrowserFragment);
-            }
-            drawerLayout.closeDrawer(GravityCompat.START);
-        });
-
-        scheduledTasksButton.setOnClickListener(v -> {
-            if (navController != null) {
-                navController.navigate(R.id.cronJobListFragment);
             }
             drawerLayout.closeDrawer(GravityCompat.START);
         });

--- a/app/src/main/java/io/finett/droidclaw/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/SettingsFragment.java
@@ -155,7 +155,7 @@ public class SettingsFragment extends Fragment {
                 break;
             case ITEM_CRON_JOBS:
                 Navigation.findNavController(requireView())
-                        .navigate(R.id.cronJobListFragment);
+                        .navigate(R.id.action_settingsFragment_to_cronJobListFragment);
                 break;
             case ITEM_SKILLS:
                 Navigation.findNavController(requireView())

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -81,18 +81,6 @@
             android:text="@string/memory" />
 
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/button_scheduled_tasks"
-            style="@style/Widget.Material3.Button.TextButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="start|center_vertical"
-            android:insetTop="0dp"
-            android:insetBottom="0dp"
-            android:paddingStart="20dp"
-            android:paddingEnd="20dp"
-            android:text="@string/cron_jobs" />
-
-        <com.google.android.material.button.MaterialButton
             android:id="@+id/button_settings"
             style="@style/Widget.Material3.Button.TextButton"
             android:layout_width="match_parent"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -71,6 +71,13 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+        <action
+            android:id="@+id/action_settingsFragment_to_cronJobListFragment"
+            app:destination="@id/cronJobListFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
remove the scheduled tasks shortcut from the side drawer so it is accessed from the settings screen instead

add a dedicated navigation action for cron jobs to keep settings navigation consistent and preserve submenu transitions