### PR TITLE
test: add comprehensive unit tests across core modules

### DIFF
--- a/app/src/test/java/io/finett/droidclaw/agent/ConversationSummarizerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/agent/ConversationSummarizerTest.java
@@ -352,6 +352,276 @@ public class ConversationSummarizerTest {
         assertTrue("Many small messages should need summarization", needs);
     }
 
+    @Test
+    public void testGetTokenThresholdReturns75PercentOfWindow() {
+        assertEquals("Threshold should be 75% of 4096", 3072, summarizer.getTokenThreshold());
+    }
+
+    @Test
+    public void testGetContextWindowReturnsDefault() {
+        assertEquals("Default window should be 4096", 4096, summarizer.getContextWindow());
+    }
+
+    @Test
+    public void testNeedsSummarizationExactlyAtThresholdReturnsTrue() {
+        boolean needs = summarizer.needsSummarization(3072);
+
+        assertTrue("Should need summarization exactly at threshold", needs);
+    }
+
+    @Test
+    public void testNeedsSummarizationOneTokenBelowThresholdReturnsFalse() {
+        boolean needs = summarizer.needsSummarization(3071);
+
+        assertFalse("Should not need summarization one token below threshold", needs);
+    }
+
+    @Test
+    public void testNeedsSummarizationOneTokenAboveThresholdReturnsTrue() {
+        boolean needs = summarizer.needsSummarization(3073);
+
+        assertTrue("Should need summarization one token above threshold", needs);
+    }
+
+    @Test
+    public void testNeedsSummarizationWithCustomContextWindow() {
+        ConversationSummarizer customSummarizer = new ConversationSummarizer(mockApiService, mockMemoryRepository, 8192);
+
+        assertEquals("Custom window should be 8192", 8192, customSummarizer.getContextWindow());
+        assertEquals("Custom threshold should be 75% of 8192", 6144, customSummarizer.getTokenThreshold());
+
+        assertFalse("Should not need summarization below custom threshold",
+                customSummarizer.needsSummarization(6143));
+        assertTrue("Should need summarization at custom threshold",
+                customSummarizer.needsSummarization(6144));
+    }
+
+    @Test
+    public void testSummarizeAndSaveSplitsMessagesCorrectly() throws IOException {
+        // Create 12 messages - should keep ~4 recent, summarize 8
+        List<ChatMessage> messages = createSmallMessages(12);
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onSuccess("Summary");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<List<ChatMessage>> resultCaptor = ArgumentCaptor.forClass(List.class);
+        verify(callback).onResult(resultCaptor.capture());
+
+        List<ChatMessage> result = resultCaptor.getValue();
+        assertTrue("Should return fewer messages than original", result.size() < messages.size());
+        assertTrue("Should keep at least some messages", result.size() > 0);
+    }
+
+    @Test
+    public void testSummarizeAndSaveKeepsRecentMessages() throws IOException {
+        List<ChatMessage> messages = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            messages.add(new ChatMessage("Message " + i, i % 2 == 0 ? ChatMessage.TYPE_USER : ChatMessage.TYPE_ASSISTANT));
+        }
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onSuccess("Summary");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<List<ChatMessage>> resultCaptor = ArgumentCaptor.forClass(List.class);
+        verify(callback).onResult(resultCaptor.capture());
+
+        List<ChatMessage> result = resultCaptor.getValue();
+        // The last few messages should be kept
+        String lastKeptContent = result.get(result.size() - 1).getContent();
+        assertTrue("Should keep recent messages", lastKeptContent.contains("Message"));
+    }
+
+    @Test
+    public void testSummarizeAndSaveZeroMessagesReturnsEmpty() throws IOException {
+        List<ChatMessage> messages = new ArrayList<>();
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        verify(callback).onResult(eq(messages));
+        verifyNoInteractions(mockApiService);
+    }
+
+    @Test
+    public void testSummarizeAndSaveLlmSuccessAppendsToDailyNote() throws IOException {
+        List<ChatMessage> messages = createMessagesWithTokens(500, 600, 700, 800, 900, 1000, 1100, 1200);
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onSuccess("Generated summary text");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        verify(mockMemoryRepository).appendToDailyNote(anyString());
+    }
+
+    @Test
+    public void testSummarizeAndSaveLlmErrorUsesFallbackAndStillCompresses() throws IOException {
+        List<ChatMessage> messages = createMessagesWithTokens(500, 600, 700, 800, 900, 1000, 1100, 1200);
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onError("API failure");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<List<ChatMessage>> resultCaptor = ArgumentCaptor.forClass(List.class);
+        verify(callback).onResult(resultCaptor.capture());
+
+        List<ChatMessage> result = resultCaptor.getValue();
+        assertTrue("Should return compressed list on LLM error", result.size() < messages.size());
+    }
+
+    @Test
+    public void testBuildSummaryPromptSkipsNullContent() throws IOException {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new ChatMessage(null, ChatMessage.TYPE_USER));
+        messages.add(new ChatMessage("Valid message", ChatMessage.TYPE_ASSISTANT));
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onSuccess("Summary");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<List<ChatMessage>> requestCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockApiService).sendMessage(requestCaptor.capture(), any(), any());
+
+        String prompt = requestCaptor.getValue().get(0).getContent();
+        assertFalse("Should not contain 'null' as content", prompt.contains("null"));
+        assertTrue("Should contain valid message", prompt.contains("Valid message"));
+    }
+
+    @Test
+    public void testBuildSummaryPromptSkipsEmptyContent() throws IOException {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new ChatMessage("", ChatMessage.TYPE_USER));
+        messages.add(new ChatMessage("Non-empty", ChatMessage.TYPE_ASSISTANT));
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onSuccess("Summary");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<List<ChatMessage>> requestCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockApiService).sendMessage(requestCaptor.capture(), any(), any());
+
+        String prompt = requestCaptor.getValue().get(0).getContent();
+        assertTrue("Should contain non-empty message", prompt.contains("Non-empty"));
+    }
+
+    @Test
+    public void testCreateFallbackSummaryCountsCorrectly() throws IOException {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new ChatMessage("U1", ChatMessage.TYPE_USER));
+        messages.add(new ChatMessage("A1", ChatMessage.TYPE_ASSISTANT));
+        messages.add(new ChatMessage("U2", ChatMessage.TYPE_USER));
+        messages.add(new ChatMessage("A2", ChatMessage.TYPE_ASSISTANT));
+        messages.add(new ChatMessage("A3", ChatMessage.TYPE_ASSISTANT));
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onError("Error");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<String> entryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockMemoryRepository).appendToDailyNote(entryCaptor.capture());
+
+        String savedEntry = entryCaptor.getValue();
+        // With 5 messages: keepCount = min(8, 5/3) = 1, summarizeCount = 4
+        // First 4 messages: U1, A1, U2, A2 = 2 user, 2 assistant
+        assertTrue("Should contain 2 user messages", savedEntry.contains("2 user messages"));
+        assertTrue("Should contain 2 assistant messages", savedEntry.contains("2 assistant messages"));
+    }
+
+    @Test
+    public void testSummarizeAndSaveSaveIOExceptionStillReturnsCompressed() throws IOException {
+        List<ChatMessage> messages = createMessagesWithTokens(500, 600, 700, 800, 900, 1000, 1100, 1200);
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onSuccess("Summary");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        doThrow(new IOException("Write failed")).when(mockMemoryRepository).appendToDailyNote(anyString());
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<List<ChatMessage>> resultCaptor = ArgumentCaptor.forClass(List.class);
+        verify(callback).onResult(resultCaptor.capture());
+
+        List<ChatMessage> result = resultCaptor.getValue();
+        assertTrue("Should return compressed list even when save fails", result.size() < messages.size());
+    }
+
+    @Test
+    public void testSummarizeAndSavePromptContainsInstructions() throws IOException {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new ChatMessage("Hello", ChatMessage.TYPE_USER));
+        messages.add(new ChatMessage("Hi", ChatMessage.TYPE_ASSISTANT));
+
+        ConversationSummarizer.SummarizeCallback callback = mock(ConversationSummarizer.SummarizeCallback.class);
+
+        doAnswer(invocation -> {
+            LlmApiService.ChatCallback cb = invocation.getArgument(2);
+            cb.onSuccess("Summary");
+            return null;
+        }).when(mockApiService).sendMessage(anyList(), any(), any(LlmApiService.ChatCallback.class));
+
+        summarizer.summarizeAndSave(messages, callback);
+
+        ArgumentCaptor<List<ChatMessage>> requestCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockApiService).sendMessage(requestCaptor.capture(), any(), any());
+
+        String prompt = requestCaptor.getValue().get(0).getContent();
+        assertTrue("Should ask to summarize", prompt.contains("Summarize"));
+        assertTrue("Should mention key topics", prompt.contains("Key topics"));
+        assertTrue("Should mention decisions", prompt.contains("decisions"));
+        assertTrue("Should mention facts", prompt.contains("Facts"));
+        assertTrue("Should mention action items", prompt.contains("Action items"));
+        assertTrue("Should have word limit", prompt.contains("200 words"));
+    }
+
     private List<ChatMessage> createSmallMessages(int count) {
         List<ChatMessage> messages = new ArrayList<>();
         for (int i = 0; i < count; i++) {

--- a/app/src/test/java/io/finett/droidclaw/agent/IdentityManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/agent/IdentityManagerTest.java
@@ -1,0 +1,402 @@
+package io.finett.droidclaw.agent;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+import io.finett.droidclaw.filesystem.WorkspaceManager;
+import io.finett.droidclaw.model.ChatMessage;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class IdentityManagerTest {
+
+    @Mock
+    private WorkspaceManager mockWorkspaceManager;
+
+    private File tempDir;
+    private IdentityManager identityManager;
+
+    @Before
+    public void setUp() throws IOException {
+        tempDir = createTempDir();
+        when(mockWorkspaceManager.getWorkspaceRoot()).thenReturn(tempDir);
+
+        // Ensure .agent directory exists
+        File agentDir = new File(tempDir, ".agent");
+        agentDir.mkdirs();
+
+        identityManager = new IdentityManager(null, mockWorkspaceManager);
+    }
+
+    @After
+    public void tearDown() {
+        deleteRecursive(tempDir);
+    }
+
+    @Test
+    public void loadIdentity_withBothFiles_returnsCompleteContext() throws IOException {
+        writeIdentityFile(".agent/soul.md", "# Soul\nI am DroidClaw.");
+        writeIdentityFile(".agent/user.md", "# User\nUser preferences.");
+
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertNotNull("Identity context should not be null", identity);
+        assertTrue("Should have soul content", identity.hasSoul());
+        assertTrue("Should have user content", identity.hasUser());
+        assertFalse("Identity should not be empty", identity.isEmpty());
+        assertTrue("Soul content should contain expected text",
+                identity.getSoulContent().contains("I am DroidClaw."));
+        assertTrue("User content should contain expected text",
+                identity.getUserContent().contains("User preferences."));
+    }
+
+    @Test
+    public void loadIdentity_withMissingSoulFile_returnsEmptySoul() throws IOException {
+        writeIdentityFile(".agent/user.md", "# User\nUser info");
+        // soul.md does not exist
+
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertFalse("Should not have soul when file missing", identity.hasSoul());
+        assertTrue("Should still have user content", identity.hasUser());
+        assertEquals("Soul content should be empty string", "", identity.getSoulContent());
+    }
+
+    @Test
+    public void loadIdentity_withMissingUserFile_returnsEmptyUser() throws IOException {
+        writeIdentityFile(".agent/soul.md", "# Soul\nSoul info");
+        // user.md does not exist
+
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertTrue("Should have soul content", identity.hasSoul());
+        assertFalse("Should not have user when file missing", identity.hasUser());
+        assertEquals("User content should be empty string", "", identity.getUserContent());
+    }
+
+    @Test
+    public void loadIdentity_withBothFilesMissing_returnsEmptyContext() throws IOException {
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertFalse("Should not have soul", identity.hasSoul());
+        assertFalse("Should not have user", identity.hasUser());
+        assertTrue("Identity should be empty", identity.isEmpty());
+    }
+
+    @Test
+    public void loadIdentity_withEmptySoulFile_hasEmptySoul() throws IOException {
+        writeIdentityFile(".agent/soul.md", "");
+        writeIdentityFile(".agent/user.md", "User content");
+
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertFalse("Empty file should result in hasSoul() = false", identity.hasSoul());
+        assertTrue("Should still have user content", identity.hasUser());
+    }
+
+    @Test
+    public void loadIdentity_withWhitespaceOnlySoulFile_hasEmptySoul() throws IOException {
+        writeIdentityFile(".agent/soul.md", "   \n\t\n   ");
+        writeIdentityFile(".agent/user.md", "User content");
+
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertFalse("Whitespace-only file should result in hasSoul() = false", identity.hasSoul());
+    }
+
+    @Test
+    public void loadIdentity_withWhitespaceOnlyUserFile_hasEmptyUser() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Soul content");
+        writeIdentityFile(".agent/user.md", "  \n  \t  ");
+
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertTrue("Should have soul content", identity.hasSoul());
+        assertFalse("Whitespace-only user file should result in hasUser() = false", identity.hasUser());
+    }
+
+    @Test
+    public void loadIdentity_withMultilineContent_preservesContent() throws IOException {
+        String soulContent = "# Soul\n\nLine 1\nLine 2\nLine 3\n";
+        writeIdentityFile(".agent/soul.md", soulContent);
+        writeIdentityFile(".agent/user.md", "User");
+
+        IdentityManager.IdentityContext identity = identityManager.loadIdentity();
+
+        assertTrue("Should contain Line 1", identity.getSoulContent().contains("Line 1"));
+        assertTrue("Should contain Line 2", identity.getSoulContent().contains("Line 2"));
+        assertTrue("Should contain Line 3", identity.getSoulContent().contains("Line 3"));
+    }
+
+    @Test
+    public void getIdentityMessages_cachesBetweenCalls_returnsSameContent() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Soul content");
+        writeIdentityFile(".agent/user.md", "User content");
+
+        List<ChatMessage> firstCall = identityManager.getIdentityMessages();
+        List<ChatMessage> secondCall = identityManager.getIdentityMessages();
+
+        assertEquals("Cached calls should return same number of messages",
+                firstCall.size(), secondCall.size());
+        for (int i = 0; i < firstCall.size(); i++) {
+            assertEquals("Cached messages should have same content",
+                    firstCall.get(i).getContent(), secondCall.get(i).getContent());
+        }
+        // Workspace root is queried twice on first call (once per file), zero on second (cache hit)
+        verify(mockWorkspaceManager, times(2)).getWorkspaceRoot();
+    }
+
+    @Test
+    public void clearCache_forcesReload_loadsNewContent() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Original soul");
+        writeIdentityFile(".agent/user.md", "Original user");
+
+        List<ChatMessage> initialMessages = identityManager.getIdentityMessages();
+        String initialContent = initialMessages.get(0).getContent();
+
+        // Modify the file
+        writeIdentityFile(".agent/soul.md", "Modified soul");
+
+        // Clear cache and reload
+        identityManager.clearCache();
+        List<ChatMessage> newMessages = identityManager.getIdentityMessages();
+        String newContent = newMessages.get(0).getContent();
+
+        assertFalse("Content should change after cache clear and file modification",
+                initialContent.equals(newContent));
+        assertTrue("New content should contain updated text",
+                newContent.contains("Modified soul"));
+    }
+
+    @Test
+    public void clearCache_canBeCalledMultipleTimes() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Soul");
+        writeIdentityFile(".agent/user.md", "User");
+
+        identityManager.clearCache();
+        identityManager.clearCache();
+        identityManager.clearCache();
+
+        List<ChatMessage> messages = identityManager.getIdentityMessages();
+        assertFalse("Should still load messages after multiple clears", messages.isEmpty());
+    }
+
+    @Test
+    public void getIdentityMessages_withBothFiles_returnsSystemMessages() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Soul content");
+        writeIdentityFile(".agent/user.md", "User content");
+
+        List<ChatMessage> messages = identityManager.getIdentityMessages();
+
+        assertNotNull("Should return message list", messages);
+        assertEquals("Should have exactly 2 messages", 2, messages.size());
+
+        for (ChatMessage message : messages) {
+            assertEquals("All identity messages should be TYPE_SYSTEM",
+                    ChatMessage.TYPE_SYSTEM, message.getType());
+            assertTrue("System messages should have content",
+                    message.getContent() != null && !message.getContent().trim().isEmpty());
+        }
+    }
+
+    @Test
+    public void getIdentityMessages_preservesMessageOrder_soulBeforeUser() throws IOException {
+        writeIdentityFile(".agent/soul.md", "SOUL_CONTENT");
+        writeIdentityFile(".agent/user.md", "USER_CONTENT");
+
+        List<ChatMessage> messages = identityManager.getIdentityMessages();
+
+        assertEquals("Should have exactly 2 messages", 2, messages.size());
+        assertTrue("First message should be soul content",
+                messages.get(0).getContent().contains("SOUL_CONTENT"));
+        assertTrue("Second message should be user content",
+                messages.get(1).getContent().contains("USER_CONTENT"));
+    }
+
+    @Test
+    public void getIdentityMessages_withOnlySoul_returnsSingleMessage() throws IOException {
+        writeIdentityFile(".agent/soul.md", "ONLY_SOUL");
+        // user.md does not exist
+
+        List<ChatMessage> messages = identityManager.getIdentityMessages();
+
+        assertEquals("Should have exactly 1 message", 1, messages.size());
+        assertTrue("Message should be soul content",
+                messages.get(0).getContent().contains("ONLY_SOUL"));
+    }
+
+    @Test
+    public void getIdentityMessages_withOnlyUser_returnsSingleMessage() throws IOException {
+        // soul.md does not exist
+        writeIdentityFile(".agent/user.md", "ONLY_USER");
+
+        List<ChatMessage> messages = identityManager.getIdentityMessages();
+
+        assertEquals("Should have exactly 1 message", 1, messages.size());
+        assertTrue("Message should be user content",
+                messages.get(0).getContent().contains("ONLY_USER"));
+    }
+
+    @Test
+    public void getIdentityMessages_withEmptyFiles_returnsEmptyList() throws IOException {
+        writeIdentityFile(".agent/soul.md", "");
+        writeIdentityFile(".agent/user.md", "");
+
+        List<ChatMessage> messages = identityManager.getIdentityMessages();
+
+        assertTrue("Should return empty list when both files are empty", messages.isEmpty());
+    }
+
+    @Test
+    public void getIdentityMessages_withNoFiles_returnsEmptyList() throws IOException {
+        List<ChatMessage> messages = identityManager.getIdentityMessages();
+
+        assertTrue("Should return empty list when no files exist", messages.isEmpty());
+    }
+
+    @Test
+    public void identityFilesExist_withBothFiles_returnsTrue() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Soul");
+        writeIdentityFile(".agent/user.md", "User");
+
+        assertTrue("Identity files should exist", identityManager.identityFilesExist());
+    }
+
+    @Test
+    public void identityFilesExist_withNoFiles_returnsFalse() {
+        assertFalse("Should return false when files don't exist",
+                identityManager.identityFilesExist());
+    }
+
+    @Test
+    public void identityFilesExist_withOnlySoulFile_returnsFalse() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Soul");
+        // user.md missing
+
+        assertFalse("Should return false when only soul file exists",
+                identityManager.identityFilesExist());
+    }
+
+    @Test
+    public void identityFilesExist_withOnlyUserFile_returnsFalse() throws IOException {
+        // soul.md missing
+        writeIdentityFile(".agent/user.md", "User");
+
+        assertFalse("Should return false when only user file exists",
+                identityManager.identityFilesExist());
+    }
+
+    @Test
+    public void identityFilesExist_afterFileDeletion_returnsFalse() throws IOException {
+        writeIdentityFile(".agent/soul.md", "Soul");
+        writeIdentityFile(".agent/user.md", "User");
+
+        assertTrue("Files should exist initially", identityManager.identityFilesExist());
+
+        // Delete one file
+        new File(tempDir, ".agent/soul.md").delete();
+
+        assertFalse("Should return false after deleting one file",
+                identityManager.identityFilesExist());
+    }
+
+    @Test
+    public void identityContext_isEmpty_withEmptyStrings() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext("", "");
+        assertTrue("Context with empty strings should be empty", context.isEmpty());
+        assertFalse("Should not have soul", context.hasSoul());
+        assertFalse("Should not have user", context.hasUser());
+    }
+
+    @Test
+    public void identityContext_isEmpty_withWhitespace() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext("  ", "\n\t");
+        assertTrue("Context with whitespace should be empty", context.isEmpty());
+    }
+
+    @Test
+    public void identityContext_isEmpty_withNulls() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext(null, null);
+        assertTrue("Context with null values should be empty", context.isEmpty());
+        assertFalse("Should not have soul", context.hasSoul());
+        assertFalse("Should not have user", context.hasUser());
+    }
+
+    @Test
+    public void identityContext_isEmpty_withPartialContent() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext("content", "");
+        assertFalse("Context with one non-empty value should not be empty", context.isEmpty());
+        assertTrue("Should have soul", context.hasSoul());
+        assertFalse("Should not have user", context.hasUser());
+    }
+
+    @Test
+    public void identityContext_isEmpty_withBothContent() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext("soul", "user");
+        assertFalse("Context with both values should not be empty", context.isEmpty());
+        assertTrue("Should have soul", context.hasSoul());
+        assertTrue("Should have user", context.hasUser());
+    }
+
+    @Test
+    public void identityContext_getters_returnCorrectValues() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext("soul_val", "user_val");
+
+        assertEquals("getSoulContent should return soul value", "soul_val", context.getSoulContent());
+        assertEquals("getUserContent should return user value", "user_val", context.getUserContent());
+    }
+
+    @Test
+    public void identityContext_hasSoul_withNullSoul() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext(null, "user");
+
+        assertFalse("Should not have soul with null", context.hasSoul());
+        assertTrue("Should have user", context.hasUser());
+    }
+
+    @Test
+    public void identityContext_hasUser_withNullUser() {
+        IdentityManager.IdentityContext context = new IdentityManager.IdentityContext("soul", null);
+
+        assertTrue("Should have soul", context.hasSoul());
+        assertFalse("Should not have user with null", context.hasUser());
+    }
+
+    private File createTempDir() {
+        File temp = new File(System.getProperty("java.io.tmpdir"), "identity_test_" + System.currentTimeMillis());
+        temp.mkdirs();
+        return temp;
+    }
+
+    private void writeIdentityFile(String relativePath, String content) throws IOException {
+        File file = new File(tempDir, relativePath);
+        file.getParentFile().mkdirs();
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(content);
+        }
+    }
+
+    private void deleteRecursive(File file) {
+        if (file == null || !file.exists()) return;
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/agent/MemoryContextBuilderTest.java
+++ b/app/src/test/java/io/finett/droidclaw/agent/MemoryContextBuilderTest.java
@@ -268,4 +268,162 @@ public class MemoryContextBuilderTest {
 
         assertFalse("Should return false when all checks fail", hasMemory);
     }
+
+    @Test
+    public void testBuildMemoryContext_orderIsLongTermTodayYesterday() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("LONG_TERM");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("TODAY");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("YESTERDAY");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        int longTermIdx = context.indexOf("LONG_TERM");
+        int todayIdx = context.indexOf("TODAY");
+        int yesterdayIdx = context.indexOf("YESTERDAY");
+
+        assertTrue("Long-term should appear before today", longTermIdx < todayIdx);
+        assertTrue("Today should appear before yesterday", todayIdx < yesterdayIdx);
+    }
+
+    @Test
+    public void testBuildMemoryContext_longTermBeforeTodaySection() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("LT_CONTENT");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("T_CONTENT");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        int ltSection = context.indexOf("# Long-term Memory");
+        int todaySection = context.indexOf("# Today's Context");
+        assertTrue("Long-term section should come before today section", ltSection < todaySection);
+    }
+
+    @Test
+    public void testBuildMemoryContext_todayBeforeYesterdaySection() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("T_CONTENT");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("Y_CONTENT");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        int todaySection = context.indexOf("# Today's Context");
+        int yesterdaySection = context.indexOf("# Yesterday's Context");
+        assertTrue("Today section should come before yesterday section", todaySection < yesterdaySection);
+    }
+
+    @Test
+    public void testBuildMemoryContext_wrapsWithMemoryContextMarkers() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("Some content");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        assertTrue("Should start with MEMORY CONTEXT marker",
+                context.startsWith("--- MEMORY CONTEXT ---"));
+        assertTrue("Should end with END MEMORY CONTEXT marker",
+                context.trim().endsWith("--- END MEMORY CONTEXT ---"));
+    }
+
+    @Test
+    public void testBuildMemoryContext_markersOnlyAppearOnce() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("Content");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("More");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("Even more");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        assertEquals("Start marker should appear exactly once", 1,
+                countOccurrences(context, "--- MEMORY CONTEXT ---"));
+        assertEquals("End marker should appear exactly once", 1,
+                countOccurrences(context, "--- END MEMORY CONTEXT ---"));
+    }
+
+    @Test
+    public void testBuildMemoryContext_noMarkersWhenEmpty() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        assertFalse("Should not contain start marker when empty",
+                context.contains("--- MEMORY CONTEXT ---"));
+        assertFalse("Should not contain end marker when empty",
+                context.contains("--- END MEMORY CONTEXT ---"));
+    }
+
+    @Test
+    public void testBuildMemoryContext_trimsLongTermContent() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("  \n  trimmed content  \n  ");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        assertTrue("Should contain trimmed content", context.contains("trimmed content"));
+    }
+
+    @Test
+    public void testBuildMemoryContext_trimsTodayContent() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("  \n  today note  \n  ");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        assertTrue("Should contain trimmed today content", context.contains("today note"));
+    }
+
+    @Test
+    public void testBuildMemoryContext_trimsYesterdayContent() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenReturn("");
+        when(mockMemoryRepository.readTodayNote()).thenReturn("");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("  \n  yesterday note  \n  ");
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        assertTrue("Should contain trimmed yesterday content", context.contains("yesterday note"));
+    }
+
+    @Test
+    public void testBuildMemoryContext_longTermThrows_stillReturnsEmpty() throws IOException {
+        when(mockMemoryRepository.readLongTermMemory()).thenThrow(new IOException("Disk error"));
+
+        String context = memoryContextBuilder.buildMemoryContext();
+
+        assertEquals("Should return empty on IOException from long-term", "", context);
+    }
+
+    @Test
+    public void testHasMemory_allThreeExist_returnsTrue() throws IOException {
+        when(mockMemoryRepository.longTermMemoryExists()).thenReturn(true);
+        when(mockMemoryRepository.readTodayNote()).thenReturn("Today");
+        when(mockMemoryRepository.readYesterdayNote()).thenReturn("Yesterday");
+
+        boolean hasMemory = memoryContextBuilder.hasMemory();
+
+        assertTrue("Should return true when all three exist", hasMemory);
+    }
+
+    @Test
+    public void testHasMemory_yesterdayThrows_returnsFalse() throws IOException {
+        when(mockMemoryRepository.longTermMemoryExists()).thenReturn(false);
+        when(mockMemoryRepository.readTodayNote()).thenReturn("");
+        when(mockMemoryRepository.readYesterdayNote()).thenThrow(new IOException("Error"));
+
+        boolean hasMemory = memoryContextBuilder.hasMemory();
+
+        assertFalse("Should return false on IOException from readYesterdayNote", hasMemory);
+    }
+
+    private int countOccurrences(String str, String sub) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = str.indexOf(sub, idx)) != -1) {
+            count++;
+            idx += sub.length();
+        }
+        return count;
+    }
 }

--- a/app/src/test/java/io/finett/droidclaw/shell/ExecPlannerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/shell/ExecPlannerTest.java
@@ -124,4 +124,238 @@ public class ExecPlannerTest {
         assertEquals(1, plan.getArgv().size());
         assertEquals("-l", plan.getArgv().get(0));
     }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsEmptyCommand() throws Exception {
+        planner.plan("", workspace);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsWhitespaceOnlyCommand() throws Exception {
+        planner.plan("   \n\t  ", workspace);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsNullCommand() throws Exception {
+        planner.plan(null, workspace);
+    }
+
+    @Test
+    public void tokenise_emptyString_returnsEmpty() throws Exception {
+        List<String> tokens = ExecPlanner.tokenise("");
+        assertTrue("Empty string should tokenise to empty list", tokens.isEmpty());
+    }
+
+    @Test
+    public void tokenise_whitespaceOnly_returnsEmpty() throws Exception {
+        List<String> tokens = ExecPlanner.tokenise("   \n\t  ");
+        assertTrue("Whitespace-only should tokenise to empty list", tokens.isEmpty());
+    }
+
+    @Test
+    public void tokenise_singleToken_noQuotes() throws Exception {
+        List<String> tokens = ExecPlanner.tokenise("ls");
+        assertEquals(1, tokens.size());
+        assertEquals("ls", tokens.get(0));
+    }
+
+    @Test
+    public void tokenise_multipleTokens_noQuotes() throws Exception {
+        List<String> tokens = ExecPlanner.tokenise("ls -la /home");
+        assertEquals(3, tokens.size());
+        assertEquals("ls", tokens.get(0));
+        assertEquals("-la", tokens.get(1));
+        assertEquals("/home", tokens.get(2));
+    }
+
+    @Test
+    public void tokenise_mixedQuotes() throws Exception {
+        List<String> tokens = ExecPlanner.tokenise("echo \"hello world\" 'foo bar' baz");
+        assertEquals(4, tokens.size());
+        assertEquals("echo", tokens.get(0));
+        assertEquals("hello world", tokens.get(1));
+        assertEquals("foo bar", tokens.get(2));
+        assertEquals("baz", tokens.get(3));
+    }
+
+    @Test
+    public void tokenise_nestedQuotes() throws Exception {
+        List<String> tokens = ExecPlanner.tokenise("echo \"'inner single'\"");
+        assertEquals(2, tokens.size());
+        assertEquals("echo", tokens.get(0));
+        assertEquals("'inner single'", tokens.get(1));
+    }
+
+    @Test(expected = SecurityException.class)
+    public void tokenise_unterminatedDoubleQuote() throws Exception {
+        ExecPlanner.tokenise("echo \"unterminated");
+    }
+
+    @Test(expected = SecurityException.class)
+    public void tokenise_unterminatedSingleQuote() throws Exception {
+        ExecPlanner.tokenise("echo 'unterminated");
+    }
+
+    @Test
+    public void tokenise_escapedInQuotes_preserved() throws Exception {
+        List<String> tokens = ExecPlanner.tokenise("echo \"hello\\nworld\"");
+        assertEquals(2, tokens.size());
+        assertEquals("hello\\nworld", tokens.get(1));
+    }
+
+    @Test
+    public void planHash_sameInput_sameHash() throws Exception {
+        ExecPlan p1 = planner.plan("ls -l", workspace);
+        ExecPlan p2 = planner.plan("ls -l", workspace);
+
+        assertEquals("Same input should produce same hash", p1.getPlanHash(), p2.getPlanHash());
+    }
+
+    @Test
+    public void planHash_differentExe_differentHash() throws Exception {
+        ExecPlan p1 = planner.plan("ls", workspace);
+        ExecPlan p2 = planner.plan("ls -l", workspace);
+
+        assertNotEquals("Different argv should produce different hash", p1.getPlanHash(), p2.getPlanHash());
+    }
+
+    @Test
+    public void planHash_differentMode_differentHash() throws Exception {
+        ExecPlan p1 = planner.planFromTokens(
+                Arrays.asList("ls"), workspace, ExecPlan.ExecMode.DIRECT);
+        ExecPlan p2 = planner.planFromTokens(
+                Arrays.asList("ls"), workspace, ExecPlan.ExecMode.SHELL);
+
+        assertNotEquals("Different mode should produce different hash", p1.getPlanHash(), p2.getPlanHash());
+    }
+
+    @Test
+    public void plan_containsCorrectFields() throws Exception {
+        ExecPlan plan = planner.plan("ls -la", workspace);
+
+        assertNotNull("Exe path should not be null", plan.getCanonicalExePath());
+        assertTrue("Exe path should be absolute", plan.getCanonicalExePath().startsWith("/"));
+        assertEquals("Should have 1 arg", 1, plan.getArgv().size());
+        assertEquals("-la", plan.getArgv().get(0));
+        assertNotNull("CWD should not be null", plan.getCwd());
+        assertEquals("Mode should be DIRECT", ExecPlan.ExecMode.DIRECT, plan.getMode());
+        assertNotNull("Hash should not be null", plan.getPlanHash());
+        assertEquals("Hash should be 64 hex chars", 64, plan.getPlanHash().length());
+    }
+
+    @Test
+    public void plan_approvalDescriptionContainsFields() throws Exception {
+        ExecPlan plan = planner.plan("ls -la", workspace);
+
+        String desc = plan.toApprovalDescription();
+        assertTrue("Should contain mode", desc.contains("DIRECT"));
+        assertTrue("Should contain executable", desc.contains("ls"));
+        assertTrue("Should contain arguments", desc.contains("-la"));
+        assertTrue("Should contain working dir", desc.contains("Working dir"));
+        assertTrue("Should contain plan ID", desc.contains("Plan ID"));
+    }
+
+    @Test
+    public void plan_toStringContainsHash() throws Exception {
+        ExecPlan plan = planner.plan("ls", workspace);
+
+        String str = plan.toString();
+        assertTrue("Should contain mode", str.contains("DIRECT"));
+        assertTrue("Should contain exe", str.contains("ls"));
+        assertTrue("Should contain truncated hash", str.contains("..."));
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsLeftAngleBracket() throws Exception {
+        plan("cat < file.txt");
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsRightAngleBracket() throws Exception {
+        plan("echo test > file.txt");
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsParentheses() throws Exception {
+        plan("echo $(date)");
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsCurlyBraces() throws Exception {
+        plan("echo {a,b}");
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsExclamation() throws Exception {
+        plan("echo hello!");
+    }
+
+    @Test(expected = SecurityException.class)
+    public void rejectsTilde() throws Exception {
+        plan("ls ~");
+    }
+
+    @Test
+    public void resolveCwd_workspaceRoot_allowed() throws Exception {
+        ExecPlan plan = planner.plan("ls", workspace);
+        assertEquals(workspace.getCanonicalFile(), plan.getCwd());
+    }
+
+    @Test(expected = SecurityException.class)
+    public void resolveCwd_outsideWorkspace_rejected() throws Exception {
+        File outside = new File("/");
+        planner.plan("ls", outside);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void resolveCwd_nonexistent_rejected() throws Exception {
+        File nonexistent = new File(workspace, "does_not_exist_12345");
+        planner.plan("ls", nonexistent);
+    }
+
+    @Test
+    public void planFromTokens_emptyArgv() throws Exception {
+        ExecPlan plan = planner.planFromTokens(
+                Arrays.asList("ls"), workspace, ExecPlan.ExecMode.DIRECT);
+
+        assertEquals(LS_PATH, plan.getCanonicalExePath());
+        assertTrue("Argv should be empty", plan.getArgv().isEmpty());
+    }
+
+    @Test
+    public void planFromTokens_multipleArgv() throws Exception {
+        ExecPlan plan = planner.planFromTokens(
+                Arrays.asList("ls", "-la", "/tmp"), workspace, ExecPlan.ExecMode.DIRECT);
+
+        assertEquals(2, plan.getArgv().size());
+        assertEquals("-la", plan.getArgv().get(0));
+        assertEquals("/tmp", plan.getArgv().get(1));
+    }
+
+    @Test(expected = SecurityException.class)
+    public void planFromTokens_nullTokens() throws Exception {
+        planner.planFromTokens(null, workspace, ExecPlan.ExecMode.DIRECT);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void planFromTokens_emptyTokens() throws Exception {
+        planner.planFromTokens(Arrays.asList(), workspace, ExecPlan.ExecMode.DIRECT);
+    }
+
+    @Test
+    public void computeHash_stableAcrossCalls() {
+        String h1 = ExecPlan.computeHash("/bin/ls", Arrays.asList("-la"), workspace, ExecPlan.ExecMode.DIRECT);
+        String h2 = ExecPlan.computeHash("/bin/ls", Arrays.asList("-la"), workspace, ExecPlan.ExecMode.DIRECT);
+
+        assertEquals("Hash should be deterministic", h1, h2);
+        assertEquals("Should be 64 hex chars", 64, h1.length());
+    }
+
+    @Test
+    public void computeHash_differentFields_differentHash() {
+        String h1 = ExecPlan.computeHash("/bin/ls", Arrays.asList("-la"), workspace, ExecPlan.ExecMode.DIRECT);
+        String h2 = ExecPlan.computeHash("/bin/ls", Arrays.asList("-la"), workspace, ExecPlan.ExecMode.SHELL);
+
+        assertNotEquals("Different mode should change hash", h1, h2);
+    }
 }

--- a/app/src/test/java/io/finett/droidclaw/tool/impl/PythonToolTest.java
+++ b/app/src/test/java/io/finett/droidclaw/tool/impl/PythonToolTest.java
@@ -146,13 +146,328 @@ public class PythonToolTest {
         ToolDefinition definition = pythonTool.getDefinition();
         JsonObject params = definition.getFunction().getParameters();
         
-        assertTrue("Should have code parameter", 
+        assertTrue("Should have code parameter",
                 params.getAsJsonObject("properties").has("code"));
-        assertTrue("Should have script_path parameter", 
+        assertTrue("Should have script_path parameter",
                 params.getAsJsonObject("properties").has("script_path"));
-        assertTrue("Should have package parameter", 
+        assertTrue("Should have package parameter",
                 params.getAsJsonObject("properties").has("package"));
-        assertTrue("Should have timeout_seconds parameter", 
+        assertTrue("Should have timeout_seconds parameter",
                 params.getAsJsonObject("properties").has("timeout_seconds"));
+    }
+
+    @Test
+    public void testResolveScriptPath_withValidRelativePath() throws Exception {
+        File scriptFile = new File(workspaceRoot, "test_script.py");
+        scriptFile.createNewFile();
+
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "test_script.py");
+        ToolResult result = pythonTool.execute(arguments);
+
+        // Script exists but Python executor may fail in test environment; just verify path resolved
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testResolveScriptPath_withNestedPath() throws Exception {
+        File subdir = new File(workspaceRoot, "scripts");
+        subdir.mkdirs();
+        File scriptFile = new File(subdir, "nested.py");
+        scriptFile.createNewFile();
+
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "scripts/nested.py");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testResolveScriptPath_withNullPath() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", (String) null);
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with null script path", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_withEmptyPath() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with empty script path", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_withWhitespacePath() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "   ");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with whitespace script path", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_rejectsAbsolutePath() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "/etc/passwd");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should reject absolute path", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_rejectsDoubleDotTraversal() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "../outside.py");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should reject .. traversal", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_rejectsDotDotInMiddle() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "foo/../../etc/passwd");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should reject embedded .. traversal", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_rejectsSlashDotDot() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "foo/../..");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should reject /.. traversal", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_rejectsNonexistentFile() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "does_not_exist.py");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should reject nonexistent file", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_rejectsDirectory() throws Exception {
+        File dir = new File(workspaceRoot, "script_dir");
+        dir.mkdirs();
+
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "script_dir");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should reject directory (not a file)", result.isSuccess());
+    }
+
+    @Test
+    public void testResolveScriptPath_rejectsSymlinkOutsideWorkspace() throws Exception {
+        File outsideFile = new File(System.getProperty("java.io.tmpdir"), "outside_target.py");
+        outsideFile.createNewFile();
+
+        File symlink = new File(workspaceRoot, "evil_link.py");
+        try {
+            java.nio.file.Files.createSymbolicLink(symlink.toPath(), outsideFile.toPath());
+
+            JsonObject arguments = new JsonObject();
+            arguments.addProperty("script_path", "evil_link.py");
+            ToolResult result = pythonTool.execute(arguments);
+
+            // The canonical path check should reject symlinks pointing outside workspace
+            assertFalse("Should reject symlink outside workspace", result.isSuccess());
+        } catch (Exception e) {
+            // Symlinks may not be supported on all platforms; skip if create fails
+        } finally {
+            outsideFile.delete();
+            symlink.delete();
+        }
+    }
+
+    @Test
+    public void testExecute_withCodeOnly() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        ToolResult result = pythonTool.execute(arguments);
+
+        // May fail due to missing Python runtime in test, but should not error on validation
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testExecute_withScriptOnly() throws Exception {
+        File scriptFile = new File(workspaceRoot, "test.py");
+        scriptFile.createNewFile();
+
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "test.py");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testExecute_withPackageOnly() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("package", "requests");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testExecute_withNoMode() {
+        JsonObject arguments = new JsonObject();
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with no mode", result.isSuccess());
+        assertTrue("Should mention required parameters", result.toJson().contains("Must provide one of"));
+    }
+
+    @Test
+    public void testExecute_withAllThreeModes() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("script_path", "test.py");
+        arguments.addProperty("package", "requests");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with multiple modes", result.isSuccess());
+        assertTrue("Should mention mutually exclusive", result.toJson().contains("Can only provide one of"));
+    }
+
+    @Test
+    public void testExecute_withTwoModes_codeAndScript() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("script_path", "test.py");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with two modes", result.isSuccess());
+    }
+
+    @Test
+    public void testExecute_withTwoModes_codeAndPackage() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("package", "requests");
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with two modes", result.isSuccess());
+    }
+
+    @Test
+    public void testExecute_withTimeoutAtLowerBoundary() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("timeout_seconds", 1);
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testExecute_withTimeoutAtUpperBoundary() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("timeout_seconds", 300);
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testExecute_withTimeoutAboveUpperBoundary() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("timeout_seconds", 301);
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with timeout > 300", result.isSuccess());
+    }
+
+    @Test
+    public void testExecute_withTimeoutZero() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("timeout_seconds", 0);
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with timeout = 0", result.isSuccess());
+    }
+
+    @Test
+    public void testExecute_withTimeoutNegative() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello')");
+        arguments.addProperty("timeout_seconds", -5);
+        ToolResult result = pythonTool.execute(arguments);
+
+        assertFalse("Should fail with negative timeout", result.isSuccess());
+    }
+
+    @Test
+    public void testGetApprovalDescription_withCode() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "print('hello world')");
+        String desc = pythonTool.getApprovalDescription(arguments);
+
+        assertTrue("Should contain code preview", desc.contains("print"));
+        assertTrue("Should mention Python code", desc.contains("Execute Python code"));
+    }
+
+    @Test
+    public void testGetApprovalDescription_withLongCode_truncated() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("code", "x = " + "1".repeat(100));
+        String desc = pythonTool.getApprovalDescription(arguments);
+
+        assertTrue("Should contain ellipsis for long code", desc.contains("..."));
+        assertTrue("Should be truncated", desc.length() < 120);
+    }
+
+    @Test
+    public void testGetApprovalDescription_withScriptPath() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("script_path", "analysis.py");
+        String desc = pythonTool.getApprovalDescription(arguments);
+
+        assertTrue("Should contain script path", desc.contains("analysis.py"));
+        assertTrue("Should mention script", desc.contains("Execute Python script"));
+    }
+
+    @Test
+    public void testGetApprovalDescription_withPackage() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("package", "requests");
+        String desc = pythonTool.getApprovalDescription(arguments);
+
+        assertTrue("Should contain package name", desc.contains("requests"));
+        assertTrue("Should mention pip", desc.contains("pip"));
+    }
+
+    @Test
+    public void testGetApprovalDescription_withNoArgs() {
+        JsonObject arguments = new JsonObject();
+        String desc = pythonTool.getApprovalDescription(arguments);
+
+        assertTrue("Should have default description", desc.contains("Execute Python operation"));
+    }
+
+    @Test
+    public void testRequiresApproval_returnsTrue() {
+        assertTrue("Python tool should require approval", pythonTool.requiresApproval());
+    }
+
+    @Test
+    public void testShutdown_doesNotThrow() {
+        pythonTool.shutdown();
+        // Should complete without exception
     }
 }

--- a/app/src/test/java/io/finett/droidclaw/tool/impl/ShellToolTest.java
+++ b/app/src/test/java/io/finett/droidclaw/tool/impl/ShellToolTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 
 import io.finett.droidclaw.filesystem.PathValidator;
+import io.finett.droidclaw.shell.ExecPlan;
 import io.finett.droidclaw.shell.ExecPlanner;
 import io.finett.droidclaw.shell.ShellConfig;
 import io.finett.droidclaw.tool.ToolDefinition;
@@ -381,5 +382,338 @@ public class ShellToolTest {
         ShellTool pathValidatorTool = new ShellTool(pathValidator, ShellConfig.createDefault());
         assertNotNull(pathValidatorTool);
         assertEquals("execute_shell", pathValidatorTool.getName());
+    }
+
+    @Test
+    public void testBuildExecPlan_withValidCommand_returnsPlan() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo hello");
+
+        ExecPlan plan = tool.buildExecPlan(args);
+
+        assertNotNull("Plan should be built for valid command", plan);
+        assertTrue("Plan should contain echo", plan.getCanonicalExePath().endsWith("echo"));
+        assertEquals("Plan should have 1 arg", 1, plan.getArgv().size());
+        assertEquals("hello", plan.getArgv().get(0));
+        assertNotNull("Plan hash should not be null", plan.getPlanHash());
+        assertTrue("Plan hash should be non-empty", plan.getPlanHash().length() > 0);
+    }
+
+    @Test
+    public void testBuildExecPlan_withEmptyCommand_returnsNull() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "   ");
+
+        ExecPlan plan = tool.buildExecPlan(args);
+
+        assertNull("Plan should be null for empty command", plan);
+    }
+
+    @Test
+    public void testBuildExecPlan_withMetachar_returnsNull() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo hello; rm -rf /");
+
+        ExecPlan plan = tool.buildExecPlan(args);
+
+        assertNull("Plan should be null when metachar detected", plan);
+    }
+
+    @Test
+    public void testBuildExecPlan_withMissingCommand_returnsNull() {
+        JsonObject args = new JsonObject();
+
+        ExecPlan plan = tool.buildExecPlan(args);
+
+        assertNull("Plan should be null when command missing", plan);
+    }
+
+    @Test
+    public void testBuildExecPlan_hashChangesWithDifferentArgs() {
+        JsonObject args1 = new JsonObject();
+        args1.addProperty("command", "echo hello");
+
+        JsonObject args2 = new JsonObject();
+        args2.addProperty("command", "echo world");
+
+        ExecPlan plan1 = tool.buildExecPlan(args1);
+        ExecPlan plan2 = tool.buildExecPlan(args2);
+
+        assertNotNull(plan1);
+        assertNotNull(plan2);
+        assertNotEquals("Different args should produce different hashes",
+                plan1.getPlanHash(), plan2.getPlanHash());
+    }
+
+    @Test
+    public void testBuildExecPlan_hashStableForSameArgs() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo hello");
+
+        ExecPlan plan1 = tool.buildExecPlan(args);
+        ExecPlan plan2 = tool.buildExecPlan(args);
+
+        assertNotNull(plan1);
+        assertNotNull(plan2);
+        assertEquals("Same args should produce same hash",
+                plan1.getPlanHash(), plan2.getPlanHash());
+    }
+
+    @Test
+    public void testBuildExecPlan_approvalDescriptionContainsHash() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo hello");
+
+        ExecPlan plan = tool.buildExecPlan(args);
+
+        assertNotNull(plan);
+        String desc = plan.toApprovalDescription();
+        assertTrue("Description should contain mode", desc.contains("DIRECT"));
+        assertTrue("Description should contain executable", desc.contains("echo"));
+        assertTrue("Description should contain working dir", desc.contains("Working dir"));
+        assertTrue("Description should contain plan ID", desc.contains("Plan ID"));
+    }
+
+    @Test
+    public void testGetApprovalDescription_withCommand() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "ls -la");
+
+        String desc = tool.getApprovalDescription(args);
+
+        assertTrue("Should contain command", desc.contains("ls -la"));
+        assertTrue("Should mention shell command", desc.contains("Execute shell command"));
+    }
+
+    @Test
+    public void testGetApprovalDescription_withWorkingDir() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "pwd");
+        args.addProperty("working_directory", "subdir");
+
+        String desc = tool.getApprovalDescription(args);
+
+        assertTrue("Should contain working directory", desc.contains("subdir"));
+    }
+
+    @Test
+    public void testGetApprovalDescription_missingCommand() {
+        JsonObject args = new JsonObject();
+
+        String desc = tool.getApprovalDescription(args);
+
+        assertTrue("Should show unknown command", desc.contains("unknown command"));
+    }
+
+    @Test
+    public void testExecuteWithCommandSubstitution_dollarParen() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo $(whoami)");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject command substitution", result.isSuccess());
+        assertTrue("Error should mention metacharacter or security",
+                result.getError().contains("metacharacter") || result.getError().contains("Security"));
+    }
+
+    @Test
+    public void testExecuteWithCommandSubstitution_backtick() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo `whoami`");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject backtick substitution", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithRedirection_output() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo test > /tmp/file.txt");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject redirection", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithRedirection_input() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "cat < /etc/passwd");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject input redirection", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithPipe() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "ls | wc -l");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject pipe", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithAmpersand() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "ls && echo done");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject ampersand", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithSemicolon() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "ls; echo done");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject semicolon", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithQuestionMarkGlob() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo ?");
+
+        ToolResult result = tool.execute(args);
+
+        // '?' is not in metachars, so this may succeed or fail depending on shell
+        // Just verify it doesn't crash
+        assertNotNull("Result should not be null", result);
+    }
+
+    @Test
+    public void testExecuteWithTildeExpansion() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "ls ~");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject tilde expansion", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithExclamationMark() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo hello!");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject exclamation mark", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithBraceExpansion() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo {a,b,c}");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject brace expansion", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithDoubleDotTraversal() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "pwd");
+        args.addProperty("working_directory", "foo/../..");
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Should reject double-dot traversal", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithNullWorkingDirectory_usesRoot() {
+        ShellConfig fullConfig = ShellConfig.createFull();
+        ShellTool fullTool = new ShellTool(pathValidator, fullConfig);
+
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "pwd");
+
+        ToolResult result = fullTool.execute(args);
+
+        assertTrue("Null working directory should use workspace root", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithWhitespaceWorkingDirectory_usesRoot() {
+        ShellConfig fullConfig = ShellConfig.createFull();
+        ShellTool fullTool = new ShellTool(pathValidator, fullConfig);
+
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "pwd");
+        args.addProperty("working_directory", "   ");
+
+        ToolResult result = fullTool.execute(args);
+
+        assertTrue("Whitespace working directory should use workspace root", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithTimeoutAtBoundary_300() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo test");
+        args.addProperty("timeout_seconds", 300);
+
+        ToolResult result = tool.execute(args);
+
+        assertTrue("Timeout at upper boundary should be valid", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithTimeoutAtBoundary_1() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo test");
+        args.addProperty("timeout_seconds", 1);
+
+        ToolResult result = tool.execute(args);
+
+        assertTrue("Timeout at lower boundary should be valid", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithTimeoutAboveBoundary_301() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo test");
+        args.addProperty("timeout_seconds", 301);
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Timeout above upper boundary should fail", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithTimeoutZero() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo test");
+        args.addProperty("timeout_seconds", 0);
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Timeout of zero should fail", result.isSuccess());
+    }
+
+    @Test
+    public void testExecuteWithTimeoutNegative() {
+        JsonObject args = new JsonObject();
+        args.addProperty("command", "echo test");
+        args.addProperty("timeout_seconds", -1);
+
+        ToolResult result = tool.execute(args);
+
+        assertFalse("Negative timeout should fail", result.isSuccess());
+    }
+
+    @Test
+    public void testRequiresApproval_returnsTrue() {
+        assertTrue("Shell tool should require approval", tool.requiresApproval());
     }
 }

--- a/app/src/test/java/io/finett/droidclaw/worker/HeartbeatWorkerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/worker/HeartbeatWorkerTest.java
@@ -1,0 +1,456 @@
+package io.finett.droidclaw.worker;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.finett.droidclaw.model.HeartbeatConfig;
+import io.finett.droidclaw.model.HeartbeatResponse;
+
+public class HeartbeatWorkerTest {
+
+    private static final Pattern HEARTBEAT_JSON_PATTERN = Pattern.compile(
+            "\\{\\s*\"HEARTBEAT_OK\"\\s*:\\s*(true|false)\\s*\\}",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    @Test
+    public void parseStructured_healthyTrue_noIssues() {
+        String json = "{\"healthy\":true,\"summary\":\"All systems normal\",\"issues\":[]}";
+        HeartbeatResponse response = HeartbeatResponse.fromJson(json);
+
+        assertTrue("Should be healthy", response.isHealthy());
+        assertEquals("All systems normal", response.getSummary());
+        assertTrue("Should have no issues", response.getIssues().isEmpty());
+        assertFalse("Should not have issues", response.hasIssues());
+    }
+
+    @Test
+    public void parseStructured_healthyFalse_withIssues() {
+        String json = "{\"healthy\":false,\"summary\":\"Issues found\",\"issues\":[{\"category\":\"workspace\",\"description\":\"3 incomplete tasks\",\"severity\":\"low\"}]}";
+        HeartbeatResponse response = HeartbeatResponse.fromJson(json);
+
+        assertFalse("Should not be healthy", response.isHealthy());
+        assertEquals("Issues found", response.getSummary());
+        assertTrue("Should have issues", response.hasIssues());
+        assertEquals("Should have 1 issue", 1, response.getIssues().size());
+
+        HeartbeatResponse.Issue issue = response.getIssues().get(0);
+        assertEquals("workspace", issue.getCategory());
+        assertEquals("3 incomplete tasks", issue.getDescription());
+        assertEquals("low", issue.getSeverity());
+    }
+
+    @Test
+    public void parseStructured_multipleIssues_variousSeverities() {
+        String json = "{\"healthy\":false,\"summary\":\"Multiple issues\",\"issues\":[" +
+                "{\"category\":\"memory\",\"description\":\"Stale memories\",\"severity\":\"medium\"}," +
+                "{\"category\":\"tasks\",\"description\":\"Failed execution\",\"severity\":\"high\"}" +
+                "]}";
+        HeartbeatResponse response = HeartbeatResponse.fromJson(json);
+
+        assertFalse("Should not be healthy", response.isHealthy());
+        assertEquals("Should have 2 issues", 2, response.getIssues().size());
+        assertEquals("medium", response.getIssues().get(0).getSeverity());
+        assertEquals("high", response.getIssues().get(1).getSeverity());
+    }
+
+    @Test
+    public void parseStructured_withExtraFields_ignoresThem() {
+        String json = "{\"healthy\":true,\"summary\":\"All good\",\"issues\":[],\"extra\":\"ignored\",\"model\":\"gpt-4\"}";
+        HeartbeatResponse response = HeartbeatResponse.fromJson(json);
+
+        assertTrue("Should be healthy despite extra fields", response.isHealthy());
+        assertEquals("All good", response.getSummary());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseStructured_missingHealthyField_throws() {
+        String json = "{\"summary\":\"Missing healthy\",\"issues\":[]}";
+        HeartbeatResponse.fromJson(json);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseStructured_missingSummaryField_throws() {
+        String json = "{\"healthy\":true,\"issues\":[]}";
+        HeartbeatResponse.fromJson(json);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseStructured_missingIssuesField_throws() {
+        String json = "{\"healthy\":true,\"summary\":\"Missing issues\"}";
+        HeartbeatResponse.fromJson(json);
+    }
+
+    @Test(expected = com.google.gson.JsonSyntaxException.class)
+    public void parseStructured_invalidJson_throws() {
+        HeartbeatResponse.fromJson("not valid json at all");
+    }
+
+    @Test
+    public void parseStructured_emptyIssuesArray() {
+        String json = "{\"healthy\":true,\"summary\":\"No issues\",\"issues\":[]}";
+        HeartbeatResponse response = HeartbeatResponse.fromJson(json);
+
+        assertTrue("Should be healthy", response.isHealthy());
+        assertNotNull("Issues list should not be null", response.getIssues());
+        assertTrue("Issues should be empty", response.getIssues().isEmpty());
+    }
+
+    @Test
+    public void getJsonSchema_returnsValidSchema() {
+        JsonObject schema = HeartbeatResponse.getJsonSchema();
+
+        assertNotNull("Schema should not be null", schema);
+        assertEquals("Type should be object", "object", schema.get("type").getAsString());
+        assertTrue("Should have properties", schema.has("properties"));
+        assertTrue("Should have required fields", schema.has("required"));
+
+        JsonObject properties = schema.getAsJsonObject("properties");
+        assertTrue("Should have healthy property", properties.has("healthy"));
+        assertTrue("Should have summary property", properties.has("summary"));
+        assertTrue("Should have issues property", properties.has("issues"));
+
+        JsonObject healthyProp = properties.getAsJsonObject("healthy");
+        assertEquals("boolean", healthyProp.get("type").getAsString());
+
+        JsonObject issuesProp = properties.getAsJsonObject("issues");
+        assertEquals("array", issuesProp.get("type").getAsString());
+        assertTrue("Issues should have items", issuesProp.has("items"));
+
+        JsonArray required = schema.getAsJsonArray("required");
+        assertEquals("Should require 3 fields", 3, required.size());
+    }
+
+    @Test
+    public void getJsonSchema_issueSchemaHasSeverityEnum() {
+        JsonObject schema = HeartbeatResponse.getJsonSchema();
+        JsonObject properties = schema.getAsJsonObject("properties");
+        JsonObject issuesProp = properties.getAsJsonObject("issues");
+        JsonObject items = issuesProp.getAsJsonObject("items");
+        JsonObject issueProps = items.getAsJsonObject("properties");
+        JsonObject severityProp = issueProps.getAsJsonObject("severity");
+
+        assertTrue("Severity should have enum", severityProp.has("enum"));
+        JsonArray enumValues = severityProp.getAsJsonArray("enum");
+        assertEquals("Should have 3 severity levels", 3, enumValues.size());
+        assertEquals("low", enumValues.get(0).getAsString());
+        assertEquals("medium", enumValues.get(1).getAsString());
+        assertEquals("high", enumValues.get(2).getAsString());
+    }
+
+    @Test
+    public void issue_toString_formatsCorrectly() {
+        HeartbeatResponse.Issue issue = new HeartbeatResponse.Issue(
+                "workspace", "Incomplete tasks found", "medium");
+
+        assertEquals("[MEDIUM] workspace: Incomplete tasks found", issue.toString());
+    }
+
+    @Test
+    public void issue_gettersReturnCorrectValues() {
+        HeartbeatResponse.Issue issue = new HeartbeatResponse.Issue(
+                "category1", "description1", "high");
+
+        assertEquals("category1", issue.getCategory());
+        assertEquals("description1", issue.getDescription());
+        assertEquals("high", issue.getSeverity());
+    }
+
+    @Test
+    public void issue_withEmptyStrings() {
+        HeartbeatResponse.Issue issue = new HeartbeatResponse.Issue("", "", "low");
+
+        assertEquals("", issue.getCategory());
+        assertEquals("", issue.getDescription());
+        assertEquals("low", issue.getSeverity());
+        assertEquals("[LOW] : ", issue.toString());
+    }
+
+    @Test
+    public void detectLegacy_trueAtEndOfResponse() {
+        String content = "System review complete. All healthy.\n\n{\"HEARTBEAT_OK\": true}";
+        assertTrue("Should detect HEARTBEAT_OK true", detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectLegacy_trueWithSpaces() {
+        String content = "{ \"HEARTBEAT_OK\" : true }";
+        assertTrue("Should detect with spaces", detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectLegacy_false_issuesPresent() {
+        String content = "Found issues: 3 tasks incomplete\n{\"HEARTBEAT_OK\": false}";
+        assertFalse("Should return false when HEARTBEAT_OK is false", detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectLegacy_noMarker() {
+        String content = "System has issues. Some checks failed.";
+        assertFalse("Should not detect when no JSON present", detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectLegacy_nullContent() {
+        assertFalse("Should not detect in null content", detectLegacyHeartbeatOk(null));
+    }
+
+    @Test
+    public void detectLegacy_emptyContent() {
+        assertFalse("Should not detect in empty content", detectLegacyHeartbeatOk(""));
+    }
+
+    @Test
+    public void detectLegacy_refusalPrefix() {
+        String content = "[REFUSAL] I'm sorry, I cannot assist with that request.";
+        assertFalse("Should return false for refusal", detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectLegacy_mixedCase_regexMatchesButKeyLookupFails() {
+        String content = "{\"heartbeat_ok\": true}";
+        // The regex is case-insensitive and matches, but Gson key lookup is case-sensitive
+        // so "HEARTBEAT_OK" won't find "heartbeat_ok" - result is false
+        assertFalse("Mixed case key should not be found by case-sensitive Gson lookup",
+                detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectLegacy_multipleMarkers_usesFirst() {
+        String content = "{\"HEARTBEAT_OK\": false} some text {\"HEARTBEAT_OK\": true}";
+        // First match is false
+        assertFalse("Should use first match", detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectStructured_healthyTrue() {
+        String content = "{\"healthy\":true,\"summary\":\"All good\",\"issues\":[]}";
+        assertTrue("Should detect structured healthy", detectStructuredHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectStructured_healthyFalse() {
+        String content = "{\"healthy\":false,\"summary\":\"Issues\",\"issues\":[{\"category\":\"test\",\"description\":\"test\",\"severity\":\"low\"}]}";
+        assertFalse("Should detect structured unhealthy", detectStructuredHeartbeatOk(content));
+    }
+
+    @Test
+    public void detectStructured_invalidJson_fallsBackToLegacy() {
+        String content = "{\"healthy\":true,\"summary\":\"bad\"} {\"HEARTBEAT_OK\": true}";
+        // First tries structured, fails (missing issues), falls back to legacy
+        assertTrue("Should fall back to legacy", detectLegacyHeartbeatOk(content));
+    }
+
+    @Test
+    public void refusal_startsWithRefusalMarker() {
+        String content = "[REFUSAL] Content policy violation";
+        assertTrue("Should detect refusal prefix", isRefusal(content));
+    }
+
+    @Test
+    public void refusal_doesNotStartWithRefusal() {
+        String content = "Some normal response [REFUSAL] in middle";
+        assertFalse("Should not detect refusal in middle", isRefusal(content));
+    }
+
+    @Test
+    public void refusal_emptyString() {
+        assertFalse("Empty string is not refusal", isRefusal(""));
+    }
+
+    @Test
+    public void refusal_nullString() {
+        assertFalse("Null is not refusal", isRefusal(null));
+    }
+
+    @Test
+    public void stalenessLevel_fresh_neverRun() {
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, 0L);
+        long now = System.currentTimeMillis();
+
+        assertEquals("Never run should be FRESH",
+                HeartbeatConfig.StalenessLevel.FRESH, config.getStalenessLevel(now));
+        assertEquals("Ratio should be 0", 0, config.getStalenessRatio(now), 0.001);
+    }
+
+    @Test
+    public void stalenessLevel_fresh_withinInterval() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, now - 15 * 60 * 1000L);
+
+        assertEquals("Within interval should be FRESH",
+                HeartbeatConfig.StalenessLevel.FRESH, config.getStalenessLevel(now));
+        assertTrue("Ratio should be < 1", config.getStalenessRatio(now) < 1.0);
+    }
+
+    @Test
+    public void stalenessLevel_slightlyLate_oneInterval() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, now - 30 * 60 * 1000L);
+
+        assertEquals("Exactly one interval should be SLIGHTLY_LATE",
+                HeartbeatConfig.StalenessLevel.SLIGHTLY_LATE, config.getStalenessLevel(now));
+        assertEquals("Ratio should be 1.0", 1.0, config.getStalenessRatio(now), 0.001);
+    }
+
+    @Test
+    public void stalenessLevel_slightlyLate_twoIntervals() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, now - 60 * 60 * 1000L);
+
+        assertEquals("Two intervals should be SLIGHTLY_LATE",
+                HeartbeatConfig.StalenessLevel.SLIGHTLY_LATE, config.getStalenessLevel(now));
+        assertEquals("Ratio should be 2.0", 2.0, config.getStalenessRatio(now), 0.001);
+    }
+
+    @Test
+    public void stalenessLevel_slightlyLate_threeIntervals() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, now - 90 * 60 * 1000L);
+
+        assertEquals("Three intervals should be SLIGHTLY_LATE",
+                HeartbeatConfig.StalenessLevel.SLIGHTLY_LATE, config.getStalenessLevel(now));
+        assertEquals("Ratio should be 3.0", 3.0, config.getStalenessRatio(now), 0.001);
+    }
+
+    @Test
+    public void stalenessLevel_dead_fourIntervals() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, now - 120 * 60 * 1000L);
+
+        assertEquals("Four intervals should be DEAD",
+                HeartbeatConfig.StalenessLevel.DEAD, config.getStalenessLevel(now));
+        assertTrue("Ratio should be > 3", config.getStalenessRatio(now) > 3.0);
+    }
+
+    @Test
+    public void stalenessRatio_zeroInterval_returnsZero() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 0L, now - 1000L);
+
+        assertEquals("Zero interval should return 0 ratio", 0, config.getStalenessRatio(now), 0.001);
+    }
+
+    @Test
+    public void stalenessRatio_negativeInterval_returnsZero() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, -1L, now - 1000L);
+
+        assertEquals("Negative interval should return 0 ratio", 0, config.getStalenessRatio(now), 0.001);
+    }
+
+    @Test
+    public void shouldRun_disabled_returnsFalse() {
+        HeartbeatConfig config = new HeartbeatConfig(false, 30 * 60 * 1000L, 0L);
+        assertFalse("Disabled should not run", config.shouldRun(System.currentTimeMillis()));
+    }
+
+    @Test
+    public void shouldRun_enabled_firstRun_returnsTrue() {
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, 0L);
+        assertTrue("First run should execute", config.shouldRun(System.currentTimeMillis()));
+    }
+
+    @Test
+    public void shouldRun_intervalNotElapsed_returnsFalse() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 60 * 60 * 1000L, now - 5 * 60 * 1000L);
+        assertFalse("Should not run when interval not elapsed", config.shouldRun(now));
+    }
+
+    @Test
+    public void shouldRun_intervalElapsed_returnsTrue() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, now - 60 * 60 * 1000L);
+        assertTrue("Should run when interval elapsed", config.shouldRun(now));
+    }
+
+    @Test
+    public void shouldRun_exactlyAtInterval_returnsTrue() {
+        long now = System.currentTimeMillis();
+        HeartbeatConfig config = new HeartbeatConfig(true, 30 * 60 * 1000L, now - 30 * 60 * 1000L);
+        assertTrue("Should run exactly at interval", config.shouldRun(now));
+    }
+
+    @Test
+    public void defaultConfig_values() {
+        HeartbeatConfig config = HeartbeatConfig.getDefaults();
+
+        assertFalse("Default should be disabled", config.isEnabled());
+        assertEquals("Default interval should be 30 min", 30 * 60 * 1000L, config.getIntervalMillis());
+        assertEquals("Default last run should be 0", 0L, config.getLastRunTimestamp());
+    }
+
+    @Test
+    public void config_settersAndGetters() {
+        HeartbeatConfig config = new HeartbeatConfig();
+
+        config.setEnabled(true);
+        assertTrue("Should be enabled", config.isEnabled());
+
+        config.setIntervalMillis(60000L);
+        assertEquals("Interval should be 60s", 60000L, config.getIntervalMillis());
+
+        config.setLastRunTimestamp(12345L);
+        assertEquals("Last run should be 12345", 12345L, config.getLastRunTimestamp());
+    }
+
+    private boolean detectLegacyHeartbeatOk(String content) {
+        if (content == null || content.isEmpty()) {
+            return false;
+        }
+
+        if (content.startsWith("[REFUSAL]")) {
+            return false;
+        }
+
+        // Try structured output first
+        if (content.contains("\"healthy\"") && content.contains("\"summary\"")) {
+            try {
+                HeartbeatResponse response = HeartbeatResponse.fromJson(content);
+                return response.isHealthy();
+            } catch (Exception e) {
+                // Fall through to legacy
+            }
+        }
+
+        Matcher matcher = HEARTBEAT_JSON_PATTERN.matcher(content);
+        if (matcher.find()) {
+            String jsonStr = matcher.group(0);
+            try {
+                JsonObject json = JsonParser.parseString(jsonStr).getAsJsonObject();
+                if (json.has("HEARTBEAT_OK")) {
+                    return json.get("HEARTBEAT_OK").getAsBoolean();
+                }
+            } catch (Exception e) {
+                // Parse failed
+            }
+        }
+
+        return false;
+    }
+
+    private boolean detectStructuredHeartbeatOk(String content) {
+        if (content == null || content.isEmpty()) {
+            return false;
+        }
+        try {
+            HeartbeatResponse response = HeartbeatResponse.fromJson(content);
+            return response.isHealthy();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean isRefusal(String content) {
+        return content != null && content.startsWith("[REFUSAL]");
+    }
+}


### PR DESCRIPTION
Add extensive unit tests for ConversationSummarizer, IdentityManager, MemoryContextBuilder, ExecPlanner, PythonTool, ShellTool, and HeartbeatWorker. Validates edge cases, error handling, security restrictions, parsing logic, and configuration behavior.