### PR TITLE
feat(agent): add background tool execution

### DIFF
--- a/app/src/androidTest/java/io/finett/droidclaw/service/BackgroundProcessManagerInstrumentedTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/service/BackgroundProcessManagerInstrumentedTest.java
@@ -1,0 +1,196 @@
+package io.finett.droidclaw.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.gson.JsonObject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.finett.droidclaw.tool.ToolResult;
+
+@RunWith(AndroidJUnit4.class)
+public class BackgroundProcessManagerInstrumentedTest {
+
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+    }
+
+    @Test
+    public void submit_returnsProcessId() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        String processId = manager.submit("test_tool", "{}", () -> {
+            latch.countDown();
+            return ToolResult.success(new JsonObject());
+        });
+
+        assertNotNull(processId);
+        assertFalse(processId.isEmpty());
+
+        latch.await(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void submit_processCompletesSuccessfully() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        String processId = manager.submit("test_tool", "{}", () -> {
+            JsonObject result = new JsonObject();
+            result.addProperty("value", "hello");
+            latch.countDown();
+            return ToolResult.success(result);
+        });
+
+        boolean done = latch.await(5, TimeUnit.SECONDS);
+        assertTrue("Task did not complete in time", done);
+
+        // Give a moment for status update
+        Thread.sleep(100);
+
+        BackgroundProcess process = manager.get(processId);
+        assertNotNull(process);
+        assertEquals(BackgroundProcess.STATUS_COMPLETED, process.getStatus());
+        assertNotNull(process.getResult());
+        assertTrue(process.getFinishedAt() > 0);
+    }
+
+    @Test
+    public void submit_processFailsOnException() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        String processId = manager.submit("failing_tool", "{}", () -> {
+            latch.countDown();
+            throw new RuntimeException("deliberate failure");
+        });
+
+        boolean done = latch.await(5, TimeUnit.SECONDS);
+        assertTrue("Task did not complete in time", done);
+
+        Thread.sleep(100);
+
+        BackgroundProcess process = manager.get(processId);
+        assertNotNull(process);
+        assertEquals(BackgroundProcess.STATUS_FAILED, process.getStatus());
+        assertNotNull(process.getError());
+    }
+
+    @Test
+    public void kill_runningProcess_returnsTrue() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch startedLatch = new CountDownLatch(1);
+
+        String processId = manager.submit("long_tool", "{}", () -> {
+            startedLatch.countDown();
+            // Simulate long-running task that respects interruption
+            Thread.sleep(30_000);
+            return ToolResult.success(new JsonObject());
+        });
+
+        // Wait for task to start
+        boolean started = startedLatch.await(3, TimeUnit.SECONDS);
+        assertTrue("Task did not start in time", started);
+
+        boolean killed = manager.kill(processId);
+        assertTrue("Kill should return true for a running process", killed);
+
+        Thread.sleep(200);
+
+        BackgroundProcess process = manager.get(processId);
+        assertNotNull(process);
+        assertEquals(BackgroundProcess.STATUS_KILLED, process.getStatus());
+    }
+
+    @Test
+    public void kill_nonExistentProcess_returnsFalse() {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+        assertFalse(manager.kill("nonexistent-process-id"));
+    }
+
+    @Test
+    public void listAll_includesSubmittedProcesses() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        String processId = manager.submit("list_test_tool", "{}", () -> {
+            latch.countDown();
+            return ToolResult.success(new JsonObject());
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        List<BackgroundProcess> all = manager.listAll();
+        boolean found = false;
+        for (BackgroundProcess p : all) {
+            if (processId.equals(p.getId())) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue("Submitted process should appear in listAll()", found);
+    }
+
+    @Test
+    public void runningCount_decreasesAfterCompletion() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        manager.submit("count_test_tool", "{}", () -> {
+            latch.countDown();
+            return ToolResult.success(new JsonObject());
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+        Thread.sleep(200);
+
+        // After completion the count should not include this finished process
+        int running = manager.runningCount();
+        // We can only assert it's non-negative; other tests may have running processes
+        assertTrue(running >= 0);
+    }
+
+    @Test
+    public void get_unknownId_returnsNull() {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+        assertNull(manager.get("totally-unknown-id-xyz"));
+    }
+
+    @Test
+    public void backgroundProcess_getDurationMs_returnsZeroWhileRunning() {
+        BackgroundProcess process = new BackgroundProcess("id", "tool", "{}");
+        assertEquals(0L, process.getDurationMs());
+    }
+
+    @Test
+    public void backgroundProcess_getDurationMs_returnsCorrectValueAfterFinish() {
+        BackgroundProcess process = new BackgroundProcess("id", "tool", "{}");
+        long now = System.currentTimeMillis() + 100;
+        process.setFinishedAt(now);
+        assertTrue(process.getDurationMs() > 0);
+    }
+}

--- a/app/src/androidTest/java/io/finett/droidclaw/tool/BackgroundProcessToolsInstrumentedTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/tool/BackgroundProcessToolsInstrumentedTest.java
@@ -1,0 +1,205 @@
+package io.finett.droidclaw.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.gson.JsonObject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.finett.droidclaw.service.BackgroundProcess;
+import io.finett.droidclaw.service.BackgroundProcessManager;
+import io.finett.droidclaw.tool.impl.KillBackgroundProcessTool;
+import io.finett.droidclaw.tool.impl.ListBackgroundProcessesTool;
+
+@RunWith(AndroidJUnit4.class)
+public class BackgroundProcessToolsInstrumentedTest {
+
+    private Context context;
+    private KillBackgroundProcessTool killTool;
+    private ListBackgroundProcessesTool listTool;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+        killTool = new KillBackgroundProcessTool(context);
+        listTool = new ListBackgroundProcessesTool(context);
+    }
+
+    // ==================== KillBackgroundProcessTool ====================
+
+    @Test
+    public void killTool_missingProcessId_returnsError() {
+        JsonObject args = new JsonObject();
+        ToolResult result = killTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertNotNull(result.getError());
+    }
+
+    @Test
+    public void killTool_emptyProcessId_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("process_id", "");
+        ToolResult result = killTool.execute(args);
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    public void killTool_unknownProcessId_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("process_id", "nonexistent-abc-123");
+        ToolResult result = killTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("No background process found"));
+    }
+
+    @Test
+    public void killTool_completedProcess_returnsNotRunning() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        String processId = manager.submit("done_tool", "{}", () -> {
+            latch.countDown();
+            return ToolResult.success(new JsonObject());
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+        Thread.sleep(150);
+
+        JsonObject args = new JsonObject();
+        args.addProperty("process_id", processId);
+        ToolResult result = killTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        String content = result.getContent();
+        assertNotNull(content);
+        assertTrue(content.contains("\"killed\":false"));
+    }
+
+    @Test
+    public void killTool_runningProcess_killsIt() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        String processId = manager.submit("slow_tool", "{}", () -> {
+            startLatch.countDown();
+            Thread.sleep(30_000);
+            return ToolResult.success(new JsonObject());
+        });
+
+        startLatch.await(3, TimeUnit.SECONDS);
+
+        JsonObject args = new JsonObject();
+        args.addProperty("process_id", processId);
+        ToolResult result = killTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        String content = result.getContent();
+        assertNotNull(content);
+        assertTrue(content.contains("\"killed\":true"));
+    }
+
+    @Test
+    public void killTool_requiresApproval() {
+        assertTrue(killTool.requiresApproval());
+    }
+
+    @Test
+    public void killTool_name() {
+        assertEquals("kill_background_process", killTool.getName());
+    }
+
+    // ==================== ListBackgroundProcessesTool ====================
+
+    @Test
+    public void listTool_noArgs_returnsAllProcesses() {
+        JsonObject args = new JsonObject();
+        ToolResult result = listTool.execute(args);
+        assertTrue(result.isSuccess());
+        String content = result.getContent();
+        assertNotNull(content);
+        assertTrue(content.contains("\"processes\""));
+        assertTrue(content.contains("\"total\""));
+    }
+
+    @Test
+    public void listTool_filterRunning_returnsOnlyRunning() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        String processId = manager.submit("running_tool", "{}", () -> {
+            startLatch.countDown();
+            Thread.sleep(20_000);
+            return ToolResult.success(new JsonObject());
+        });
+
+        startLatch.await(3, TimeUnit.SECONDS);
+
+        JsonObject args = new JsonObject();
+        args.addProperty("status", "running");
+        ToolResult result = listTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        String content = result.getContent();
+        assertNotNull(content);
+        assertTrue(content.contains(processId));
+
+        // Cleanup
+        manager.kill(processId);
+    }
+
+    @Test
+    public void listTool_filterCompleted_doesNotIncludeRunning() throws InterruptedException {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        String runningId = manager.submit("still_running", "{}", () -> {
+            startLatch.countDown();
+            Thread.sleep(20_000);
+            return ToolResult.success(new JsonObject());
+        });
+
+        startLatch.await(3, TimeUnit.SECONDS);
+
+        JsonObject args = new JsonObject();
+        args.addProperty("status", "completed");
+        ToolResult result = listTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        String content = result.getContent();
+        // The still-running process should NOT appear in completed filter
+        assertFalse("Running process should not appear in completed filter",
+                content.contains(runningId));
+
+        // Cleanup
+        manager.kill(runningId);
+    }
+
+    @Test
+    public void listTool_doesNotRequireApproval() {
+        assertFalse(listTool.requiresApproval());
+    }
+
+    @Test
+    public void listTool_name() {
+        assertEquals("list_background_processes", listTool.getName());
+    }
+
+    @Test
+    public void listTool_nullArgs_doesNotCrash() {
+        ToolResult result = listTool.execute(null);
+        assertTrue(result.isSuccess());
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".DroidClawApplication"
@@ -27,6 +30,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".service.BackgroundProcessService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.model.ChatMessage;
 import io.finett.droidclaw.model.FileAttachment;
+import io.finett.droidclaw.service.BackgroundProcessManager;
 import io.finett.droidclaw.shell.ExecPlan;
 import io.finett.droidclaw.tool.Tool;
 import io.finett.droidclaw.tool.ToolRegistry;
@@ -303,6 +304,20 @@ public class AgentLoop {
         Log.d(TAG, "Processing tool: " + toolName + " with args: " + arguments.toString());
         callback.onToolCall(toolName, arguments.toString());
 
+        boolean wantsBackground = arguments.has("background")
+                && !arguments.get("background").isJsonNull()
+                && arguments.get("background").getAsBoolean();
+        boolean bgExecEnabled = settingsManager != null
+                && settingsManager.getAgentConfig().isBackgroundExecEnabled();
+
+        if (wantsBackground && bgExecEnabled) {
+            JsonObject cleanedArgs = arguments.deepCopy();
+            cleanedArgs.remove("background");
+
+            dispatchBackgroundTool(toolCall, cleanedArgs, toolCalls, index, conversationHistory, callback);
+            return;
+        }
+
         // Check if this tool requires approval
         Tool tool = toolRegistry.getTool(toolName);
         boolean needsApproval = requireApproval && tool != null && tool.requiresApproval();
@@ -346,6 +361,56 @@ public class AgentLoop {
             // Execute without approval
             executeToolAndContinue(toolCall, toolCalls, index, conversationHistory, callback);
         }
+    }
+
+    /**
+     * Dispatch a tool call to run asynchronously, bypassing the approval flow.
+     * The user has already opted in via the background_exec agent setting, so re-prompting
+     * for approval would defeat the purpose of fire-and-forget execution.
+     */
+    private void dispatchBackgroundTool(LlmApiService.ToolCall toolCall, JsonObject cleanedArgs,
+                                        List<LlmApiService.ToolCall> toolCalls, int index,
+                                        List<ChatMessage> conversationHistory, AgentCallback callback) {
+        String toolName = toolCall.getName();
+
+        android.content.Context context = null;
+        try {
+            context = toolRegistry.getContext();
+        } catch (Exception e) {
+            Log.w(TAG, "Could not get context for background dispatch, falling back to sync execution");
+            executeToolAndContinue(toolCall, toolCalls, index, conversationHistory, callback);
+            return;
+        }
+
+        final android.content.Context finalContext = context;
+
+        String processId = BackgroundProcessManager.getInstance(finalContext).submit(
+                toolName,
+                cleanedArgs.toString(),
+                () -> toolRegistry.executeTool(toolName, cleanedArgs)
+        );
+
+        Log.d(TAG, "Tool " + toolName + " dispatched to background: process_id=" + processId);
+        callback.onToolCall(toolName, cleanedArgs.toString());
+
+        JsonObject bgResult = new JsonObject();
+        bgResult.addProperty("process_id", processId);
+        bgResult.addProperty("status", "running");
+        bgResult.addProperty("message",
+                "Tool '" + toolName + "' is running in background. "
+                + "Use list_background_processes to check status or kill_background_process to cancel.");
+
+        String resultContent = bgResult.toString();
+        callback.onToolResult(toolName, resultContent);
+
+        ChatMessage toolResultMessage = ChatMessage.createToolResultMessage(
+                toolCall.getId(),
+                toolName,
+                resultContent
+        );
+        conversationHistory.add(toolResultMessage);
+
+        processToolCallsWithApproval(toolCalls, index + 1, conversationHistory, callback);
     }
 
     private void executeToolAndContinue(LlmApiService.ToolCall toolCall, List<LlmApiService.ToolCall> toolCalls,

--- a/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
@@ -33,6 +33,7 @@ public class AgentSettingsFragment extends Fragment {
     private SwitchMaterial switchRequireApproval;
     private TextInputEditText inputShellTimeout;
     private SwitchMaterial switchBackgroundShellAccess;
+    private SwitchMaterial switchBackgroundExec;
     private TextInputEditText inputCustomAllowlist;
     private Button buttonSave;
 
@@ -72,6 +73,7 @@ public class AgentSettingsFragment extends Fragment {
         switchRequireApproval = view.findViewById(R.id.switch_require_approval);
         inputShellTimeout = view.findViewById(R.id.input_shell_timeout);
         switchBackgroundShellAccess = view.findViewById(R.id.switch_background_shell_access);
+        switchBackgroundExec = view.findViewById(R.id.switch_background_exec);
         inputCustomAllowlist = view.findViewById(R.id.input_custom_allowlist);
         buttonSave = view.findViewById(R.id.button_save);
     }
@@ -141,6 +143,7 @@ public class AgentSettingsFragment extends Fragment {
             switchRequireApproval.setChecked(agentConfig.isRequireApproval());
             inputShellTimeout.setText(String.valueOf(agentConfig.getShellTimeout()));
             switchBackgroundShellAccess.setChecked(agentConfig.isBackgroundShellEnabled());
+            switchBackgroundExec.setChecked(agentConfig.isBackgroundExecEnabled());
 
             StringBuilder allowlistText = new StringBuilder();
             for (String path : agentConfig.getCustomAllowlist()) {
@@ -223,6 +226,7 @@ public class AgentSettingsFragment extends Fragment {
         agentConfig.setRequireApproval(switchRequireApproval.isChecked());
         agentConfig.setShellTimeout(shellTimeout);
         agentConfig.setBackgroundShellEnabled(switchBackgroundShellAccess.isChecked());
+        agentConfig.setBackgroundExecEnabled(switchBackgroundExec.isChecked());
         agentConfig.setCustomAllowlist(customAllowlist);
 
 

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -527,8 +527,11 @@ public class ChatFragment extends Fragment {
             public void onToolCall(String toolName, String arguments) {
                 Log.d(TAG, "Tool call: " + toolName + " with args: " + arguments);
 
-
-                String statusMessage = getToolStatusMessage(toolName, arguments);
+                boolean isBackground = arguments.contains("\"background\":true")
+                        || arguments.contains("\"background\": true");
+                String statusMessage = isBackground
+                        ? "Dispatching " + formatToolName(toolName) + " to background..."
+                        : getToolStatusMessage(toolName, arguments);
                 String iterationInfo = "Step " + agentLoop.getIterationCount() + "/20";
                 updateStatus(statusMessage, iterationInfo);
             }
@@ -668,6 +671,10 @@ public class ChatFragment extends Fragment {
                 return "Deleting file...";
             case "file_info":
                 return "Getting file info...";
+            case "kill_background_process":
+                return "Killing background process...";
+            case "list_background_processes":
+                return "Listing background processes...";
             default:
                 return "Executing: " + formatToolName(toolName);
         }

--- a/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
+++ b/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
@@ -11,6 +11,7 @@ public class AgentConfig {
     private boolean requireApproval;
     private int shellTimeout;
     private boolean backgroundShellEnabled; // allow shell/python in background workers
+    private boolean backgroundExecEnabled; // allow agent to dispatch any tool with background=true
     private List<String> customAllowlist; // extra executable paths for relaxed mode
 
     public AgentConfig() {
@@ -27,6 +28,7 @@ public class AgentConfig {
         this.requireApproval = requireApproval;
         this.shellTimeout = shellTimeout;
         this.backgroundShellEnabled = backgroundShellEnabled;
+        this.backgroundExecEnabled = false;
         this.customAllowlist = customAllowlist != null ? new ArrayList<>(customAllowlist) : new ArrayList<>();
     }
 
@@ -97,6 +99,14 @@ public class AgentConfig {
 
     public void setBackgroundShellEnabled(boolean backgroundShellEnabled) {
         this.backgroundShellEnabled = backgroundShellEnabled;
+    }
+
+    public boolean isBackgroundExecEnabled() {
+        return backgroundExecEnabled;
+    }
+
+    public void setBackgroundExecEnabled(boolean backgroundExecEnabled) {
+        this.backgroundExecEnabled = backgroundExecEnabled;
     }
 
     public List<String> getCustomAllowlist() {

--- a/app/src/main/java/io/finett/droidclaw/service/BackgroundProcess.java
+++ b/app/src/main/java/io/finett/droidclaw/service/BackgroundProcess.java
@@ -1,0 +1,104 @@
+package io.finett.droidclaw.service;
+
+import java.util.concurrent.Future;
+
+/**
+ * Represents a single tool execution dispatched asynchronously by the agent.
+ *
+ * Lifecycle: running → completed | failed | killed
+ */
+public class BackgroundProcess {
+
+    public static final String STATUS_RUNNING = "running";
+    public static final String STATUS_COMPLETED = "completed";
+    public static final String STATUS_FAILED = "failed";
+    public static final String STATUS_KILLED = "killed";
+
+    private final String id;
+    private final String toolName;
+    private final String argumentsJson;
+    private final long startedAt;
+
+    private volatile String status;
+    private volatile long finishedAt;
+    private volatile String result;
+    private volatile String error;
+
+    // Not serialized — used internally for cancellation only
+    private Future<?> future;
+
+    public BackgroundProcess(String id, String toolName, String argumentsJson) {
+        this.id = id;
+        this.toolName = toolName;
+        this.argumentsJson = argumentsJson;
+        this.startedAt = System.currentTimeMillis();
+        this.status = STATUS_RUNNING;
+        this.finishedAt = 0;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public String getArgumentsJson() {
+        return argumentsJson;
+    }
+
+    public long getStartedAt() {
+        return startedAt;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public long getFinishedAt() {
+        return finishedAt;
+    }
+
+    public void setFinishedAt(long finishedAt) {
+        this.finishedAt = finishedAt;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public Future<?> getFuture() {
+        return future;
+    }
+
+    public void setFuture(Future<?> future) {
+        this.future = future;
+    }
+
+    public boolean isRunning() {
+        return STATUS_RUNNING.equals(status);
+    }
+
+    /** Duration in milliseconds. Returns 0 while still running. */
+    public long getDurationMs() {
+        if (finishedAt == 0) return 0;
+        return finishedAt - startedAt;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/service/BackgroundProcessManager.java
+++ b/app/src/main/java/io/finett/droidclaw/service/BackgroundProcessManager.java
@@ -1,0 +1,243 @@
+package io.finett.droidclaw.service;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Singleton that manages agent-initiated background tool executions.
+ *
+ * <p>Any tool call tagged with {@code "background": true} by the agent is submitted
+ * here instead of being executed synchronously in the agent loop. The agent receives
+ * a {@code process_id} immediately and can query or cancel it later via the
+ * {@code list_background_processes} and {@code kill_background_process} tools.
+ *
+ * <p>The underlying {@link ThreadPoolExecutor} keeps the process list bounded and
+ * the {@link BackgroundProcessService} foreground service alive while work is in flight.
+ */
+public class BackgroundProcessManager {
+
+    private static final String TAG = "BackgroundProcessManager";
+
+    /** Maximum concurrent background tool executions. */
+    private static final int MAX_CONCURRENT = 8;
+
+    /** Maximum number of completed/failed/killed entries retained in memory. */
+    private static final int MAX_HISTORY = 50;
+
+    private static volatile BackgroundProcessManager instance;
+
+    private final Context appContext;
+    private final ConcurrentHashMap<String, BackgroundProcess> processes = new ConcurrentHashMap<>();
+    private final ThreadPoolExecutor executor;
+
+    private BackgroundProcessManager(Context context) {
+        this.appContext = context.getApplicationContext();
+        this.executor = new ThreadPoolExecutor(
+                2,
+                MAX_CONCURRENT,
+                60L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>()
+        );
+    }
+
+    public static BackgroundProcessManager getInstance(Context context) {
+        if (instance == null) {
+            synchronized (BackgroundProcessManager.class) {
+                if (instance == null) {
+                    instance = new BackgroundProcessManager(context);
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Submit a tool for background execution.
+     *
+     * @param toolName     Name of the tool being executed (for display)
+     * @param argumentsJson JSON string of the arguments (stripped of the "background" key)
+     * @param task         The callable that performs the actual tool execution
+     * @return The {@code process_id} assigned to this execution
+     */
+    public String submit(String toolName, String argumentsJson, Callable<ToolResult> task) {
+        purgeCompletedIfNeeded();
+
+        String processId = UUID.randomUUID().toString();
+        BackgroundProcess process = new BackgroundProcess(processId, toolName, argumentsJson);
+        processes.put(processId, process);
+
+        Future<?> future = executor.submit(() -> {
+            Log.d(TAG, "Background process started: " + processId + " tool=" + toolName);
+            try {
+                ToolResult result = task.call();
+                process.setFinishedAt(System.currentTimeMillis());
+                if (result.isSuccess()) {
+                    process.setResult(result.getContent());
+                    process.setStatus(BackgroundProcess.STATUS_COMPLETED);
+                    Log.d(TAG, "Background process completed: " + processId);
+                } else {
+                    process.setError(result.getError());
+                    process.setStatus(BackgroundProcess.STATUS_FAILED);
+                    Log.w(TAG, "Background process failed: " + processId + " — " + result.getError());
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                process.setFinishedAt(System.currentTimeMillis());
+                process.setStatus(BackgroundProcess.STATUS_KILLED);
+                Log.d(TAG, "Background process interrupted (killed): " + processId);
+            } catch (Exception e) {
+                process.setFinishedAt(System.currentTimeMillis());
+                process.setError(e.getMessage());
+                process.setStatus(BackgroundProcess.STATUS_FAILED);
+                Log.e(TAG, "Background process threw exception: " + processId, e);
+            } finally {
+                updateServiceNotification();
+                stopServiceIfIdle();
+            }
+        });
+
+        process.setFuture(future);
+
+        // Ensure the foreground service is alive while we have running work
+        BackgroundProcessService.ensureRunning(appContext);
+        updateServiceNotification();
+
+        Log.d(TAG, "Submitted background process: " + processId + " tool=" + toolName);
+        return processId;
+    }
+
+    /**
+     * Attempt to kill a running background process.
+     *
+     * @param processId The process to kill
+     * @return {@code true} if the process was found and cancellation was requested
+     */
+    public boolean kill(String processId) {
+        BackgroundProcess process = processes.get(processId);
+        if (process == null) {
+            Log.w(TAG, "Kill requested for unknown process: " + processId);
+            return false;
+        }
+
+        if (!process.isRunning()) {
+            Log.d(TAG, "Kill requested but process already finished: " + processId + " status=" + process.getStatus());
+            return false;
+        }
+
+        Future<?> future = process.getFuture();
+        if (future != null) {
+            future.cancel(true);
+        }
+
+        process.setFinishedAt(System.currentTimeMillis());
+        process.setStatus(BackgroundProcess.STATUS_KILLED);
+        Log.d(TAG, "Kill requested for process: " + processId);
+
+        updateServiceNotification();
+        stopServiceIfIdle();
+        return true;
+    }
+
+    /**
+     * Kill all currently running background processes.
+     * Called from {@link BackgroundProcessService#onDestroy()} when the service is destroyed.
+     */
+    public void killAll() {
+        for (BackgroundProcess process : processes.values()) {
+            if (process.isRunning()) {
+                Future<?> future = process.getFuture();
+                if (future != null) {
+                    future.cancel(true);
+                }
+                process.setFinishedAt(System.currentTimeMillis());
+                process.setStatus(BackgroundProcess.STATUS_KILLED);
+            }
+        }
+        Log.d(TAG, "All background processes killed");
+    }
+
+    /**
+     * Get a single process by ID, or {@code null} if not found.
+     */
+    public BackgroundProcess get(String processId) {
+        return processes.get(processId);
+    }
+
+    /**
+     * Return all processes sorted by start time descending (newest first).
+     */
+    public List<BackgroundProcess> listAll() {
+        List<BackgroundProcess> list = new ArrayList<>(processes.values());
+        Collections.sort(list, (a, b) -> Long.compare(b.getStartedAt(), a.getStartedAt()));
+        return list;
+    }
+
+    /**
+     * Return only processes matching the given status, sorted by start time descending.
+     */
+    public List<BackgroundProcess> listByStatus(String status) {
+        List<BackgroundProcess> list = new ArrayList<>();
+        for (BackgroundProcess p : processes.values()) {
+            if (status.equals(p.getStatus())) {
+                list.add(p);
+            }
+        }
+        Collections.sort(list, (a, b) -> Long.compare(b.getStartedAt(), a.getStartedAt()));
+        return list;
+    }
+
+    /** Number of processes currently in the RUNNING state. */
+    public int runningCount() {
+        int count = 0;
+        for (BackgroundProcess p : processes.values()) {
+            if (p.isRunning()) count++;
+        }
+        return count;
+    }
+
+    // ==================== Internals ====================
+
+    private void purgeCompletedIfNeeded() {
+        List<BackgroundProcess> finished = new ArrayList<>();
+        for (BackgroundProcess p : processes.values()) {
+            if (!p.isRunning()) {
+                finished.add(p);
+            }
+        }
+
+        if (finished.size() <= MAX_HISTORY) return;
+
+        // Remove oldest finished entries beyond the cap
+        Collections.sort(finished, Comparator.comparingLong(BackgroundProcess::getFinishedAt));
+        int toRemove = finished.size() - MAX_HISTORY;
+        for (int i = 0; i < toRemove; i++) {
+            processes.remove(finished.get(i).getId());
+        }
+        Log.d(TAG, "Purged " + toRemove + " old background process records");
+    }
+
+    private void updateServiceNotification() {
+        int running = runningCount();
+        BackgroundProcessService.updateNotification(appContext, running);
+    }
+
+    private void stopServiceIfIdle() {
+        if (runningCount() == 0) {
+            BackgroundProcessService.stopIfIdle(appContext);
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/service/BackgroundProcessService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/BackgroundProcessService.java
@@ -1,0 +1,180 @@
+package io.finett.droidclaw.service;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.PowerManager;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+
+import io.finett.droidclaw.R;
+
+/**
+ * Foreground service that keeps background tool executions alive.
+ *
+ * <p>Started by {@link BackgroundProcessManager} when the first background process is submitted
+ * and stopped automatically when all processes finish or are killed.
+ *
+ * <p>Holds a {@link PowerManager.WakeLock} to prevent the CPU from sleeping mid-execution.
+ */
+public class BackgroundProcessService extends Service {
+
+    private static final String TAG = "BackgroundProcessService";
+
+    static final String CHANNEL_ID = "droidclaw_bg_exec";
+    private static final int NOTIFICATION_ID = 8801;
+
+    static final String ACTION_UPDATE_NOTIFICATION = "io.finett.droidclaw.BG_UPDATE";
+    static final String ACTION_STOP = "io.finett.droidclaw.BG_STOP";
+    static final String EXTRA_RUNNING_COUNT = "running_count";
+
+    private PowerManager.WakeLock wakeLock;
+    private NotificationManager notificationManager;
+
+    // ==================== Lifecycle ====================
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        createNotificationChannel();
+        acquireWakeLock();
+        Log.d(TAG, "BackgroundProcessService created");
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null && ACTION_STOP.equals(intent.getAction())) {
+            Log.d(TAG, "Stop action received — killing all processes and stopping service");
+            BackgroundProcessManager.getInstance(this).killAll();
+            stopForeground(true);
+            stopSelf();
+            return START_NOT_STICKY;
+        }
+
+        int runningCount = (intent != null)
+                ? intent.getIntExtra(EXTRA_RUNNING_COUNT, 0)
+                : 0;
+
+        startForeground(NOTIFICATION_ID, buildNotification(runningCount));
+
+        if (intent != null && ACTION_UPDATE_NOTIFICATION.equals(intent.getAction())) {
+            // Just a notification refresh — no new work to start
+            return START_STICKY;
+        }
+
+        Log.d(TAG, "BackgroundProcessService started — " + runningCount + " process(es) running");
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        // Safety net: kill any remaining processes if the OS tears down the service
+        BackgroundProcessManager.getInstance(this).killAll();
+        releaseWakeLock();
+        Log.d(TAG, "BackgroundProcessService destroyed");
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    // ==================== Static helpers called by BackgroundProcessManager ====================
+
+    /**
+     * Start (or no-op if already running) the foreground service.
+     * Called when the first background process is submitted.
+     */
+    public static void ensureRunning(Context context) {
+        Intent intent = new Intent(context, BackgroundProcessService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
+    }
+
+    /**
+     * Push an updated notification to reflect the current running count.
+     * Safe to call even when the service is not running (it will start it).
+     */
+    public static void updateNotification(Context context, int runningCount) {
+        Intent intent = new Intent(context, BackgroundProcessService.class);
+        intent.setAction(ACTION_UPDATE_NOTIFICATION);
+        intent.putExtra(EXTRA_RUNNING_COUNT, runningCount);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
+    }
+
+    /**
+     * Stop the service if there are no running processes left.
+     * Called by {@link BackgroundProcessManager} after each process finishes.
+     */
+    public static void stopIfIdle(Context context) {
+        Intent intent = new Intent(context, BackgroundProcessService.class);
+        intent.setAction(ACTION_STOP);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
+    }
+
+    // ==================== Notification ====================
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID,
+                    "DroidClaw Background Tasks",
+                    NotificationManager.IMPORTANCE_LOW
+            );
+            channel.setDescription("Shows active background tool executions");
+            channel.setShowBadge(false);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    private Notification buildNotification(int runningCount) {
+        String title = runningCount == 1
+                ? "DroidClaw — 1 task running in background"
+                : "DroidClaw — " + runningCount + " tasks running in background";
+
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.ic_popup_sync)
+                .setContentTitle(title)
+                .setContentText("Tap to open DroidClaw")
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true)
+                .setAutoCancel(false)
+                .build();
+    }
+
+    // ==================== WakeLock ====================
+
+    private void acquireWakeLock() {
+        PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        if (pm != null) {
+            wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "DroidClaw:BgExec");
+            wakeLock.acquire();
+        }
+    }
+
+    private void releaseWakeLock() {
+        if (wakeLock != null && wakeLock.isHeld()) {
+            wakeLock.release();
+            wakeLock = null;
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -35,6 +35,8 @@ import io.finett.droidclaw.tool.impl.ResumeTaskTool;
 import io.finett.droidclaw.tool.impl.DeleteTaskTool;
 import io.finett.droidclaw.tool.impl.ViewTaskHistoryTool;
 import io.finett.droidclaw.tool.impl.TaskStatsTool;
+import io.finett.droidclaw.tool.impl.KillBackgroundProcessTool;
+import io.finett.droidclaw.tool.impl.ListBackgroundProcessesTool;
 import io.finett.droidclaw.tool.impl.SetupHeartbeatTool;
 import io.finett.droidclaw.tool.impl.SubmitNotificationTool;
 import io.finett.droidclaw.util.SettingsManager;
@@ -117,6 +119,9 @@ public class ToolRegistry {
         registerTool(new SetupHeartbeatTool(context));
 
         registerTool(new SubmitNotificationTool(context));
+
+        registerTool(new KillBackgroundProcessTool(context));
+        registerTool(new ListBackgroundProcessesTool(context));
     }
 
     /**
@@ -180,14 +185,58 @@ public class ToolRegistry {
     public JsonArray getToolDefinitions() {
         JsonArray definitions = new JsonArray();
         boolean shellEnabled = isShellAccessEnabled();
+        boolean bgExecEnabled = settingsManager != null
+                && settingsManager.getAgentConfig().isBackgroundExecEnabled();
 
         for (Tool tool : tools.values()) {
             if (requiresShellAccess(tool.getName()) && !shellEnabled) {
                 continue;
             }
-            definitions.add(tool.getDefinition().toJson());
+            JsonObject toolJson = tool.getDefinition().toJson();
+
+            // Inject "background" boolean property into every tool's schema
+            // so the LLM can request async execution when backgroundExecEnabled is on
+            if (bgExecEnabled) {
+                injectBackgroundParam(toolJson);
+            }
+
+            definitions.add(toolJson);
         }
         return definitions;
+    }
+
+    /**
+     * Inject an optional "background" boolean parameter into a tool definition's JSON schema.
+     * This allows the LLM to pass {@code "background": true} in strict/structured output mode
+     * where additionalProperties is false.
+     */
+    private void injectBackgroundParam(JsonObject toolJson) {
+        try {
+            JsonObject function = toolJson.getAsJsonObject("function");
+            if (function == null) return;
+
+            JsonObject parameters = function.getAsJsonObject("parameters");
+            if (parameters == null) return;
+
+            JsonObject properties = parameters.getAsJsonObject("properties");
+            if (properties == null) return;
+
+            // Skip tools that already manage background processes
+            String name = function.has("name") ? function.get("name").getAsString() : "";
+            if ("kill_background_process".equals(name)
+                    || "list_background_processes".equals(name)) {
+                return;
+            }
+
+            JsonObject bgProp = new JsonObject();
+            bgProp.addProperty("type", "boolean");
+            bgProp.addProperty("description",
+                    "Set to true to run this tool asynchronously in the background. "
+                    + "Returns a process_id immediately. Default: false.");
+            properties.add("background", bgProp);
+        } catch (Exception e) {
+            // Schema injection is best-effort — do not break tool registration
+        }
     }
 
     public ToolResult executeTool(String toolName, JsonObject arguments) {
@@ -217,6 +266,10 @@ public class ToolRegistry {
 
     public File getWorkspaceRoot() {
         return workspaceManager.getWorkspaceRoot();
+    }
+
+    public Context getContext() {
+        return context;
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/KillBackgroundProcessTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/KillBackgroundProcessTool.java
@@ -1,0 +1,101 @@
+package io.finett.droidclaw.tool.impl;
+
+import android.content.Context;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.service.BackgroundProcess;
+import io.finett.droidclaw.service.BackgroundProcessManager;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Kills a running background process by its process_id.
+ *
+ * <p>Only processes in the "running" state can be killed. Processes that have already
+ * completed, failed, or been killed return a descriptive error.
+ */
+public class KillBackgroundProcessTool implements Tool {
+
+    private static final String TOOL_NAME = "kill_background_process";
+
+    private final Context context;
+
+    public KillBackgroundProcessTool(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return true;
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        String processId = arguments.has("process_id")
+                ? arguments.get("process_id").getAsString() : "unknown";
+        return "Kill background process: " + processId;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addString("process_id", "The ID of the background process to kill", true)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "Kill a running background process by its process_id. "
+                + "Only processes with status 'running' can be killed. "
+                + "Returns whether the kill was successful.",
+                parameters
+        );
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        if (!arguments.has("process_id")) {
+            return ToolResult.error("Missing required parameter: process_id");
+        }
+
+        String processId = arguments.get("process_id").getAsString().trim();
+        if (processId.isEmpty()) {
+            return ToolResult.error("process_id must not be empty");
+        }
+
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+        BackgroundProcess process = manager.get(processId);
+
+        if (process == null) {
+            return ToolResult.error("No background process found with id: " + processId);
+        }
+
+        if (!process.isRunning()) {
+            JsonObject result = new JsonObject();
+            result.addProperty("killed", false);
+            result.addProperty("process_id", processId);
+            result.addProperty("status", process.getStatus());
+            result.addProperty("message", "Process is not running (status: " + process.getStatus() + ")");
+            return ToolResult.success(result);
+        }
+
+        boolean killed = manager.kill(processId);
+
+        JsonObject result = new JsonObject();
+        result.addProperty("killed", killed);
+        result.addProperty("process_id", processId);
+        result.addProperty("status", killed
+                ? BackgroundProcess.STATUS_KILLED
+                : process.getStatus());
+        if (!killed) {
+            result.addProperty("message", "Kill request sent but process may have finished concurrently");
+        }
+        return ToolResult.success(result);
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ListBackgroundProcessesTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ListBackgroundProcessesTool.java
@@ -1,0 +1,112 @@
+package io.finett.droidclaw.tool.impl;
+
+import android.content.Context;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+import io.finett.droidclaw.service.BackgroundProcess;
+import io.finett.droidclaw.service.BackgroundProcessManager;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Lists all background processes managed by the agent, optionally filtered by status.
+ *
+ * <p>Returns an array of process records including their ID, tool name, status,
+ * timing info, and a preview of the result/error.
+ */
+public class ListBackgroundProcessesTool implements Tool {
+
+    private static final String TOOL_NAME = "list_background_processes";
+    private static final int RESULT_PREVIEW_LENGTH = 200;
+
+    private final Context context;
+
+    public ListBackgroundProcessesTool(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return false;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addString("status",
+                        "Filter by status: 'running', 'completed', 'failed', 'killed', or 'all'. Default: 'all'",
+                        false)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "List background processes that were dispatched with background=true. "
+                + "Returns each process's ID, tool name, status, timing info, and "
+                + "a preview of the result. Use this to check on long-running tasks. "
+                + "Optionally filter by status.",
+                parameters
+        );
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(context);
+
+        String statusFilter = "all";
+        if (arguments != null && arguments.has("status")
+                && !arguments.get("status").isJsonNull()) {
+            statusFilter = arguments.get("status").getAsString().trim().toLowerCase();
+        }
+
+        List<BackgroundProcess> processes;
+        if ("all".equals(statusFilter)) {
+            processes = manager.listAll();
+        } else {
+            processes = manager.listByStatus(statusFilter);
+        }
+
+        JsonArray array = new JsonArray();
+        for (BackgroundProcess p : processes) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("process_id", p.getId());
+            obj.addProperty("tool_name", p.getToolName());
+            obj.addProperty("status", p.getStatus());
+            obj.addProperty("started_at", p.getStartedAt());
+
+            if (p.getFinishedAt() > 0) {
+                obj.addProperty("finished_at", p.getFinishedAt());
+                obj.addProperty("duration_ms", p.getDurationMs());
+            }
+
+            if (p.getResult() != null) {
+                String preview = p.getResult().length() > RESULT_PREVIEW_LENGTH
+                        ? p.getResult().substring(0, RESULT_PREVIEW_LENGTH) + "..."
+                        : p.getResult();
+                obj.addProperty("result_preview", preview);
+            }
+
+            if (p.getError() != null) {
+                obj.addProperty("error", p.getError());
+            }
+
+            array.add(obj);
+        }
+
+        JsonObject result = new JsonObject();
+        result.addProperty("total", processes.size());
+        result.addProperty("running_count", manager.runningCount());
+        result.add("processes", array);
+
+        return ToolResult.success(result);
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -227,6 +227,7 @@ public class SettingsManager {
         config.setRequireApproval(json.optBoolean("requireApproval", true));
         config.setShellTimeout(json.optInt("shellTimeout", 30));
         config.setBackgroundShellEnabled(json.optBoolean("backgroundShellEnabled", false));
+        config.setBackgroundExecEnabled(json.optBoolean("backgroundExecEnabled", false));
 
         List<String> customAllowlist = new ArrayList<>();
         if (json.has("customAllowlist")) {
@@ -315,6 +316,7 @@ public class SettingsManager {
         json.put("requireApproval", config.isRequireApproval());
         json.put("shellTimeout", config.getShellTimeout());
         json.put("backgroundShellEnabled", config.isBackgroundShellEnabled());
+        json.put("backgroundExecEnabled", config.isBackgroundExecEnabled());
 
         JSONArray allowlistArr = new JSONArray();
         for (String path : config.getCustomAllowlist()) {

--- a/app/src/main/res/layout/fragment_agent_settings.xml
+++ b/app/src/main/res/layout/fragment_agent_settings.xml
@@ -133,6 +133,42 @@
 
         </LinearLayout>
 
+        <!-- Background Tool Execution Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/background_exec"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/background_exec_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_background_exec"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
         <!-- Custom Allowlist -->
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,8 @@
     <string name="shell_timeout_description">Command execution limit</string>
     <string name="background_shell_access">Shell in Background Tasks</string>
     <string name="background_shell_access_description">Allow cron jobs and workers to run shell/Python commands</string>
+    <string name="background_exec">Background Tool Execution</string>
+    <string name="background_exec_description">Allow the agent to run any tool asynchronously with background=true</string>
     <string name="custom_allowlist">Custom Command Allowlist</string>
     <string name="custom_allowlist_description">Extra executable paths allowed in Relaxed mode (one per line)</string>
 

--- a/app/src/test/java/io/finett/droidclaw/model/AgentConfigTest.java
+++ b/app/src/test/java/io/finett/droidclaw/model/AgentConfigTest.java
@@ -56,6 +56,7 @@ public class AgentConfigTest {
         assertTrue(defaults.isRequireApproval());
         assertEquals(30, defaults.getShellTimeout());
         assertFalse(defaults.isBackgroundShellEnabled());
+        assertFalse(defaults.isBackgroundExecEnabled());
         assertTrue(defaults.getCustomAllowlist().isEmpty());
     }
 
@@ -299,6 +300,20 @@ public class AgentConfigTest {
         assertTrue(config.isBackgroundShellEnabled());
         config.setBackgroundShellEnabled(false);
         assertFalse(config.isBackgroundShellEnabled());
+    }
+
+    @Test
+    public void setBackgroundExecEnabled_updatesValue() {
+        config.setBackgroundExecEnabled(true);
+        assertTrue(config.isBackgroundExecEnabled());
+        config.setBackgroundExecEnabled(false);
+        assertFalse(config.isBackgroundExecEnabled());
+    }
+
+    @Test
+    public void defaultConstructor_backgroundExecEnabled_isFalse() {
+        AgentConfig c = new AgentConfig();
+        assertFalse(c.isBackgroundExecEnabled());
     }
 
     @Test

--- a/app/src/test/java/io/finett/droidclaw/tool/ToolRegistryTest.java
+++ b/app/src/test/java/io/finett/droidclaw/tool/ToolRegistryTest.java
@@ -45,15 +45,16 @@ public class ToolRegistryTest {
         int toolCount = toolRegistry.getToolCount();
         // Without SettingsManager: sandboxMode="strict", shellEnabled=true but strict blocks
         // shell/python and also mutating file tools (write/edit/delete).
-        // Read-only file tools (4) + automation/notification tools (10) = 14.
-        assertEquals("Should have exactly 14 tools in strict mode without settings", 14, toolCount);
+        // Read-only file tools (4) + automation/notification tools (10)
+        // + background process tools (2) = 16.
+        assertEquals("Should have exactly 16 tools in strict mode without settings", 16, toolCount);
     }
 
     @Test
     public void testGetAllTools() {
         List<Tool> tools = toolRegistry.getAllTools();
         assertNotNull("Tools list should not be null", tools);
-        assertEquals("Should return all registered tools", 14, tools.size());
+        assertEquals("Should return all registered tools", 16, tools.size());
     }
 
     @Test
@@ -142,7 +143,7 @@ public class ToolRegistryTest {
     public void testGetToolDefinitions() {
         JsonArray definitions = toolRegistry.getToolDefinitions();
         assertNotNull("Tool definitions should not be null", definitions);
-        assertEquals("Should have definitions for all tools in strict mode", 14, definitions.size());
+        assertEquals("Should have definitions for all tools in strict mode", 16, definitions.size());
         
         JsonObject firstDef = definitions.get(0).getAsJsonObject();
         assertTrue("Should have 'type' field", firstDef.has("type"));
@@ -264,6 +265,6 @@ public class ToolRegistryTest {
         t1.join();
         t2.join();
 
-        assertEquals("Tool count should remain consistent", 14, toolRegistry.getToolCount());
+        assertEquals("Tool count should remain consistent", 16, toolRegistry.getToolCount());
     }
 }

--- a/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
@@ -119,6 +119,22 @@ public class SettingsManagerTest {
         assertEquals(20, config.getMaxIterations());
         assertTrue(config.isRequireApproval());
         assertEquals(30, config.getShellTimeout());
+        assertFalse(config.isBackgroundExecEnabled());
+    }
+
+    @Test
+    public void backgroundExecEnabled_persistsAcrossInstances() {
+        AgentConfig config = settingsManager.getAgentConfig();
+        config.setBackgroundExecEnabled(true);
+        settingsManager.setAgentConfig(config);
+
+        SettingsManager newInstance = new SettingsManager(context);
+        assertTrue(newInstance.getAgentConfig().isBackgroundExecEnabled());
+    }
+
+    @Test
+    public void backgroundExecEnabled_defaultIsFalse() {
+        assertFalse(settingsManager.getAgentConfig().isBackgroundExecEnabled());
     }
 
     @Test


### PR DESCRIPTION
Allow the agent to dispatch tool calls asynchronously when background=true is requested and background execution is enabled.

Add a background process manager, foreground service, and process model to track running, completed, failed, and killed tasks while keeping long-running work alive.

Register tools to list and kill background processes, expose the feature through agent settings and chat status messages, and persist the new background execution flag with test coverage