### PR TITLE
test: update model references to latest versions in tests

### DIFF
--- a/app/src/androidTest/java/io/finett/droidclaw/adapter/ModelsAdapterTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/adapter/ModelsAdapterTest.java
@@ -51,8 +51,8 @@ public class ModelsAdapterTest {
     @Test
     public void submitList_withModels_updatesCount() throws InterruptedException {
         List<Model> models = Arrays.asList(
-            new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096),
-            new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048)
+            new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096),
+            new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048)
         );
 
         AdapterTestHelper.submitListAndWait(adapter, models);
@@ -63,7 +63,7 @@ public class ModelsAdapterTest {
     @Test
     public void submitList_withEmptyList_clearsAdapter() throws InterruptedException {
         List<Model> models = Arrays.asList(
-            new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096)
+            new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096)
         );
         AdapterTestHelper.submitListAndWait(adapter, models);
 
@@ -75,7 +75,7 @@ public class ModelsAdapterTest {
     @Test
     public void submitList_withNull_clearsAdapter() throws InterruptedException {
         List<Model> models = Arrays.asList(
-            new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096)
+            new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096)
         );
         AdapterTestHelper.submitListAndWait(adapter, models);
 
@@ -87,13 +87,13 @@ public class ModelsAdapterTest {
     @Test
     public void submitList_replacesExistingList() throws InterruptedException {
         List<Model> models1 = Arrays.asList(
-            new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096)
+            new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096)
         );
         AdapterTestHelper.submitListAndWait(adapter, models1);
 
         List<Model> models2 = Arrays.asList(
-            new Model("claude-3", "Claude 3", "anthropic", true, Arrays.asList("text", "image"), 100000, 4096),
-            new Model("claude-2", "Claude 2", "anthropic", false, Arrays.asList("text"), 100000, 4096)
+            new Model("claude-sonnet-4-6", "Claude Sonnet 4.6", "anthropic", true, Arrays.asList("text", "image"), 100000, 4096),
+            new Model("claude-opus-4-7", "Claude Opus 4.7", "anthropic", false, Arrays.asList("text"), 100000, 4096)
         );
         AdapterTestHelper.submitListAndWait(adapter, models2);
 
@@ -127,7 +127,7 @@ public class ModelsAdapterTest {
     @Test
     public void onBindViewHolder_bindsModelName() {
         List<Model> models = Arrays.asList(
-            new Model("gpt-4", "GPT-4 Turbo", "openai", false, Arrays.asList("text"), 128000, 4096)
+            new Model("gpt-5.4", "GPT-5.4 Turbo", "openai", false, Arrays.asList("text"), 128000, 4096)
         );
         adapter.submitList(models);
 
@@ -139,13 +139,13 @@ public class ModelsAdapterTest {
         adapter.onBindViewHolder((ModelsAdapter.ModelViewHolder) viewHolder, 0);
 
         TextView nameText = viewHolder.itemView.findViewById(R.id.text_model_name);
-        assertEquals("GPT-4 Turbo", nameText.getText().toString());
+        assertEquals("GPT-5.4 Turbo", nameText.getText().toString());
     }
 
     @Test
     public void onBindViewHolder_bindsContextWindow() {
         List<Model> models = Arrays.asList(
-            new Model("claude-3", "Claude 3", "anthropic", true, Arrays.asList("text"), 200000, 4096)
+            new Model("claude-sonnet-4-6", "Claude Sonnet 4.6", "anthropic", true, Arrays.asList("text"), 200000, 4096)
         );
         adapter.submitList(models);
 
@@ -165,8 +165,8 @@ public class ModelsAdapterTest {
     @Test
     public void onBindViewHolder_multipleModels_bindsCorrectly() {
         List<Model> models = Arrays.asList(
-            new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096),
-            new Model("claude-3", "Claude 3", "anthropic", true, Arrays.asList("text"), 100000, 4096)
+            new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096),
+            new Model("claude-sonnet-4-6", "Claude 3", "anthropic", true, Arrays.asList("text"), 100000, 4096)
         );
         adapter.submitList(models);
 
@@ -177,7 +177,7 @@ public class ModelsAdapterTest {
         RecyclerView.ViewHolder viewHolder1 = adapter.onCreateViewHolder(recyclerView, 0);
         adapter.onBindViewHolder((ModelsAdapter.ModelViewHolder) viewHolder1, 0);
         TextView nameText1 = viewHolder1.itemView.findViewById(R.id.text_model_name);
-        assertEquals("GPT-4", nameText1.getText().toString());
+        assertEquals("GPT-5.4", nameText1.getText().toString());
 
         RecyclerView.ViewHolder viewHolder2 = adapter.onCreateViewHolder(recyclerView, 0);
         adapter.onBindViewHolder((ModelsAdapter.ModelViewHolder) viewHolder2, 1);
@@ -195,7 +195,7 @@ public class ModelsAdapterTest {
             clickedModel.set(model);
         });
 
-        Model testModel = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model testModel = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         List<Model> models = Arrays.asList(testModel);
         AdapterTestHelper.submitListAndWait(adapter, models);
 
@@ -221,7 +221,7 @@ public class ModelsAdapterTest {
 
     @Test
     public void clickListener_whenNotSet_doesNotCrash() {
-        Model testModel = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model testModel = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         List<Model> models = Arrays.asList(testModel);
         adapter.submitList(models);
 
@@ -236,8 +236,8 @@ public class ModelsAdapterTest {
 
     @Test
     public void diffUtil_identifiesSameItems() throws InterruptedException {
-        Model model1 = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
-        Model model2 = new Model("gpt-4", "GPT-4 Updated", "openai", false, Arrays.asList("text"), 16384, 8192);
+        Model model1 = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model2 = new Model("gpt-5.4", "GPT-5.4 Updated", "openai", false, Arrays.asList("text"), 16384, 8192);
 
         AdapterTestHelper.submitListAndWait(adapter, Arrays.asList(model1));
         assertEquals(1, adapter.getItemCount());
@@ -248,8 +248,8 @@ public class ModelsAdapterTest {
 
     @Test
     public void diffUtil_identifiesDifferentItems() throws InterruptedException {
-        Model model1 = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
-        Model model2 = new Model("claude-3", "Claude 3", "anthropic", true, Arrays.asList("text"), 100000, 4096);
+        Model model1 = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model2 = new Model("claude-sonnet-4-6", "Claude 3", "anthropic", true, Arrays.asList("text"), 100000, 4096);
 
         AdapterTestHelper.submitListAndWait(adapter, Arrays.asList(model1));
         assertEquals(1, adapter.getItemCount());
@@ -327,14 +327,14 @@ public class ModelsAdapterTest {
     @Test
     public void submitList_multipleUpdates_maintainsCorrectState() throws InterruptedException {
         List<Model> models1 = Arrays.asList(
-            new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096)
+            new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096)
         );
         AdapterTestHelper.submitListAndWait(adapter, models1);
         assertEquals(1, adapter.getItemCount());
 
         List<Model> models2 = Arrays.asList(
-            new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096),
-            new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048)
+            new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096),
+            new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048)
         );
         AdapterTestHelper.submitListAndWait(adapter, models2);
         assertEquals(2, adapter.getItemCount());

--- a/app/src/androidTest/java/io/finett/droidclaw/adapter/ProvidersAdapterTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/adapter/ProvidersAdapterTest.java
@@ -163,8 +163,8 @@ public class ProvidersAdapterTest {
     @Test
     public void onBindViewHolder_bindsModelCount() {
         Provider provider = new Provider("openai", "OpenAI", "https://api.openai.com", "sk-test", "openai");
-        provider.addModel(new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096));
-        provider.addModel(new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048));
+        provider.addModel(new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096));
+        provider.addModel(new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048));
         
         List<Provider> providers = Arrays.asList(provider);
         adapter.submitList(providers);
@@ -192,7 +192,6 @@ public class ProvidersAdapterTest {
         RecyclerView recyclerView = new RecyclerView(context);
         recyclerView.setLayoutManager(new LinearLayoutManager(context));
         RecyclerView.ViewHolder viewHolder = adapter.onCreateViewHolder(recyclerView, 0);
-
         adapter.onBindViewHolder((ProvidersAdapter.ProviderViewHolder) viewHolder, 0);
 
         TextView modelCountText = viewHolder.itemView.findViewById(R.id.text_model_count);
@@ -204,11 +203,11 @@ public class ProvidersAdapterTest {
     @Test
     public void onBindViewHolder_multipleProviders_bindsCorrectly() {
         Provider provider1 = new Provider("openai", "OpenAI", "https://api.openai.com", "sk-test", "openai");
-        provider1.addModel(new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096));
+        provider1.addModel(new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096));
         
         Provider provider2 = new Provider("anthropic", "Anthropic", "https://api.anthropic.com", "sk-ant", "anthropic");
-        provider2.addModel(new Model("claude-3", "Claude 3", "anthropic", true, Arrays.asList("text"), 100000, 4096));
-        provider2.addModel(new Model("claude-2", "Claude 2", "anthropic", false, Arrays.asList("text"), 100000, 4096));
+        provider2.addModel(new Model("claude-sonnet-4-6", "Claude Sonnet 4.6", "anthropic", true, Arrays.asList("text"), 100000, 4096));
+        provider2.addModel(new Model("claude-opus-4-7", "Claude Opus 4.7", "anthropic", false, Arrays.asList("text"), 100000, 4096));
 
         List<Provider> providers = Arrays.asList(provider1, provider2);
         adapter.submitList(providers);
@@ -305,7 +304,7 @@ public class ProvidersAdapterTest {
     public void diffUtil_detectsModelCountChange() throws InterruptedException {
         Provider provider1 = new Provider("openai", "OpenAI", "https://api.openai.com", "sk-test", "openai");
         Provider provider2 = new Provider("openai", "OpenAI", "https://api.openai.com", "sk-test", "openai");
-        provider2.addModel(new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096));
+        provider2.addModel(new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096));
 
         AdapterTestHelper.submitListAndWait(adapter, Arrays.asList(provider1));
         

--- a/app/src/test/java/io/finett/droidclaw/model/AgentConfigTest.java
+++ b/app/src/test/java/io/finett/droidclaw/model/AgentConfigTest.java
@@ -23,7 +23,7 @@ public class AgentConfigTest {
     @Test
     public void parameterizedConstructor_setsAllFields() {
         AgentConfig c = new AgentConfig(
-            "openai/gpt-4",
+            "openai/gpt-5.4",
             true,
             "relaxed",
             50,
@@ -33,7 +33,7 @@ public class AgentConfigTest {
             java.util.Arrays.asList("/system/bin/curl")
         );
         
-        assertEquals("openai/gpt-4", c.getDefaultModel());
+        assertEquals("openai/gpt-5.4", c.getDefaultModel());
         assertTrue(c.isShellAccess());
         assertEquals("relaxed", c.getSandboxMode());
         assertEquals(50, c.getMaxIterations());
@@ -69,8 +69,8 @@ public class AgentConfigTest {
 
     @Test
     public void setDefaultModel_updatesDefaultModel() {
-        config.setDefaultModel("anthropic/claude-3-opus");
-        assertEquals("anthropic/claude-3-opus", config.getDefaultModel());
+        config.setDefaultModel("anthropic/claude-opus-4-7");
+        assertEquals("anthropic/claude-opus-4-7", config.getDefaultModel());
     }
 
     @Test
@@ -114,7 +114,7 @@ public class AgentConfigTest {
 
     @Test
     public void getDefaultProviderId_withValidFormat_returnsProviderId() {
-        config.setDefaultModel("openai/gpt-4");
+        config.setDefaultModel("openai/gpt-5.4");
         assertEquals("openai", config.getDefaultProviderId());
     }
 
@@ -126,7 +126,7 @@ public class AgentConfigTest {
 
     @Test
     public void getDefaultProviderId_withoutSlash_returnsNull() {
-        config.setDefaultModel("gpt-4");
+        config.setDefaultModel("gpt-5.4");
         assertNull(config.getDefaultProviderId());
     }
 
@@ -150,8 +150,8 @@ public class AgentConfigTest {
 
     @Test
     public void getDefaultModelId_withValidFormat_returnsModelId() {
-        config.setDefaultModel("openai/gpt-4");
-        assertEquals("gpt-4", config.getDefaultModelId());
+        config.setDefaultModel("openai/gpt-5.4");
+        assertEquals("gpt-5.4", config.getDefaultModelId());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class AgentConfigTest {
 
     @Test
     public void getDefaultModelId_withoutSlash_returnsNull() {
-        config.setDefaultModel("gpt-4");
+        config.setDefaultModel("gpt-5.4");
         assertNull(config.getDefaultModelId());
     }
 
@@ -186,16 +186,16 @@ public class AgentConfigTest {
 
     @Test
     public void getDefaultModelId_withComplexModelId_returnsFullModelId() {
-        config.setDefaultModel("anthropic/claude-3-opus-20240229");
-        assertEquals("claude-3-opus-20240229", config.getDefaultModelId());
+        config.setDefaultModel("anthropic/claude-opus-4-7");
+        assertEquals("claude-opus-4-7", config.getDefaultModelId());
     }
 
     @Test
     public void setDefaultModel_thenGetIds_returnsCorrectValues() {
-        config.setDefaultModel("anthropic/claude-3-sonnet");
+        config.setDefaultModel("anthropic/claude-sonnet-4-6");
         
         assertEquals("anthropic", config.getDefaultProviderId());
-        assertEquals("claude-3-sonnet", config.getDefaultModelId());
+        assertEquals("claude-sonnet-4-6", config.getDefaultModelId());
     }
 
     @Test
@@ -256,7 +256,7 @@ public class AgentConfigTest {
 
     @Test
     public void config_multipleSetsAndGets_maintainsCorrectState() {
-        config.setDefaultModel("openai/gpt-4");
+        config.setDefaultModel("openai/gpt-5.4");
         config.setShellAccess(true);
         config.setSandboxMode("relaxed");
         config.setMaxIterations(50);
@@ -265,7 +265,7 @@ public class AgentConfigTest {
         config.setBackgroundShellEnabled(true);
         config.setCustomAllowlist(java.util.Arrays.asList("/system/bin/tar", "/system/bin/curl"));
         
-        assertEquals("openai/gpt-4", config.getDefaultModel());
+        assertEquals("openai/gpt-5.4", config.getDefaultModel());
         assertTrue(config.isShellAccess());
         assertEquals("relaxed", config.getSandboxMode());
         assertEquals(50, config.getMaxIterations());
@@ -274,7 +274,7 @@ public class AgentConfigTest {
         assertTrue(config.isBackgroundShellEnabled());
         assertEquals(2, config.getCustomAllowlist().size());
         
-        config.setDefaultModel("anthropic/claude-3");
+        config.setDefaultModel("anthropic/claude-sonnet-4-6");
         config.setShellAccess(false);
         config.setSandboxMode("strict");
         config.setMaxIterations(20);
@@ -283,7 +283,7 @@ public class AgentConfigTest {
         config.setBackgroundShellEnabled(false);
         config.setCustomAllowlist(java.util.Collections.emptyList());
         
-        assertEquals("anthropic/claude-3", config.getDefaultModel());
+        assertEquals("anthropic/claude-sonnet-4-6", config.getDefaultModel());
         assertFalse(config.isShellAccess());
         assertEquals("strict", config.getSandboxMode());
         assertEquals(20, config.getMaxIterations());

--- a/app/src/test/java/io/finett/droidclaw/model/ModelTest.java
+++ b/app/src/test/java/io/finett/droidclaw/model/ModelTest.java
@@ -33,10 +33,10 @@ public class ModelTest {
     @Test
     public void parameterizedConstructor_setsAllFields() {
         List<String> input = Arrays.asList("text", "image");
-        Model m = new Model("gpt-4-vision", "GPT-4 Vision", "openai", true, input, 128000, 4096);
+        Model m = new Model("gpt-5.4", "GPT-5.4", "openai", true, input, 128000, 4096);
         
-        assertEquals("gpt-4-vision", m.getId());
-        assertEquals("GPT-4 Vision", m.getName());
+        assertEquals("gpt-5.4", m.getId());
+        assertEquals("GPT-5.4", m.getName());
         assertEquals("openai", m.getApi());
         assertTrue(m.isReasoning());
         assertEquals(2, m.getInput().size());
@@ -48,7 +48,7 @@ public class ModelTest {
 
     @Test
     public void parameterizedConstructor_withNullInput_initializesEmptyList() {
-        Model m = new Model("gpt-4", "GPT-4", "openai", false, null, 8192, 4096);
+        Model m = new Model("gpt-5.4", "GPT-5.4", "openai", false, null, 8192, 4096);
         
         assertNotNull(m.getInput());
         assertTrue(m.getInput().isEmpty());
@@ -57,7 +57,7 @@ public class ModelTest {
     @Test
     public void parameterizedConstructor_createsDefensiveCopyOfInput() {
         List<String> input = new ArrayList<>(Arrays.asList("text"));
-        Model m = new Model("gpt-4", "GPT-4", "openai", false, input, 8192, 4096);
+        Model m = new Model("gpt-5.4", "GPT-5.4", "openai", false, input, 8192, 4096);
         
         // Modify original list
         input.add("image");
@@ -71,8 +71,8 @@ public class ModelTest {
 
     @Test
     public void setId_updatesId() {
-        model.setId("claude-3-opus");
-        assertEquals("claude-3-opus", model.getId());
+        model.setId("claude-opus-4-7");
+        assertEquals("claude-opus-4-7", model.getId());
     }
 
     @Test
@@ -296,12 +296,12 @@ public class ModelTest {
 
     @Test
     public void model_withSpecialCharacters_acceptsValues() {
-        model.setId("claude-3-opus@v1.2.3");
-        model.setName("Claude 3 Opus™ (Latest Version)");
+        model.setId("claude-opus-4-7@v1.2.3");
+        model.setName("Claude Opus 4.7™ (Latest Version)");
         model.setApi("anthropic-v3");
         
-        assertEquals("claude-3-opus@v1.2.3", model.getId());
-        assertEquals("Claude 3 Opus™ (Latest Version)", model.getName());
+        assertEquals("claude-opus-4-7@v1.2.3", model.getId());
+        assertEquals("Claude Opus 4.7™ (Latest Version)", model.getName());
         assertEquals("anthropic-v3", model.getApi());
     }
 

--- a/app/src/test/java/io/finett/droidclaw/model/ProviderTest.java
+++ b/app/src/test/java/io/finett/droidclaw/model/ProviderTest.java
@@ -80,13 +80,13 @@ public class ProviderTest {
     @Test
     public void setModels_withValidList_createsDefensiveCopy() {
         List<Model> models = new ArrayList<>();
-        Model model = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         models.add(model);
         
         provider.setModels(models);
         
         // Modify original list
-        models.add(new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048));
+        models.add(new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048));
         
         // Provider's list should not be affected
         assertEquals(1, provider.getModels().size());
@@ -102,7 +102,7 @@ public class ProviderTest {
 
     @Test
     public void addModel_withValidModel_addsToList() {
-        Model model = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         
         provider.addModel(model);
         
@@ -119,8 +119,8 @@ public class ProviderTest {
 
     @Test
     public void addModel_multipleModels_addsAllToList() {
-        Model model1 = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
-        Model model2 = new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048);
+        Model model1 = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model2 = new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048);
         
         provider.addModel(model1);
         provider.addModel(model2);
@@ -130,7 +130,7 @@ public class ProviderTest {
 
     @Test
     public void removeModel_withExistingModel_removesFromList() {
-        Model model = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         provider.addModel(model);
         
         provider.removeModel(model);
@@ -147,8 +147,8 @@ public class ProviderTest {
 
     @Test
     public void removeModel_withNonExistingModel_doesNotAffectList() {
-        Model model1 = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
-        Model model2 = new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048);
+        Model model1 = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model2 = new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048);
         provider.addModel(model1);
         
         provider.removeModel(model2);
@@ -161,28 +161,28 @@ public class ProviderTest {
 
     @Test
     public void getModelById_withExistingId_returnsModel() {
-        Model model = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         provider.addModel(model);
         
-        Model result = provider.getModelById("gpt-4");
+        Model result = provider.getModelById("gpt-5.4");
         
         assertNotNull(result);
-        assertEquals("gpt-4", result.getId());
+        assertEquals("gpt-5.4", result.getId());
     }
 
     @Test
     public void getModelById_withNonExistingId_returnsNull() {
-        Model model = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         provider.addModel(model);
         
-        Model result = provider.getModelById("gpt-3.5");
+        Model result = provider.getModelById("gpt-5.4-mini");
         
         assertNull(result);
     }
 
     @Test
     public void getModelById_withNull_returnsNull() {
-        Model model = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
         provider.addModel(model);
         
         Model result = provider.getModelById(null);
@@ -192,24 +192,24 @@ public class ProviderTest {
 
     @Test
     public void getModelById_withEmptyList_returnsNull() {
-        Model result = provider.getModelById("gpt-4");
+        Model result = provider.getModelById("gpt-5.4");
         
         assertNull(result);
     }
 
     @Test
     public void getModelById_withMultipleModels_returnsCorrectModel() {
-        Model model1 = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
-        Model model2 = new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048);
-        Model model3 = new Model("claude-3", "Claude 3", "anthropic", true, Arrays.asList("text", "image"), 100000, 4096);
+        Model model1 = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model2 = new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048);
+        Model model3 = new Model("claude-sonnet-4-6", "Claude Sonnet 4.6", "anthropic", true, Arrays.asList("text", "image"), 100000, 4096);
         provider.addModel(model1);
         provider.addModel(model2);
         provider.addModel(model3);
         
-        Model result = provider.getModelById("gpt-3.5");
+        Model result = provider.getModelById("gpt-5.4-mini");
         
         assertNotNull(result);
-        assertEquals("GPT-3.5", result.getName());
+        assertEquals("GPT-5.4 Mini", result.getName());
     }
 
     // ==================== getModelCount Tests ====================
@@ -221,8 +221,8 @@ public class ProviderTest {
 
     @Test
     public void getModelCount_withModels_returnsCorrectCount() {
-        Model model1 = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
-        Model model2 = new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048);
+        Model model1 = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model2 = new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048);
         provider.addModel(model1);
         provider.addModel(model2);
         
@@ -231,8 +231,8 @@ public class ProviderTest {
 
     @Test
     public void getModelCount_afterRemoval_returnsUpdatedCount() {
-        Model model1 = new Model("gpt-4", "GPT-4", "openai", false, Arrays.asList("text"), 8192, 4096);
-        Model model2 = new Model("gpt-3.5", "GPT-3.5", "openai", false, Arrays.asList("text"), 4096, 2048);
+        Model model1 = new Model("gpt-5.4", "GPT-5.4", "openai", false, Arrays.asList("text"), 8192, 4096);
+        Model model2 = new Model("gpt-5.4-mini", "GPT-5.4 Mini", "openai", false, Arrays.asList("text"), 4096, 2048);
         provider.addModel(model1);
         provider.addModel(model2);
         


### PR DESCRIPTION
Replace legacy model identifiers (GPT-4, GPT-3.5, Claude 3, Claude 2) with current versions (GPT-5.4, GPT-5.4 Mini, Claude Sonnet 4.6, Claude Opus 4.7) across all test fixtures.