### PR TITLE
feat(settings): encrypt storage with Keystore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,6 +127,7 @@ dependencies {
     implementation(libs.recyclerview)
     implementation(libs.okhttp)
     implementation(libs.gson)
+    implementation(libs.security.crypto)
     
     // WorkManager for background task execution
     implementation("androidx.work:work-runtime-ktx:2.9.0")

--- a/app/src/androidTest/java/io/finett/droidclaw/MainActivityTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/MainActivityTest.java
@@ -36,7 +36,6 @@ import io.finett.droidclaw.util.SettingsManager;
 public class MainActivityTest {
 
     private static final String CHAT_PREFS = "chat_messages";
-    private static final String SETTINGS_PREFS = "droidclaw_settings";
 
     @Rule
     public FlakyTestRule flakyTestRule = new FlakyTestRule();
@@ -47,11 +46,8 @@ public class MainActivityTest {
                 .getSharedPreferences(CHAT_PREFS, Context.MODE_PRIVATE);
         chatPrefs.edit().clear().commit();
 
-        SharedPreferences settingsPrefs = getApplicationContext()
-                .getSharedPreferences(SETTINGS_PREFS, Context.MODE_PRIVATE);
-        settingsPrefs.edit().clear().commit();
-
         SettingsManager settingsManager = new SettingsManager(getApplicationContext());
+        settingsManager.clear();
         settingsManager.setOnboardingCompleted(true);
     }
 

--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/ChatFragmentTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/ChatFragmentTest.java
@@ -40,7 +40,6 @@ import io.finett.droidclaw.util.SettingsManager;
 @RunWith(AndroidJUnit4.class)
 public class ChatFragmentTest {
 
-    private static final String SETTINGS_PREFS = "droidclaw_settings";
     private static final String CHAT_PREFS = "chat_messages";
 
     @Rule
@@ -48,9 +47,7 @@ public class ChatFragmentTest {
 
     @Before
     public void setUp() {
-        SharedPreferences settingsPrefs = getApplicationContext()
-                .getSharedPreferences(SETTINGS_PREFS, Context.MODE_PRIVATE);
-        settingsPrefs.edit().clear().commit();
+        new SettingsManager(getApplicationContext()).clear();
 
         SharedPreferences chatPrefs = getApplicationContext()
                 .getSharedPreferences(CHAT_PREFS, Context.MODE_PRIVATE);

--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/EnvVarsSettingsFragmentInstrumentedTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/EnvVarsSettingsFragmentInstrumentedTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.view.View;
 
 import androidx.fragment.app.testing.FragmentScenario;
@@ -27,14 +25,10 @@ import io.finett.droidclaw.util.SettingsManager;
 @RunWith(AndroidJUnit4.class)
 public class EnvVarsSettingsFragmentInstrumentedTest {
 
-    private static final String PREFS_NAME = "droidclaw_settings";
-
     @Before
     public void setUp() {
         // Clear preferences before each test for a clean state
-        SharedPreferences prefs = getApplicationContext()
-                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        prefs.edit().clear().commit();
+        new SettingsManager(getApplicationContext()).clear();
     }
 
     @Test

--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/OnboardingFragmentTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/OnboardingFragmentTest.java
@@ -7,8 +7,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.view.View;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
@@ -35,16 +33,12 @@ import io.finett.droidclaw.util.SettingsManager;
 @RunWith(AndroidJUnit4.class)
 public class OnboardingFragmentTest {
 
-    private static final String SETTINGS_PREFS = "droidclaw_settings";
-
     @Rule
     public FlakyTestRule flakyTestRule = new FlakyTestRule();
 
     @Before
     public void setUp() {
-        SharedPreferences prefs = getApplicationContext()
-                .getSharedPreferences(SETTINGS_PREFS, Context.MODE_PRIVATE);
-        prefs.edit().clear().commit();
+        new SettingsManager(getApplicationContext()).clear();
     }
 
     @Test

--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/ProviderDetailFragmentTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/ProviderDetailFragmentTest.java
@@ -7,8 +7,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -34,13 +32,9 @@ import io.finett.droidclaw.util.SettingsManager;
 @RunWith(AndroidJUnit4.class)
 public class ProviderDetailFragmentTest {
 
-    private static final String SETTINGS_PREFS = "droidclaw_settings";
-
     @Before
     public void setUp() {
-        SharedPreferences prefs = getApplicationContext()
-                .getSharedPreferences(SETTINGS_PREFS, Context.MODE_PRIVATE);
-        prefs.edit().clear().commit();
+        new SettingsManager(getApplicationContext()).clear();
     }
 
     @Test

--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/SettingsFragmentTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/SettingsFragmentTest.java
@@ -5,9 +5,6 @@ import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.view.View;
 import android.view.View;
 
 import androidx.fragment.app.testing.FragmentScenario;
@@ -26,13 +23,9 @@ import io.finett.droidclaw.util.SettingsManager;
 @RunWith(AndroidJUnit4.class)
 public class SettingsFragmentTest {
 
-    private static final String PREFS_NAME = "droidclaw_settings";
-
     @Before
     public void setUp() {
-        SharedPreferences prefs = getApplicationContext()
-                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        prefs.edit().clear().commit();
+        new SettingsManager(getApplicationContext()).clear();
     }
 
     @Test

--- a/app/src/androidTest/java/io/finett/droidclaw/integration/UserFlowIntegrationTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/integration/UserFlowIntegrationTest.java
@@ -38,7 +38,6 @@ import io.finett.droidclaw.util.TestUtils;
 @RunWith(AndroidJUnit4.class)
 public class UserFlowIntegrationTest {
 
-    private static final String SETTINGS_PREFS = "droidclaw_settings";
     private static final String CHAT_PREFS = "chat_messages";
     
     private TestUtils.SimpleIdlingResource idlingResource;
@@ -47,15 +46,13 @@ public class UserFlowIntegrationTest {
     public void setUp() {
         TestUtils.resetRootViewPicker();
 
-        SharedPreferences settingsPrefs = getApplicationContext()
-                .getSharedPreferences(SETTINGS_PREFS, Context.MODE_PRIVATE);
-        settingsPrefs.edit().clear().commit();
+        SettingsManager settingsManager = new SettingsManager(getApplicationContext());
+        settingsManager.clear();
 
         SharedPreferences chatPrefs = getApplicationContext()
                 .getSharedPreferences(CHAT_PREFS, Context.MODE_PRIVATE);
         chatPrefs.edit().clear().commit();
         
-        SettingsManager settingsManager = new SettingsManager(getApplicationContext());
         settingsManager.setOnboardingCompleted(true);
     }
     

--- a/app/src/androidTest/java/io/finett/droidclaw/ui/CriticalUserJourneysUITest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/ui/CriticalUserJourneysUITest.java
@@ -47,7 +47,6 @@ import io.finett.droidclaw.util.TestUtils;
 @LargeTest
 public class CriticalUserJourneysUITest {
 
-    private static final String SETTINGS_PREFS = "droidclaw_settings";
     private static final String CHAT_PREFS = "chat_messages";
     
     private TestUtils.SimpleIdlingResource idlingResource;
@@ -56,15 +55,13 @@ public class CriticalUserJourneysUITest {
     public void setUp() {
         TestUtils.resetRootViewPicker();
 
-        SharedPreferences settingsPrefs = getApplicationContext()
-                .getSharedPreferences(SETTINGS_PREFS, Context.MODE_PRIVATE);
-        settingsPrefs.edit().clear().commit();
+        SettingsManager settingsManager = new SettingsManager(getApplicationContext());
+        settingsManager.clear();
 
         SharedPreferences chatPrefs = getApplicationContext()
                 .getSharedPreferences(CHAT_PREFS, Context.MODE_PRIVATE);
         chatPrefs.edit().clear().commit();
         
-        SettingsManager settingsManager = new SettingsManager(getApplicationContext());
         settingsManager.setOnboardingCompleted(true);
     }
     

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -4,10 +4,15 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.security.crypto.MasterKey;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -20,7 +25,10 @@ import io.finett.droidclaw.model.Provider;
 
 public class SettingsManager {
     private static final String TAG = "SettingsManager";
-    private static final String PREFS_NAME = "droidclaw_settings";
+    /** Legacy plaintext prefs name – kept for migration only. */
+    private static final String LEGACY_PREFS_NAME = "droidclaw_settings";
+    /** Encrypted prefs file name. */
+    private static final String ENCRYPTED_PREFS_NAME = "droidclaw_settings_secure";
     private static final String KEY_SETTINGS_JSON = "settings_json";
 
     private final SharedPreferences prefs;
@@ -35,8 +43,68 @@ public class SettingsManager {
 
     public SettingsManager(Context context) {
         this.context = context;
-        this.prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        this.prefs = getOrCreateEncryptedPrefs(context);
         loadFromJson();
+    }
+
+    /**
+     * Returns an EncryptedSharedPreferences instance backed by the Android Keystore.
+     * On first run after the migration, existing plaintext data is copied over and the
+     * legacy file is deleted.
+     */
+    private SharedPreferences getOrCreateEncryptedPrefs(Context ctx) {
+        try {
+            MasterKey masterKey = new MasterKey.Builder(ctx)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build();
+
+            SharedPreferences encryptedPrefs = EncryptedSharedPreferences.create(
+                    ctx,
+                    ENCRYPTED_PREFS_NAME,
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            );
+
+            // Migrate from legacy plaintext prefs if they still exist
+            migrateLegacyPrefsIfNeeded(ctx, encryptedPrefs);
+
+            return encryptedPrefs;
+        } catch (GeneralSecurityException | IOException e) {
+            // Fallback to plaintext prefs if encryption fails (should not happen on API 23+)
+            Log.e(TAG, "Failed to create EncryptedSharedPreferences, falling back to plaintext", e);
+            return ctx.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE);
+        }
+    }
+
+    /**
+     * One-time migration: copy data from the old plaintext SharedPreferences to the new
+     * encrypted store and then delete the legacy file.
+     */
+    private void migrateLegacyPrefsIfNeeded(Context ctx, SharedPreferences encryptedPrefs) {
+        SharedPreferences legacyPrefs = ctx.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE);
+        String legacyJson = legacyPrefs.getString(KEY_SETTINGS_JSON, null);
+
+        if (legacyJson != null) {
+            // Only migrate if encrypted store is empty (first run after upgrade)
+            if (!encryptedPrefs.contains(KEY_SETTINGS_JSON)) {
+                encryptedPrefs.edit().putString(KEY_SETTINGS_JSON, legacyJson).apply();
+                Log.i(TAG, "Migrated settings from plaintext to encrypted storage");
+            }
+            // Clear legacy prefs so migration doesn't repeat
+            legacyPrefs.edit().clear().apply();
+
+            // Attempt to delete the legacy file from disk
+            try {
+                java.io.File legacyFile = new java.io.File(
+                        ctx.getApplicationInfo().dataDir + "/shared_prefs/" + LEGACY_PREFS_NAME + ".xml");
+                if (legacyFile.exists() && legacyFile.delete()) {
+                    Log.i(TAG, "Deleted legacy plaintext prefs file");
+                }
+            } catch (SecurityException se) {
+                Log.w(TAG, "Could not delete legacy prefs file", se);
+            }
+        }
     }
 
     // ==================== JSON Serialization ====================
@@ -570,5 +638,17 @@ public class SettingsManager {
             envVars.remove(key);
             saveToJson();
         }
+    }
+
+    // ==================== Test / Reset Helpers ====================
+
+    /**
+     * Clears all settings from the encrypted storage and resets in-memory state.
+     * Use this in tests or for a factory reset, rather than reaching for the
+     * underlying SharedPreferences file directly.
+     */
+    public void clear() {
+        prefs.edit().clear().apply();
+        initializeDefaults();
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ fragmentTesting = "1.8.6"
 mockito = "5.11.0"
 markwon = "4.6.2"
 desugaring = "2.1.4"
+securityCrypto = "1.1.0-alpha06"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -44,6 +45,7 @@ markwon-ext-tables = { group = "io.noties.markwon", name = "ext-tables", version
 markwon-ext-tasklist = { group = "io.noties.markwon", name = "ext-tasklist", version.ref = "markwon" }
 markwon-syntax-highlight = { group = "io.noties.markwon", name = "syntax-highlight", version.ref = "markwon" }
 desugaring = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugaring" }
+security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Replace plaintext SharedPreferences with EncryptedSharedPreferences backed by the Android Keystore. Existing data is automatically migrated from the legacy plaintext file on first run and the old file is deleted afterwards.

Add a clear() helper to SettingsManager for tests and factory resets, and update all instrumentation tests to use it instead of directly accessing the underlying SharedPreferences by name.