### PR TITLE
feat: implement chat session picker and fix leaks

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -722,5 +722,8 @@ public class ChatFragment extends Fragment {
     public void onDestroyView() {
         super.onDestroyView();
         apiService.cancelAllRequests();
+        if (toolRegistry != null) {
+            toolRegistry.shutdown();
+        }
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/fragment/ZenResultFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ZenResultFragment.java
@@ -19,6 +19,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 import io.finett.droidclaw.MainActivity;
@@ -165,21 +166,43 @@ public class ZenResultFragment extends Fragment {
             return;
         }
 
-
-        // In a full implementation, you'd show a picker of existing chats
-        MainActivity mainActivity = (MainActivity) requireActivity();
-        ChatSession session = mainActivity.getMostRecentChatSession();
-
-        if (session != null) {
-            // Inject task result into existing chat to add context
-            continuationService.continueInExistingChat(taskResult, session.getId());
-
-            Bundle args = new Bundle();
-            args.putString(ChatFragment.ARG_SESSION_ID, session.getId());
-            Navigation.findNavController(requireView()).navigate(R.id.chatFragment, args);
-        } else {
+        List<ChatSession> visibleSessions = new ChatRepository(requireContext()).getVisibleSessions();
+        if (visibleSessions.isEmpty()) {
             Toast.makeText(requireContext(), "No existing chats available", Toast.LENGTH_SHORT).show();
+            return;
         }
+
+        if (visibleSessions.size() == 1) {
+            continueInSelectedChat(visibleSessions.get(0));
+            return;
+        }
+
+        CharSequence[] sessionTitles = new CharSequence[visibleSessions.size()];
+        for (int i = 0; i < visibleSessions.size(); i++) {
+            ChatSession session = visibleSessions.get(i);
+            String title = session.getTitle();
+            sessionTitles[i] = (title == null || title.trim().isEmpty())
+                    ? getString(R.string.new_chat)
+                    : title;
+        }
+
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.chat_continuation_existing)
+                .setItems(sessionTitles, (dialog, which) -> continueInSelectedChat(visibleSessions.get(which)))
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+    }
+
+    private void continueInSelectedChat(ChatSession session) {
+        if (session == null) {
+            return;
+        }
+
+        continuationService.continueInExistingChat(taskResult, session.getId());
+
+        Bundle args = new Bundle();
+        args.putString(ChatFragment.ARG_SESSION_ID, session.getId());
+        Navigation.findNavController(requireView()).navigate(R.id.chatFragment, args);
     }
 
     private void shareResult() {

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -164,4 +164,16 @@ public class ToolRegistry {
     public File getWorkspaceRoot() {
         return workspaceManager.getWorkspaceRoot();
     }
+
+    /**
+     * Release resources held by registered tools that own lifecycle-managed executors.
+     * Must be called when the registry is discarded (e.g. fragment onDestroy, worker completion).
+     */
+    public void shutdown() {
+        for (Tool tool : tools.values()) {
+            if (tool instanceof PythonTool) {
+                ((PythonTool) tool).shutdown();
+            }
+        }
+    }
 }

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/PythonTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/PythonTool.java
@@ -167,4 +167,9 @@ public class PythonTool implements Tool {
         }
     }
 
+    public void shutdown() {
+        if (executor != null) {
+            executor.shutdown();
+        }
+    }
 }

--- a/app/src/main/java/io/finett/droidclaw/worker/BaseTaskWorker.java
+++ b/app/src/main/java/io/finett/droidclaw/worker/BaseTaskWorker.java
@@ -128,9 +128,10 @@ public abstract class BaseTaskWorker extends Worker {
             return result;
         }
 
+        ToolRegistry toolRegistry = null;
         try {
             LlmApiService apiService = createApiService();
-            ToolRegistry toolRegistry = createToolRegistry();
+            toolRegistry = createToolRegistry();
 
             AgentLoop agentLoop = new AgentLoop(apiService, toolRegistry, settingsManager);
 
@@ -221,6 +222,10 @@ public abstract class BaseTaskWorker extends Worker {
             Log.e(TAG, errorMsg, e);
             executionRecord.fail(endTime, errorMsg);
             result = createFailureResult(taskId, taskType, endTime, errorMsg);
+        } finally {
+            if (toolRegistry != null) {
+                toolRegistry.shutdown();
+            }
         }
 
         taskRepository.saveExecutionRecord(executionRecord);


### PR DESCRIPTION
- Replace the placeholder implementation in ZenResultFragment with a material dialog picker, allowing users to select an existing chat session for task continuation.
- Add a shutdown() lifecycle method to ToolRegistry and PythonTool.
- Ensure tools and executors are properly terminated in ChatFragment and BaseTaskWorker to prevent thread and memory leaks.