### PR TITLE
fix(chat): prevent request cancellation when switching between chats

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/MainActivity.java
+++ b/app/src/main/java/io/finett/droidclaw/MainActivity.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.UUID;
 
 import io.finett.droidclaw.adapter.ChatSessionAdapter;
+import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.fragment.ChatFragment;
 import io.finett.droidclaw.model.ChatSession;
 import io.finett.droidclaw.model.SessionType;
@@ -51,6 +52,7 @@ public class MainActivity extends AppCompatActivity {
     private final List<ChatSession> chatSessions = new ArrayList<>();
     private ChatRepository chatRepository;
     private SettingsManager settingsManager;
+    private LlmApiService apiService;
     private String currentSessionId;
 
     @Override
@@ -67,6 +69,7 @@ public class MainActivity extends AppCompatActivity {
         drawerLayout = findViewById(R.id.drawer_layout);
         chatRepository = new ChatRepository(this);
         settingsManager = new SettingsManager(this);
+        apiService = new LlmApiService(settingsManager);
 
         MaterialToolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -518,6 +521,14 @@ public class MainActivity extends AppCompatActivity {
         chatRepository.saveSessions(chatSessions);
         chatSessionAdapter.submitList(new ArrayList<>(chatSessions));
         Log.d(TAG, "Updated session title: " + sessionId + " -> " + newTitle);
+    }
+
+    /**
+     * Returns the shared LlmApiService scoped to the Activity.
+     * ChatFragment uses this to avoid canceling requests on chat switches.
+     */
+    public LlmApiService getApiService() {
+        return apiService;
     }
 
     @Override

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -87,9 +87,15 @@ public class ChatFragment extends Fragment {
         super.onCreate(savedInstanceState);
 
         settingsManager = new SettingsManager(requireContext());
-        apiService = new LlmApiService(settingsManager);
         chatRepository = new ChatRepository(requireContext());
         continuationService = new ChatContinuationService(requireContext());
+        
+        // Use Activity-scoped API service so requests survive chat switches
+        if (requireActivity() instanceof MainActivity) {
+            apiService = ((MainActivity) requireActivity()).getApiService();
+        } else {
+            apiService = new LlmApiService(settingsManager);
+        }
 
 
         Bundle taskArgs = getArguments();
@@ -706,9 +712,11 @@ public class ChatFragment extends Fragment {
         super.onResume();
         // Reload settings in case the user changed provider/model in the Settings screen
         settingsManager = new SettingsManager(requireContext());
-        apiService = new LlmApiService(settingsManager);
+        // Refresh the Activity-scoped API service with new settings
+        if (requireActivity() instanceof MainActivity) {
+            apiService = ((MainActivity) requireActivity()).getApiService();
+        }
         // Propagate the refreshed service to the agent loop components
-        // (ConversationSummarizer and AgentLoop hold their own apiService reference)
         int contextWindow = getModelContextWindow();
         io.finett.droidclaw.agent.ConversationSummarizer summarizer =
                 new io.finett.droidclaw.agent.ConversationSummarizer(apiService, memoryRepository, contextWindow);
@@ -721,7 +729,8 @@ public class ChatFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        apiService.cancelAllRequests();
+        // Do NOT cancel requests here — the API service is Activity-scoped
+        // and requests should survive chat switches. Only shut down tools.
         if (toolRegistry != null) {
             toolRegistry.shutdown();
         }


### PR DESCRIPTION
Move LlmApiService from Fragment scope to Activity scope so that in-flight LLM requests are not canceled when the user switches between chat sessions. ChatFragment now uses the shared Activity- scoped service instead of creating and destroying its own instance.