### PR TITLE
feat(chat): add search and export/import

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/MainActivity.java
+++ b/app/src/main/java/io/finett/droidclaw/MainActivity.java
@@ -531,6 +531,32 @@ public class MainActivity extends AppCompatActivity {
         return apiService;
     }
 
+    public String createNewSession(String title) {
+        ChatSession newSession = new ChatSession(
+                java.util.UUID.randomUUID().toString(),
+                title != null && !title.isEmpty() ? title : getString(R.string.new_chat),
+                System.currentTimeMillis()
+        );
+        chatSessions.add(0, newSession);
+        chatRepository.saveSessions(chatSessions);
+        chatSessionAdapter.submitList(new ArrayList<>(chatSessions));
+
+        currentSessionId = newSession.getId();
+        if (navController != null) {
+            Bundle args = new Bundle();
+            args.putString(ChatFragment.ARG_SESSION_ID, currentSessionId);
+            navController.navigate(R.id.chatFragment, args);
+        }
+        Log.d(TAG, "createNewSession: " + newSession.getId() + " title=" + newSession.getTitle());
+        return newSession.getId();
+    }
+
+    public void openDrawer() {
+        if (drawerLayout != null) {
+            drawerLayout.openDrawer(GravityCompat.START);
+        }
+    }
+
     @Override
     public boolean onSupportNavigateUp() {
         if (navController != null) {

--- a/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
+++ b/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
@@ -2,7 +2,11 @@ package io.finett.droidclaw.adapter;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.net.Uri;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.style.BackgroundColorSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,6 +42,11 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
     private static final int VIEW_TYPE_ATTACHMENT = 6;
 
     private final List<ChatMessage> messages = new ArrayList<>();
+
+    // Highlight color for search matches
+    private static final int HIGHLIGHT_COLOR = Color.argb(160, 255, 235, 59);
+
+    private String searchQuery = null;
 
     @Override
     public int getItemViewType(int position) {
@@ -89,12 +98,40 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
     @Override
     public void onBindViewHolder(@NonNull MessageViewHolder holder, int position) {
         ChatMessage message = messages.get(position);
-        holder.bind(message);
+        holder.bind(message, this);
     }
 
     @Override
     public int getItemCount() {
         return messages.size();
+    }
+
+    public void setSearchQuery(String query) {
+        this.searchQuery = (query != null && !query.isEmpty()) ? query : null;
+        notifyDataSetChanged();
+    }
+
+    public String getSearchQuery() {
+        return searchQuery;
+    }
+
+    SpannableString highlight(String text) {
+        if (text == null) return new SpannableString("");
+        SpannableString spannable = new SpannableString(text);
+        if (searchQuery == null || searchQuery.isEmpty()) {
+            return spannable;
+        }
+        Pattern pattern = Pattern.compile(Pattern.quote(searchQuery),
+                Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            spannable.setSpan(
+                    new BackgroundColorSpan(HIGHLIGHT_COLOR),
+                    matcher.start(),
+                    matcher.end(),
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+        return spannable;
     }
 
     public void addMessage(ChatMessage message) {
@@ -130,7 +167,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
             super(itemView);
         }
 
-        abstract void bind(ChatMessage message);
+        abstract void bind(ChatMessage message, ChatAdapter adapter);
     }
 
     static class UserMessageViewHolder extends MessageViewHolder {
@@ -146,9 +183,12 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         }
 
         @Override
-        void bind(ChatMessage message) {
+        void bind(ChatMessage message, ChatAdapter adapter) {
             String content = message.getContent();
-            if (content != null && MarkdownRenderer.containsMarkdown(content)) {
+            if (adapter.searchQuery != null && content != null
+                    && !MarkdownRenderer.containsMarkdown(content)) {
+                messageText.setText(adapter.highlight(content));
+            } else if (content != null && MarkdownRenderer.containsMarkdown(content)) {
                 MarkdownRenderer.render(context, messageText, content);
             } else {
                 messageText.setText(content);
@@ -231,9 +271,12 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         }
 
         @Override
-        void bind(ChatMessage message) {
+        void bind(ChatMessage message, ChatAdapter adapter) {
             String content = message.getContent();
-            if (content != null) {
+            if (adapter.searchQuery != null && content != null
+                    && !MarkdownRenderer.containsMarkdown(content)) {
+                messageText.setText(adapter.highlight(content));
+            } else if (content != null) {
                 MarkdownRenderer.render(context, messageText, content);
             } else {
                 messageText.setText("");
@@ -254,7 +297,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         }
 
         @Override
-        void bind(ChatMessage message) {
+        void bind(ChatMessage message, ChatAdapter adapter) {
             if (message.getToolCalls() != null && !message.getToolCalls().isEmpty()) {
                 LlmApiService.ToolCall firstToolCall = message.getToolCalls().get(0);
                 String toolName = firstToolCall.getName();
@@ -272,7 +315,9 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
                     argsBuilder.append(formatArguments(toolCall.getArguments().toString()))
                             .append("\n");
                 }
-                toolCallArgs.setText(argsBuilder.toString().trim());
+                String argsText = argsBuilder.toString().trim();
+                toolCallArgs.setText(adapter.searchQuery != null
+                        ? adapter.highlight(argsText) : argsText);
             }
         }
 
@@ -339,7 +384,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         }
 
         @Override
-        void bind(ChatMessage message) {
+        void bind(ChatMessage message, ChatAdapter adapter) {
             String content = message.getContent();
             String toolName = message.getToolName();
             Context context = itemView.getContext();
@@ -356,7 +401,9 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
             toolResultIcon.setImageResource(isError ? R.drawable.ic_status_error : R.drawable.ic_status_success);
 
             if (content != null) {
-                if (MarkdownRenderer.containsMarkdown(content)) {
+                if (adapter.searchQuery != null && !MarkdownRenderer.containsMarkdown(content)) {
+                    toolResultContent.setText(adapter.highlight(content));
+                } else if (MarkdownRenderer.containsMarkdown(content)) {
                     MarkdownRenderer.render(context, toolResultContent, content);
                 } else {
                     toolResultContent.setText(content);
@@ -545,7 +592,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         }
 
         @Override
-        void bind(ChatMessage message) {
+        void bind(ChatMessage message, ChatAdapter adapter) {
             Context context = itemView.getContext();
 
             String contextType = message.getContextType();
@@ -562,7 +609,9 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
 
             String content = message.getContent();
             if (content != null) {
-                if (MarkdownRenderer.containsMarkdown(content)) {
+                if (adapter.searchQuery != null && !MarkdownRenderer.containsMarkdown(content)) {
+                    contextCardContent.setText(adapter.highlight(content));
+                } else if (MarkdownRenderer.containsMarkdown(content)) {
                     MarkdownRenderer.render(context, contextCardContent, content);
                 } else {
                     contextCardContent.setText(content);
@@ -645,7 +694,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         }
 
         @Override
-        void bind(ChatMessage message) {
+        void bind(ChatMessage message, ChatAdapter adapter) {
             String rawDisplayName = message.getDisplayName();
             final String mimeType = message.getFileMimeType();
             final String filePath = message.getFilePath();

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -1,12 +1,19 @@
 package io.finett.droidclaw.fragment;
 
 import android.app.AlertDialog;
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.AnimationUtils;
 import android.widget.EditText;
 import android.widget.HorizontalScrollView;
 import android.widget.ImageButton;
@@ -28,6 +35,8 @@ import com.google.android.material.chip.Chip;
 import com.google.gson.JsonObject;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,18 +51,23 @@ import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.filesystem.FileUploadManager;
 import io.finett.droidclaw.filesystem.WorkspaceManager;
 import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.ChatSession;
 import io.finett.droidclaw.model.FileAttachment;
 import io.finett.droidclaw.model.TaskResult;
 import io.finett.droidclaw.repository.ChatRepository;
 import io.finett.droidclaw.repository.MemoryRepository;
 import io.finett.droidclaw.service.ChatContinuationService;
 import io.finett.droidclaw.tool.ToolRegistry;
+import io.finett.droidclaw.util.ChatExportManager;
+import io.finett.droidclaw.util.ChatImportManager;
+import io.finett.droidclaw.util.ChatSearchManager;
 import io.finett.droidclaw.util.SettingsManager;
 
 public class ChatFragment extends Fragment {
     private static final String TAG = "ChatFragment";
     public static final String ARG_SESSION_ID = "session_id";
 
+    // Chat UI
     private RecyclerView recyclerView;
     private EditText messageInput;
     private ImageButton sendButton;
@@ -64,6 +78,16 @@ public class ChatFragment extends Fragment {
     private ProgressBar progressBar;
     private TextView statusText;
     private TextView statusSubText;
+
+    // Search bar views (from included layout)
+    private View searchBar;
+    private EditText searchInput;
+    private TextView searchResultCount;
+    private ImageButton searchPrevButton;
+    private ImageButton searchNextButton;
+    private ImageButton searchCloseButton;
+
+    // Core components
     private ChatAdapter chatAdapter;
     private LlmApiService apiService;
     private SettingsManager settingsManager;
@@ -78,13 +102,31 @@ public class ChatFragment extends Fragment {
     private String currentSessionId;
     private TaskResult pendingTaskResult;
 
+    // Search state
+    private ChatSearchManager chatSearchManager;
+    private List<ChatSearchManager.SearchResult> searchResults = new ArrayList<>();
+    private int currentSearchIndex = -1;
+
+    // Export / import managers
+    private ChatExportManager chatExportManager;
+    private ChatImportManager chatImportManager;
+
+    // Pending attachments
     private List<FileAttachment> pendingAttachments = new ArrayList<>();
 
+    // Activity result launchers
     private ActivityResultLauncher<String> filePickerLauncher;
+    private ActivityResultLauncher<String> importPickerLauncher;
+
+    // Export launchers (SAF)
+    private ActivityResultLauncher<String> exportMarkdownLauncher;
+    private ActivityResultLauncher<String> exportJsonLauncher;
+    private ActivityResultLauncher<String> exportPdfLauncher;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
 
         settingsManager = new SettingsManager(requireContext());
         chatRepository = new ChatRepository(requireContext());
@@ -97,7 +139,6 @@ public class ChatFragment extends Fragment {
             apiService = new LlmApiService(settingsManager);
         }
 
-
         Bundle taskArgs = getArguments();
         if (taskArgs != null) {
             pendingTaskResult = (TaskResult) taskArgs.getSerializable(ZenResultFragment.ARG_TASK_RESULT);
@@ -105,7 +146,6 @@ public class ChatFragment extends Fragment {
                 Log.d(TAG, "Received task result for continuation: " + pendingTaskResult.getId());
             }
         }
-
 
         workspaceManager = new WorkspaceManager(requireContext());
         try {
@@ -115,9 +155,7 @@ public class ChatFragment extends Fragment {
             Log.e(TAG, "Failed to initialize workspace", e);
         }
 
-
         fileUploadManager = new FileUploadManager(requireContext(), workspaceManager);
-
 
         filePickerLauncher = registerForActivityResult(
             new ActivityResultContracts.GetContent(),
@@ -128,25 +166,51 @@ public class ChatFragment extends Fragment {
             }
         );
 
+        // Import file picker – accepts text/* files
+        importPickerLauncher = registerForActivityResult(
+            new ActivityResultContracts.GetContent(),
+            uri -> {
+                if (uri != null) {
+                    handleImportFile(uri);
+                }
+            }
+        );
+
+        // Export launchers using SAF CREATE_DOCUMENT
+        exportMarkdownLauncher = registerForActivityResult(
+            new ActivityResultContracts.CreateDocument("text/markdown"),
+            uri -> {
+                if (uri != null) runExport(uri, "md");
+            }
+        );
+        exportJsonLauncher = registerForActivityResult(
+            new ActivityResultContracts.CreateDocument("application/json"),
+            uri -> {
+                if (uri != null) runExport(uri, "json");
+            }
+        );
+        exportPdfLauncher = registerForActivityResult(
+            new ActivityResultContracts.CreateDocument("application/pdf"),
+            uri -> {
+                if (uri != null) runExport(uri, "pdf");
+            }
+        );
+
         identityManager = new IdentityManager(requireContext(), workspaceManager);
-
-
         memoryRepository = new MemoryRepository(workspaceManager);
-
 
         int contextWindow = getModelContextWindow();
         ConversationSummarizer summarizer = new ConversationSummarizer(apiService, memoryRepository, contextWindow);
         MemoryContextBuilder memoryContext = new MemoryContextBuilder(memoryRepository);
 
-
         toolRegistry = new ToolRegistry(requireContext(), settingsManager);
-
-
         agentLoop = new AgentLoop(apiService, toolRegistry, settingsManager, summarizer, memoryContext);
-
 
         loadIdentityContext();
 
+        chatSearchManager = new ChatSearchManager();
+        chatExportManager = new ChatExportManager(requireContext());
+        chatImportManager = new ChatImportManager();
 
         Bundle args = getArguments();
         if (args != null) {
@@ -167,13 +231,13 @@ public class ChatFragment extends Fragment {
             Log.d(TAG, "Loaded identity context: " + identityMessages.size() + " message(s)");
         } catch (Exception e) {
             Log.w(TAG, "Failed to load identity context, continuing without it", e);
-
         }
     }
 
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_chat, container, false);
     }
 
@@ -184,19 +248,28 @@ public class ChatFragment extends Fragment {
         initViews(view);
         setupRecyclerView();
         setupClickListeners();
+        setupSearchBar();
     }
 
     private void initViews(View view) {
-        recyclerView = view.findViewById(R.id.recyclerView);
-        messageInput = view.findViewById(R.id.messageInput);
-        sendButton = view.findViewById(R.id.sendButton);
-        attachButton = view.findViewById(R.id.attachButton);
-        statusContainer = view.findViewById(R.id.statusContainer);
+        recyclerView           = view.findViewById(R.id.recyclerView);
+        messageInput           = view.findViewById(R.id.messageInput);
+        sendButton             = view.findViewById(R.id.sendButton);
+        attachButton           = view.findViewById(R.id.attachButton);
+        statusContainer        = view.findViewById(R.id.statusContainer);
         attachmentBarContainer = view.findViewById(R.id.attachmentBarContainer);
-        attachmentBar = view.findViewById(R.id.attachmentBar);
-        progressBar = view.findViewById(R.id.progressBar);
-        statusText = view.findViewById(R.id.statusText);
-        statusSubText = view.findViewById(R.id.statusSubText);
+        attachmentBar          = view.findViewById(R.id.attachmentBar);
+        progressBar            = view.findViewById(R.id.progressBar);
+        statusText             = view.findViewById(R.id.statusText);
+        statusSubText          = view.findViewById(R.id.statusSubText);
+
+        // Search bar (included layout)
+        searchBar         = view.findViewById(R.id.searchBar);
+        searchInput       = searchBar.findViewById(R.id.searchInput);
+        searchResultCount = searchBar.findViewById(R.id.searchResultCount);
+        searchPrevButton  = searchBar.findViewById(R.id.searchPrevButton);
+        searchNextButton  = searchBar.findViewById(R.id.searchNextButton);
+        searchCloseButton = searchBar.findViewById(R.id.searchCloseButton);
     }
 
     private void setupRecyclerView() {
@@ -207,9 +280,304 @@ public class ChatFragment extends Fragment {
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(chatAdapter);
 
-
         loadChatHistory();
     }
+
+    private void setupSearchBar() {
+        searchInput.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {
+                performSearch(s.toString());
+            }
+            @Override public void afterTextChanged(Editable s) {}
+        });
+
+        searchPrevButton.setOnClickListener(v -> navigateSearch(false));
+        searchNextButton.setOnClickListener(v -> navigateSearch(true));
+        searchCloseButton.setOnClickListener(v -> hideSearchBar());
+    }
+
+
+    @Override
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_chat, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        int id = item.getItemId();
+        if (id == R.id.action_search) {
+            toggleSearchBar();
+            return true;
+        } else if (id == R.id.action_export) {
+            showExportDialog();
+            return true;
+        } else if (id == R.id.action_import) {
+            showImportDialog();
+            return true;
+        } else if (id == R.id.action_chats) {
+            if (requireActivity() instanceof MainActivity) {
+                ((MainActivity) requireActivity()).openDrawer();
+            }
+            return true;
+        } else if (id == R.id.action_files) {
+            Navigation.findNavController(requireView()).navigate(R.id.fileBrowserFragment);
+            return true;
+        } else if (id == R.id.action_settings) {
+            Navigation.findNavController(requireView()).navigate(R.id.settingsFragment);
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+
+    private void toggleSearchBar() {
+        if (searchBar.getVisibility() == View.VISIBLE) {
+            hideSearchBar();
+        } else {
+            showSearchBar();
+        }
+    }
+
+    private void showSearchBar() {
+        searchBar.setVisibility(View.VISIBLE);
+        searchBar.startAnimation(AnimationUtils.loadAnimation(requireContext(), android.R.anim.slide_in_left));
+        searchInput.requestFocus();
+        searchInput.setText("");
+    }
+
+    private void hideSearchBar() {
+        searchBar.setVisibility(View.GONE);
+        searchInput.setText("");
+        searchResults.clear();
+        currentSearchIndex = -1;
+        chatAdapter.setSearchQuery(null);
+        updateSearchResultCount();
+    }
+
+    private void performSearch(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            searchResults.clear();
+            currentSearchIndex = -1;
+            chatAdapter.setSearchQuery(null);
+            updateSearchResultCount();
+            return;
+        }
+
+        chatAdapter.setSearchQuery(query);
+        searchResults = chatSearchManager.search(chatAdapter.getMessages(), query);
+
+        if (!searchResults.isEmpty()) {
+            currentSearchIndex = 0;
+            scrollToSearchResult(searchResults.get(0).position);
+        } else {
+            currentSearchIndex = -1;
+        }
+        updateSearchResultCount();
+    }
+
+    private void navigateSearch(boolean forward) {
+        if (searchResults.isEmpty()) return;
+
+        if (forward) {
+            currentSearchIndex = (currentSearchIndex + 1) % searchResults.size();
+        } else {
+            currentSearchIndex = (currentSearchIndex - 1 + searchResults.size()) % searchResults.size();
+        }
+        scrollToSearchResult(searchResults.get(currentSearchIndex).position);
+        updateSearchResultCount();
+    }
+
+    private void scrollToSearchResult(int position) {
+        recyclerView.scrollToPosition(position);
+    }
+
+    private void updateSearchResultCount() {
+        if (searchResults.isEmpty()) {
+            if (searchInput.getText().length() > 0) {
+                searchResultCount.setText(getString(R.string.no_search_results));
+                searchResultCount.setVisibility(View.VISIBLE);
+            } else {
+                searchResultCount.setVisibility(View.GONE);
+            }
+            searchPrevButton.setVisibility(View.GONE);
+            searchNextButton.setVisibility(View.GONE);
+        } else {
+            searchResultCount.setText(getString(R.string.search_result_count,
+                    currentSearchIndex + 1, searchResults.size()));
+            searchResultCount.setVisibility(View.VISIBLE);
+            searchPrevButton.setVisibility(View.VISIBLE);
+            searchNextButton.setVisibility(View.VISIBLE);
+        }
+    }
+
+
+    private void showExportDialog() {
+        String[] options = {
+            getString(R.string.export_as_markdown),
+            getString(R.string.export_as_json),
+            getString(R.string.export_as_pdf)
+        };
+
+        new AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.export_choose_format))
+            .setItems(options, (dialog, which) -> {
+                ChatSession session = getCurrentSession();
+                switch (which) {
+                    case 0:
+                        exportMarkdownLauncher.launch(
+                                chatExportManager.buildExportFileName(session, "md"));
+                        break;
+                    case 1:
+                        exportJsonLauncher.launch(
+                                chatExportManager.buildExportFileName(session, "json"));
+                        break;
+                    case 2:
+                        exportPdfLauncher.launch(
+                                chatExportManager.buildExportFileName(session, "pdf"));
+                        break;
+                }
+            })
+            .show();
+    }
+
+    private void runExport(Uri uri, String format) {
+        List<ChatMessage> messages = chatAdapter.getMessages();
+        ChatSession session = getCurrentSession();
+
+        new Thread(() -> {
+            try {
+                try (OutputStream out = requireContext().getContentResolver().openOutputStream(uri)) {
+                    if (out == null) throw new IOException("Cannot open output stream");
+                    switch (format) {
+                        case "md":
+                            chatExportManager.exportToMarkdown(session, messages, out);
+                            break;
+                        case "json":
+                            chatExportManager.exportToJson(session, messages, out);
+                            break;
+                        case "pdf":
+                            chatExportManager.exportToPdf(session, messages, out);
+                            break;
+                    }
+                }
+                requireActivity().runOnUiThread(() ->
+                    Toast.makeText(requireContext(),
+                            getString(R.string.export_success), Toast.LENGTH_SHORT).show());
+            } catch (Exception e) {
+                Log.e(TAG, "Export failed", e);
+                requireActivity().runOnUiThread(() ->
+                    Toast.makeText(requireContext(),
+                            getString(R.string.export_error, e.getMessage()),
+                            Toast.LENGTH_LONG).show());
+            }
+        }).start();
+    }
+
+
+    private void showImportDialog() {
+        String[] options = {
+            getString(R.string.import_from_json),
+            getString(R.string.import_from_markdown)
+        };
+
+        new AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.import_chat))
+            .setItems(options, (dialog, which) -> {
+                // Store the chosen format for later use in the callback
+                // We use a tag on the view as a simple storage mechanism
+                searchBar.setTag(which == 0 ? "json" : "md");
+                importPickerLauncher.launch("*/*");
+            })
+            .show();
+    }
+
+    private void handleImportFile(Uri uri) {
+        String format = searchBar.getTag() instanceof String ? (String) searchBar.getTag() : "json";
+
+        new Thread(() -> {
+            try {
+                ChatImportManager.ImportResult result;
+                try (InputStream in = requireContext().getContentResolver().openInputStream(uri)) {
+                    if (in == null) throw new IOException("Cannot open input stream");
+                    if ("md".equals(format)) {
+                        result = chatImportManager.importFromMarkdown(in);
+                    } else {
+                        result = chatImportManager.importFromJson(in);
+                    }
+                }
+
+                final ChatImportManager.ImportResult finalResult = result;
+                requireActivity().runOnUiThread(() -> showImportActionDialog(finalResult));
+
+            } catch (Exception e) {
+                Log.e(TAG, "Import failed", e);
+                requireActivity().runOnUiThread(() ->
+                    Toast.makeText(requireContext(),
+                            getString(R.string.import_error, e.getMessage()),
+                            Toast.LENGTH_LONG).show());
+            }
+        }).start();
+    }
+
+    private void showImportActionDialog(ChatImportManager.ImportResult result) {
+        if (result.messages.isEmpty()) {
+            Toast.makeText(requireContext(),
+                    getString(R.string.import_error, "No messages found in file"),
+                    Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        String[] options = {
+            getString(R.string.import_append),
+            getString(R.string.import_replace)
+        };
+
+        new AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.import_choose_action))
+            .setMessage(getString(R.string.import_success, result.messages.size())
+                    + (result.warnings.isEmpty() ? ""
+                    : "\n" + getString(R.string.import_warnings, result.warnings.size())))
+            .setItems(options, (dialog, which) -> {
+                if (which == 0) {
+                    // Append to current chat
+                    for (ChatMessage message : result.messages) {
+                        chatAdapter.addMessage(message);
+                    }
+                    saveMessages();
+                    scrollToBottom();
+                } else {
+                    // Replace – start a new session with the imported messages
+                    if (requireActivity() instanceof MainActivity) {
+                        String newSessionId = ((MainActivity) requireActivity())
+                                .createNewSession(result.sessionTitle != null
+                                        ? result.sessionTitle : "Imported Chat");
+                        currentSessionId = newSessionId;
+                        chatAdapter.setMessages(result.messages);
+                        saveMessages();
+                        updateToolbarTitle();
+                        scrollToBottom();
+                    }
+                }
+                Toast.makeText(requireContext(),
+                        getString(R.string.import_success, result.messages.size()),
+                        Toast.LENGTH_SHORT).show();
+            })
+            .show();
+    }
+
+
+    @Nullable
+    private ChatSession getCurrentSession() {
+        if (currentSessionId == null) return null;
+        List<ChatSession> sessions = chatRepository.loadSessions();
+        for (ChatSession s : sessions) {
+            if (currentSessionId.equals(s.getId())) return s;
+        }
+        return null;
+    }
+
 
     private void loadChatHistory() {
         if (currentSessionId == null || currentSessionId.isEmpty()) {
@@ -220,22 +588,20 @@ public class ChatFragment extends Fragment {
         List<ChatMessage> savedMessages = chatRepository.loadMessages(currentSessionId);
         if (!savedMessages.isEmpty()) {
             chatAdapter.setMessages(savedMessages);
-            Log.d(TAG, "loadChatHistory: Loaded " + savedMessages.size() + " messages for session: " + currentSessionId);
+            Log.d(TAG, "loadChatHistory: Loaded " + savedMessages.size()
+                    + " messages for session: " + currentSessionId);
             scrollToBottom();
-
-
             updateToolbarTitle();
         } else {
             Log.d(TAG, "loadChatHistory: No saved messages for session: " + currentSessionId);
 
-
             if (pendingTaskResult != null) {
                 Log.d(TAG, "loadChatHistory: Adding task result context messages");
                 addTaskResultContext(pendingTaskResult);
-                pendingTaskResult = null; // Clear after use
+                pendingTaskResult = null;
             }
 
-            // No saved messages - this is a new chat (likely "New Chat")
+            // No saved messages – new chat
             updateToolbarTitle();
         }
     }
@@ -257,12 +623,10 @@ public class ChatFragment extends Fragment {
     private void addTaskResultContext(TaskResult taskResult) {
         List<ChatMessage> messages = new ArrayList<>();
 
-        // Add context card
         ChatMessage contextCard = continuationService.createContextMessage(taskResult);
         messages.add(contextCard);
         chatAdapter.addMessage(contextCard);
 
-        // Add agent prompt
         ChatMessage agentPrompt = new ChatMessage(
             String.format("I've added the %s results above. What would you like to clarify or explore?",
                          TaskResult.typeToString(taskResult.getType()).toLowerCase()),
@@ -270,7 +634,6 @@ public class ChatFragment extends Fragment {
         );
         messages.add(agentPrompt);
         chatAdapter.addMessage(agentPrompt);
-
 
         saveMessages();
         scrollToBottom();
@@ -283,7 +646,6 @@ public class ChatFragment extends Fragment {
             Log.w(TAG, "saveMessages: No session ID, cannot save messages");
             return;
         }
-
         chatRepository.saveMessages(currentSessionId, chatAdapter.getMessages());
     }
 
@@ -291,7 +653,6 @@ public class ChatFragment extends Fragment {
         if (!(requireActivity() instanceof MainActivity)) {
             return;
         }
-
         ((MainActivity) requireActivity()).updateSessionMetadata(
                 currentSessionId,
                 firstUserMessage,
@@ -301,7 +662,6 @@ public class ChatFragment extends Fragment {
 
     /**
      * Generate an LLM-based title if the session still has a default title.
-     * Called after the first assistant response.
      */
     private void generateTitleIfNeeded(List<ChatMessage> updatedHistory) {
         if (!(requireActivity() instanceof MainActivity)) {
@@ -311,7 +671,6 @@ public class ChatFragment extends Fragment {
         MainActivity activity = (MainActivity) requireActivity();
         String currentTitle = activity.getCurrentSessionTitle();
 
-        // Only generate if still using a default title
         boolean isDefaultTitle = currentTitle == null
                 || currentTitle.trim().isEmpty()
                 || getString(R.string.new_chat).equals(currentTitle);
@@ -329,16 +688,13 @@ public class ChatFragment extends Fragment {
                     @Override
                     public void onTitleGenerated(String title) {
                         if (isAdded() && getContext() != null) {
-
                             activity.updateSessionTitle(currentSessionId, title);
-
                             updateToolbarTitle();
                         }
                     }
 
                     @Override
                     public void onError(String error) {
-
                         Log.w(TAG, "Title generation error: " + error);
                     }
                 });
@@ -357,11 +713,10 @@ public class ChatFragment extends Fragment {
         return null;
     }
 
+
     private void setupClickListeners() {
         sendButton.setOnClickListener(v -> sendMessage());
-
         attachButton.setOnClickListener(v -> launchFilePicker());
-
         messageInput.setOnEditorActionListener((v, actionId, event) -> {
             sendMessage();
             return true;
@@ -376,7 +731,7 @@ public class ChatFragment extends Fragment {
     }
 
     /**
-     * Handle the selected file from the picker. Uploads it to the workspace uploads directory.
+     * Handle the selected file from the picker.
      */
     private void uploadSelectedFile(Uri uri) {
         if (fileUploadManager == null) {
@@ -400,7 +755,8 @@ public class ChatFragment extends Fragment {
                     Toast.makeText(requireContext(),
                         "Attached: " + result.getOriginalName(),
                         Toast.LENGTH_SHORT).show();
-                    Log.d(TAG, "File attached: " + result.getOriginalName() + " -> " + result.getFilename());
+                    Log.d(TAG, "File attached: " + result.getOriginalName()
+                            + " -> " + result.getFilename());
                 });
             } catch (IOException e) {
                 Log.e(TAG, "Failed to upload file", e);
@@ -480,6 +836,7 @@ public class ChatFragment extends Fragment {
         return name;
     }
 
+
     private void sendMessage() {
         String messageText = messageInput.getText().toString().trim();
         if (messageText.isEmpty()) {
@@ -487,12 +844,11 @@ public class ChatFragment extends Fragment {
         }
 
         if (!settingsManager.isConfigured()) {
-            Toast.makeText(requireContext(), "Please configure API settings first", Toast.LENGTH_LONG).show();
-            Navigation.findNavController(requireView())
-                    .navigate(R.id.settingsFragment);
+            Toast.makeText(requireContext(), "Please configure API settings first",
+                    Toast.LENGTH_LONG).show();
+            Navigation.findNavController(requireView()).navigate(R.id.settingsFragment);
             return;
         }
-
 
         List<FileAttachment> attachments = consumePendingAttachments();
 
@@ -505,15 +861,13 @@ public class ChatFragment extends Fragment {
         chatAdapter.addMessage(userMessage);
         scrollToBottom();
 
-
         saveMessages();
         updateSessionMetadata(messageText);
-        Log.d(TAG, "sendMessage: Added and saved user message. Total: " + chatAdapter.getItemCount());
+        Log.d(TAG, "sendMessage: Added and saved user message. Total: "
+                + chatAdapter.getItemCount());
 
         messageInput.setText("");
-
         setLoading(true);
-
 
         List<ChatMessage> conversationHistory = new ArrayList<>(chatAdapter.getMessages());
 
@@ -538,9 +892,8 @@ public class ChatFragment extends Fragment {
 
             @Override
             public void onToolResult(String toolName, String result) {
-                Log.d(TAG, "Tool result: " + toolName + " -> " + result.substring(0, Math.min(100, result.length())));
-
-
+                Log.d(TAG, "Tool result: " + toolName + " -> "
+                        + result.substring(0, Math.min(100, result.length())));
                 String iterationInfo = "Step " + agentLoop.getIterationCount() + "/20";
                 updateStatus("✓ " + formatToolName(toolName) + " completed", iterationInfo);
             }
@@ -549,19 +902,15 @@ public class ChatFragment extends Fragment {
             public void onComplete(String finalResponse, List<ChatMessage> updatedHistory) {
                 setLoading(false);
 
-
                 chatAdapter.setMessages(updatedHistory);
                 scrollToBottom();
 
-
                 saveMessages();
                 updateSessionMetadata(null);
-                Log.d(TAG, "onComplete: Agent completed. Total messages: " + chatAdapter.getItemCount());
-
+                Log.d(TAG, "onComplete: Agent completed. Total messages: "
+                        + chatAdapter.getItemCount());
 
                 generateTitleIfNeeded(updatedHistory);
-
-
                 updateToolbarTitle();
             }
 
@@ -576,12 +925,11 @@ public class ChatFragment extends Fragment {
             }
 
             @Override
-            public void onApprovalRequired(String toolName, String description, JsonObject arguments,
+            public void onApprovalRequired(String toolName, String description,
+                                           JsonObject arguments,
                                            AgentLoop.ApprovalCallback approvalCallback) {
-
-                requireActivity().runOnUiThread(() -> {
-                    showApprovalDialog(toolName, description, approvalCallback);
-                });
+                requireActivity().runOnUiThread(() ->
+                    showApprovalDialog(toolName, description, approvalCallback));
             }
         });
     }
@@ -589,7 +937,8 @@ public class ChatFragment extends Fragment {
     /**
      * Show a dialog asking user to approve or deny a tool execution.
      */
-    private void showApprovalDialog(String toolName, String description, AgentLoop.ApprovalCallback approvalCallback) {
+    private void showApprovalDialog(String toolName, String description,
+                                    AgentLoop.ApprovalCallback approvalCallback) {
         new AlertDialog.Builder(requireContext())
             .setTitle("Approve Tool Execution?")
             .setMessage("Tool: " + formatToolName(toolName) + "\n\n" + description)
@@ -640,7 +989,6 @@ public class ChatFragment extends Fragment {
      * Get a user-friendly status message for tool execution.
      */
     private String getToolStatusMessage(String toolName, String arguments) {
-
         if (toolName.equals("list_files") && arguments.contains(".agent/skills")) {
             return "Discovering available skills...";
         } else if (toolName.equals("read_file") && arguments.contains(".agent/skills")) {
@@ -649,34 +997,20 @@ public class ChatFragment extends Fragment {
             return "Reading skill instructions...";
         }
 
-        // Tool-specific messages
         switch (toolName) {
-            case "execute_shell":
-                return "Running shell command...";
-            case "execute_python":
-                return "Executing Python script...";
-            case "pip_install":
-                return "Installing Python package...";
-            case "read_file":
-                return "Reading file...";
-            case "write_file":
-                return "Writing file...";
-            case "edit_file":
-                return "Editing file...";
-            case "list_files":
-                return "Listing directory...";
-            case "search_files":
-                return "Searching files...";
-            case "delete_file":
-                return "Deleting file...";
-            case "file_info":
-                return "Getting file info...";
-            case "kill_background_process":
-                return "Killing background process...";
-            case "list_background_processes":
-                return "Listing background processes...";
-            default:
-                return "Executing: " + formatToolName(toolName);
+            case "execute_shell":     return "Running shell command...";
+            case "execute_python":    return "Executing Python script...";
+            case "pip_install":       return "Installing Python package...";
+            case "read_file":         return "Reading file...";
+            case "write_file":        return "Writing file...";
+            case "edit_file":         return "Editing file...";
+            case "list_files":        return "Listing directory...";
+            case "search_files":      return "Searching files...";
+            case "delete_file":       return "Deleting file...";
+            case "file_info":         return "Getting file info...";
+            case "kill_background_process":  return "Killing background process...";
+            case "list_background_processes": return "Listing background processes...";
+            default:                  return "Executing: " + formatToolName(toolName);
         }
     }
 
@@ -696,10 +1030,6 @@ public class ChatFragment extends Fragment {
         return formatted.toString();
     }
 
-    /**
-     * Get the context window size from the currently selected model.
-     * Falls back to default if model is not configured.
-     */
     private int getModelContextWindow() {
         Object[] selected = settingsManager.getSelectedProviderAndModel();
         if (selected != null && selected[1] instanceof io.finett.droidclaw.model.Model) {
@@ -708,8 +1038,6 @@ public class ChatFragment extends Fragment {
             Log.d(TAG, "Using model context window: " + contextWindow);
             return contextWindow;
         }
-
-        // Fallback to default
         Log.w(TAG, "Model not configured, using default context window: 4096");
         return 4096;
     }
@@ -726,7 +1054,8 @@ public class ChatFragment extends Fragment {
         // Propagate the refreshed service to the agent loop components
         int contextWindow = getModelContextWindow();
         io.finett.droidclaw.agent.ConversationSummarizer summarizer =
-                new io.finett.droidclaw.agent.ConversationSummarizer(apiService, memoryRepository, contextWindow);
+                new io.finett.droidclaw.agent.ConversationSummarizer(
+                        apiService, memoryRepository, contextWindow);
         io.finett.droidclaw.agent.MemoryContextBuilder memoryContext =
                 new io.finett.droidclaw.agent.MemoryContextBuilder(memoryRepository);
         agentLoop = new AgentLoop(apiService, toolRegistry, settingsManager, summarizer, memoryContext);

--- a/app/src/main/java/io/finett/droidclaw/util/ChatExportManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/ChatExportManager.java
@@ -1,0 +1,419 @@
+package io.finett.droidclaw.util;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.pdf.PdfDocument;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.ChatSession;
+import io.finett.droidclaw.model.FileAttachment;
+
+public class ChatExportManager {
+    private static final String TAG = "ChatExportManager";
+    private static final SimpleDateFormat TIMESTAMP_FMT =
+            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+
+    private static final int PDF_PAGE_WIDTH  = 595;
+    private static final int PDF_PAGE_HEIGHT = 842;
+    private static final int PDF_MARGIN      = 48;
+    private static final int PDF_LINE_HEIGHT = 18;
+    private static final float PDF_FONT_SIZE = 11f;
+
+    private final Context context;
+
+    public ChatExportManager(Context context) {
+        this.context = context;
+    }
+
+
+    /**
+     * Exports the conversation to Markdown and writes it to {@code out}.
+     *
+     * @param session  Session metadata (may be null; skips header if so)
+     * @param messages The messages to export
+     * @param out      Destination stream; caller is responsible for closing it
+     */
+    public void exportToMarkdown(ChatSession session, List<ChatMessage> messages,
+                                 OutputStream out) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        // Document header
+        sb.append("# DroidClaw Chat Export\n\n");
+        if (session != null) {
+            sb.append("**Session:** ").append(escapeMarkdown(session.getTitle())).append("\n");
+            sb.append("**Exported:** ")
+              .append(TIMESTAMP_FMT.format(new Date()))
+              .append("\n\n");
+            sb.append("---\n\n");
+        }
+
+        for (ChatMessage message : messages) {
+            appendMessageMarkdown(sb, message);
+        }
+
+        out.write(sb.toString().getBytes("UTF-8"));
+        out.flush();
+        Log.d(TAG, "Exported " + messages.size() + " messages to Markdown");
+    }
+
+    private void appendMessageMarkdown(StringBuilder sb, ChatMessage message) {
+        String timestamp = TIMESTAMP_FMT.format(new Date(message.getTimestamp()));
+
+        switch (message.getType()) {
+            case ChatMessage.TYPE_USER:
+                sb.append("### User (").append(timestamp).append(")\n\n");
+                if (message.getContent() != null) {
+                    sb.append(message.getContent()).append("\n");
+                }
+                if (message.hasAttachments()) {
+                    for (FileAttachment att : message.getAttachments()) {
+                        sb.append("\n📎 **File:** ").append(att.getOriginalName())
+                          .append(" (`").append(att.getAbsolutePath()).append("`)\n");
+                    }
+                }
+                sb.append("\n");
+                break;
+
+            case ChatMessage.TYPE_ASSISTANT:
+                sb.append("### Assistant (").append(timestamp).append(")\n\n");
+                if (message.getContent() != null) {
+                    sb.append(message.getContent()).append("\n");
+                }
+                sb.append("\n");
+                break;
+
+            case ChatMessage.TYPE_TOOL_CALL:
+                if (message.getToolCalls() != null) {
+                    for (LlmApiService.ToolCall toolCall : message.getToolCalls()) {
+                        sb.append("#### Tool Call: `").append(toolCall.getName())
+                          .append("` (").append(timestamp).append(")\n\n");
+                        sb.append("```json\n");
+                        sb.append(toolCall.getArguments() != null
+                                ? toolCall.getArguments().toString() : "{}");
+                        sb.append("\n```\n\n");
+                    }
+                }
+                break;
+
+            case ChatMessage.TYPE_TOOL_RESULT:
+                sb.append("#### Tool Result: `")
+                  .append(message.getToolName() != null ? message.getToolName() : "unknown")
+                  .append("`\n\n");
+                if (message.getContent() != null) {
+                    sb.append("```\n").append(message.getContent()).append("\n```\n\n");
+                }
+                break;
+
+            case ChatMessage.TYPE_SYSTEM:
+                sb.append("> **System:** ");
+                if (message.getContent() != null) {
+                    sb.append(message.getContent().replace("\n", "\n> "));
+                }
+                sb.append("\n\n");
+                break;
+
+            case ChatMessage.TYPE_CONTEXT_CARD:
+                sb.append("> **Context [").append(message.getContextType()).append("]:** ");
+                if (message.getContent() != null) {
+                    sb.append(message.getContent().replace("\n", "\n> "));
+                }
+                sb.append("\n\n");
+                break;
+
+            case ChatMessage.TYPE_ATTACHMENT:
+                sb.append("📎 **File:** ");
+                String displayName = message.getDisplayName() != null
+                        ? message.getDisplayName() : message.getFilePath();
+                sb.append(displayName);
+                if (message.getFilePath() != null) {
+                    sb.append(" (`").append(message.getFilePath()).append("`)");
+                }
+                sb.append("\n\n");
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private String escapeMarkdown(String text) {
+        if (text == null) return "";
+        return text.replace("\\", "\\\\")
+                   .replace("`", "\\`")
+                   .replace("*", "\\*")
+                   .replace("_", "\\_")
+                   .replace("[", "\\[")
+                   .replace("]", "\\]");
+    }
+
+
+    /**
+     * Exports the full conversation to JSON (full-fidelity backup).
+     *
+     * @param session  Session metadata (may be null)
+     * @param messages The messages to export
+     * @param out      Destination stream; caller is responsible for closing it
+     */
+    public void exportToJson(ChatSession session, List<ChatMessage> messages,
+                             OutputStream out) throws IOException {
+        try {
+            JSONObject root = new JSONObject();
+            root.put("exportedAt", TIMESTAMP_FMT.format(new Date()));
+            root.put("version", 1);
+
+            if (session != null) {
+                JSONObject sessionObj = new JSONObject();
+                sessionObj.put("id", session.getId());
+                sessionObj.put("title", session.getTitle());
+                sessionObj.put("updatedAt", session.getUpdatedAt());
+                root.put("session", sessionObj);
+            }
+
+            JSONArray messagesArray = new JSONArray();
+            for (ChatMessage message : messages) {
+                messagesArray.put(serializeMessage(message));
+            }
+            root.put("messages", messagesArray);
+
+            out.write(root.toString(2).getBytes("UTF-8"));
+            out.flush();
+            Log.d(TAG, "Exported " + messages.size() + " messages to JSON");
+
+        } catch (JSONException e) {
+            throw new IOException("Failed to serialize chat to JSON", e);
+        }
+    }
+
+    private JSONObject serializeMessage(ChatMessage message) throws JSONException {
+        JSONObject obj = new JSONObject();
+        obj.put("type", message.getType());
+        obj.put("timestamp", message.getTimestamp());
+
+        if (message.getContent() != null) {
+            obj.put("content", message.getContent());
+        }
+
+        if (message.getType() == ChatMessage.TYPE_TOOL_CALL
+                && message.getToolCalls() != null) {
+            JSONArray toolCallsArr = new JSONArray();
+            for (LlmApiService.ToolCall toolCall : message.getToolCalls()) {
+                JSONObject tc = new JSONObject();
+                tc.put("id", toolCall.getId());
+                tc.put("name", toolCall.getName());
+                tc.put("arguments",
+                        toolCall.getArguments() != null ? toolCall.getArguments().toString() : "{}");
+                toolCallsArr.put(tc);
+            }
+            obj.put("toolCalls", toolCallsArr);
+        }
+
+        if (message.getType() == ChatMessage.TYPE_TOOL_RESULT) {
+            if (message.getToolCallId() != null) obj.put("toolCallId", message.getToolCallId());
+            if (message.getToolName()   != null) obj.put("toolName",   message.getToolName());
+        }
+
+        if (message.getType() == ChatMessage.TYPE_CONTEXT_CARD) {
+            obj.put("isContextCard", message.isContextCard());
+            if (message.getContextType()    != null) obj.put("contextType",    message.getContextType());
+            if (message.getOriginalTaskId() != null) obj.put("originalTaskId", message.getOriginalTaskId());
+        }
+
+        if (message.hasAttachments()) {
+            JSONArray attArr = new JSONArray();
+            for (FileAttachment att : message.getAttachments()) {
+                JSONObject attObj = new JSONObject();
+                attObj.put("filename",     att.getFilename());
+                attObj.put("originalName", att.getOriginalName());
+                attObj.put("absolutePath", att.getAbsolutePath());
+                attObj.put("mimeType",     att.getMimeType());
+                attArr.put(attObj);
+            }
+            obj.put("attachments", attArr);
+        }
+
+        if (message.getType() == ChatMessage.TYPE_ATTACHMENT) {
+            if (message.getFilePath()    != null) obj.put("filePath",    message.getFilePath());
+            if (message.getFileMimeType() != null) obj.put("fileMimeType", message.getFileMimeType());
+            if (message.getDisplayName() != null) obj.put("displayName", message.getDisplayName());
+        }
+
+        return obj;
+    }
+
+
+    /**
+     * Exports the conversation to PDF using the Android {@link PdfDocument} API.
+     *
+     * @param session  Session metadata (may be null)
+     * @param messages The messages to export
+     * @param out      Destination stream; caller is responsible for closing it
+     */
+    public void exportToPdf(ChatSession session, List<ChatMessage> messages,
+                            OutputStream out) throws IOException {
+        PdfDocument pdfDoc = new PdfDocument();
+
+        Paint titlePaint = new Paint();
+        titlePaint.setTextSize(16f);
+        titlePaint.setFakeBoldText(true);
+
+        Paint bodyPaint = new Paint();
+        bodyPaint.setTextSize(PDF_FONT_SIZE);
+
+        Paint labelPaint = new Paint();
+        labelPaint.setTextSize(PDF_FONT_SIZE);
+        labelPaint.setFakeBoldText(true);
+
+        // Flatten all messages to text lines first
+        List<String> lines = buildPdfLines(session, messages);
+
+        int pageNumber = 1;
+        int lineIndex  = 0;
+
+        while (lineIndex < lines.size()) {
+            PdfDocument.PageInfo pageInfo = new PdfDocument.PageInfo.Builder(
+                    PDF_PAGE_WIDTH, PDF_PAGE_HEIGHT, pageNumber).create();
+            PdfDocument.Page page = pdfDoc.startPage(pageInfo);
+            Canvas canvas = page.getCanvas();
+
+            float y = PDF_MARGIN;
+            float maxY = PDF_PAGE_HEIGHT - PDF_MARGIN;
+
+            while (lineIndex < lines.size() && y < maxY) {
+                String line = lines.get(lineIndex);
+                canvas.drawText(line, PDF_MARGIN, y, bodyPaint);
+                y += PDF_LINE_HEIGHT;
+                lineIndex++;
+            }
+
+            pdfDoc.finishPage(page);
+            pageNumber++;
+        }
+
+        pdfDoc.writeTo(out);
+        pdfDoc.close();
+        out.flush();
+        Log.d(TAG, "Exported " + messages.size() + " messages to PDF (" + (pageNumber - 1) + " pages)");
+    }
+
+    private List<String> buildPdfLines(ChatSession session, List<ChatMessage> messages) {
+        List<String> lines = new java.util.ArrayList<>();
+
+        lines.add("DroidClaw Chat Export");
+        lines.add("");
+        if (session != null) {
+            lines.add("Session: " + session.getTitle());
+            lines.add("Exported: " + TIMESTAMP_FMT.format(new Date()));
+            lines.add("");
+            lines.add("----------------------------------------------");
+            lines.add("");
+        }
+
+        for (ChatMessage message : messages) {
+            String timestamp = TIMESTAMP_FMT.format(new Date(message.getTimestamp()));
+            switch (message.getType()) {
+                case ChatMessage.TYPE_USER:
+                    lines.add("[User - " + timestamp + "]");
+                    appendWrappedLines(lines, message.getContent());
+                    break;
+
+                case ChatMessage.TYPE_ASSISTANT:
+                    lines.add("[Assistant - " + timestamp + "]");
+                    appendWrappedLines(lines, message.getContent());
+                    break;
+
+                case ChatMessage.TYPE_TOOL_CALL:
+                    if (message.getToolCalls() != null) {
+                        for (LlmApiService.ToolCall tc : message.getToolCalls()) {
+                            lines.add("[Tool Call: " + tc.getName() + " - " + timestamp + "]");
+                            appendWrappedLines(lines,
+                                    tc.getArguments() != null ? tc.getArguments().toString() : "{}");
+                        }
+                    }
+                    break;
+
+                case ChatMessage.TYPE_TOOL_RESULT:
+                    lines.add("[Tool Result: " + message.getToolName() + "]");
+                    appendWrappedLines(lines, message.getContent());
+                    break;
+
+                case ChatMessage.TYPE_SYSTEM:
+                    lines.add("[System]");
+                    appendWrappedLines(lines, message.getContent());
+                    break;
+
+                case ChatMessage.TYPE_CONTEXT_CARD:
+                    lines.add("[Context: " + message.getContextType() + "]");
+                    appendWrappedLines(lines, message.getContent());
+                    break;
+
+                case ChatMessage.TYPE_ATTACHMENT:
+                    String name = message.getDisplayName() != null
+                            ? message.getDisplayName() : message.getFilePath();
+                    lines.add("[Attachment: " + name + "]");
+                    break;
+
+                default:
+                    break;
+            }
+            lines.add("");
+        }
+
+        return lines;
+    }
+
+    /**
+     * Splits {@code text} into lines no longer than ~80 characters and appends them.
+     */
+    private void appendWrappedLines(List<String> lines, String text) {
+        if (text == null || text.isEmpty()) {
+            lines.add("");
+            return;
+        }
+        for (String rawLine : text.split("\n", -1)) {
+            if (rawLine.length() <= 80) {
+                lines.add(rawLine);
+            } else {
+                int start = 0;
+                while (start < rawLine.length()) {
+                    int end = Math.min(start + 80, rawLine.length());
+                    lines.add(rawLine.substring(start, end));
+                    start = end;
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Returns a suggested export filename for the given session and format extension
+     * (e.g. "md", "json", "pdf").
+     */
+    public String buildExportFileName(ChatSession session, String extension) {
+        String base = "droidclaw-chat";
+        if (session != null && session.getTitle() != null && !session.getTitle().isEmpty()) {
+            String sanitized = session.getTitle()
+                    .replaceAll("[^a-zA-Z0-9\\s\\-]", "")
+                    .trim()
+                    .replaceAll("\\s+", "-")
+                    .toLowerCase(Locale.US);
+            if (sanitized.length() > 40) sanitized = sanitized.substring(0, 40);
+            if (!sanitized.isEmpty()) base = sanitized;
+        }
+        String datePart = new SimpleDateFormat("yyyyMMdd", Locale.US).format(new Date());
+        return base + "-" + datePart + "." + extension;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/util/ChatImportManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/ChatImportManager.java
@@ -1,0 +1,366 @@
+package io.finett.droidclaw.util;
+
+import android.util.Log;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.FileAttachment;
+
+public class ChatImportManager {
+    private static final String TAG = "ChatImportManager";
+
+    private static final SimpleDateFormat TIMESTAMP_FMT =
+            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+
+    // Markdown header patterns
+    private static final Pattern USER_HEADER      = Pattern.compile(
+            "^###\\s+User\\s*\\(([^)]+)\\)\\s*$");
+    private static final Pattern ASSISTANT_HEADER = Pattern.compile(
+            "^###\\s+Assistant\\s*\\(([^)]+)\\)\\s*$");
+    private static final Pattern TOOL_CALL_HEADER = Pattern.compile(
+            "^####\\s+Tool Call:\\s*`([^`]+)`(?:\\s*\\(([^)]+)\\))?\\s*$");
+    private static final Pattern TOOL_RESULT_HEADER = Pattern.compile(
+            "^####\\s+Tool Result:\\s*`([^`]+)`\\s*$");
+
+    public static class ImportResult {
+        public final List<ChatMessage> messages;
+        public final String sessionTitle;
+        public final List<String> warnings;
+
+        public ImportResult(List<ChatMessage> messages, String sessionTitle,
+                            List<String> warnings) {
+            this.messages     = messages;
+            this.sessionTitle = sessionTitle;
+            this.warnings     = warnings;
+        }
+    }
+
+
+    /**
+     * Parses a full-fidelity JSON backup produced by {@link ChatExportManager#exportToJson}.
+     *
+     * @param in Input stream (UTF-8). Caller is responsible for closing it.
+     * @return   Parsed {@link ImportResult} containing messages and optional session title.
+     * @throws IOException if the stream cannot be read or the JSON is invalid.
+     */
+    public ImportResult importFromJson(InputStream in) throws IOException {
+        String json = readStreamToString(in);
+        List<String> warnings = new ArrayList<>();
+        List<ChatMessage> messages = new ArrayList<>();
+        String sessionTitle = null;
+
+        try {
+            JSONObject root = new JSONObject(json);
+
+            int version = root.optInt("version", 1);
+            if (version != 1) {
+                warnings.add("Unknown export version " + version + "; attempting import anyway.");
+            }
+
+            if (root.has("session")) {
+                JSONObject sessionObj = root.getJSONObject("session");
+                sessionTitle = sessionObj.optString("title", null);
+            }
+
+            if (!root.has("messages")) {
+                throw new IOException("JSON export does not contain a 'messages' field.");
+            }
+
+            JSONArray messagesArray = root.getJSONArray("messages");
+            for (int i = 0; i < messagesArray.length(); i++) {
+                try {
+                    ChatMessage message = deserializeMessage(messagesArray.getJSONObject(i));
+                    if (message != null) {
+                        messages.add(message);
+                    }
+                } catch (Exception e) {
+                    warnings.add("Skipped message at index " + i + ": " + e.getMessage());
+                    Log.w(TAG, "Error deserializing message at index " + i, e);
+                }
+            }
+
+        } catch (JSONException e) {
+            throw new IOException("Malformed JSON export: " + e.getMessage(), e);
+        }
+
+        Log.d(TAG, "Imported " + messages.size() + " messages from JSON"
+                + (warnings.isEmpty() ? "" : " (" + warnings.size() + " warnings)"));
+        return new ImportResult(messages, sessionTitle, warnings);
+    }
+
+    private ChatMessage deserializeMessage(JSONObject obj) throws JSONException {
+        int type = obj.getInt("type");
+        if (type < ChatMessage.TYPE_USER || type > ChatMessage.TYPE_ATTACHMENT) {
+            throw new JSONException("Invalid message type: " + type);
+        }
+
+        long timestamp = obj.optLong("timestamp", System.currentTimeMillis());
+        String content = obj.has("content") && !obj.isNull("content")
+                ? obj.getString("content") : null;
+
+        ChatMessage message;
+
+        if (type == ChatMessage.TYPE_TOOL_CALL && obj.has("toolCalls")) {
+            JSONArray toolCallsArr = obj.getJSONArray("toolCalls");
+            List<LlmApiService.ToolCall> toolCalls = new ArrayList<>();
+            for (int j = 0; j < toolCallsArr.length(); j++) {
+                JSONObject tc = toolCallsArr.getJSONObject(j);
+                String id   = tc.optString("id", "");
+                String name = tc.getString("name");
+                String argsStr = tc.optString("arguments", "{}");
+                JsonObject args = JsonParser.parseString(argsStr).getAsJsonObject();
+                toolCalls.add(new LlmApiService.ToolCall(id, name, args));
+            }
+            message = ChatMessage.createToolCallMessage(toolCalls);
+        } else if (type == ChatMessage.TYPE_TOOL_RESULT) {
+            String toolCallId = obj.optString("toolCallId", null);
+            String toolName   = obj.optString("toolName",   null);
+            message = ChatMessage.createToolResultMessage(toolCallId, toolName, content);
+        } else if (type == ChatMessage.TYPE_CONTEXT_CARD) {
+            message = new ChatMessage(content, type);
+            message.setIsContextCard(obj.optBoolean("isContextCard", true));
+            if (obj.has("contextType") && !obj.isNull("contextType")) {
+                message.setContextType(obj.getString("contextType"));
+            }
+            if (obj.has("originalTaskId") && !obj.isNull("originalTaskId")) {
+                message.setOriginalTaskId(obj.getString("originalTaskId"));
+            }
+        } else if (type == ChatMessage.TYPE_ATTACHMENT) {
+            String filePath    = obj.optString("filePath",    null);
+            String mimeType    = obj.optString("fileMimeType", null);
+            String displayName = obj.optString("displayName", null);
+            message = ChatMessage.createAttachmentMessage(filePath, displayName, mimeType);
+        } else {
+            message = new ChatMessage(content, type);
+        }
+
+        // Restore attachments for user messages
+        if (obj.has("attachments")) {
+            JSONArray attArr = obj.getJSONArray("attachments");
+            List<FileAttachment> attachments = new ArrayList<>();
+            for (int j = 0; j < attArr.length(); j++) {
+                JSONObject attObj = attArr.getJSONObject(j);
+                attachments.add(new FileAttachment(
+                        attObj.optString("filename", ""),
+                        attObj.optString("originalName", ""),
+                        attObj.optString("absolutePath", ""),
+                        attObj.optString("mimeType", "")
+                ));
+            }
+            message.setAttachments(attachments);
+        }
+
+        message.setTimestamp(timestamp);
+        return message;
+    }
+
+
+    /**
+     * Parses Markdown produced by {@link ChatExportManager#exportToMarkdown}.
+     *
+     * Note: Markdown import is inherently lossy – tool call arguments and
+     * multi-attachment state may not be fully recoverable. JSON import is preferred
+     * for round-trip fidelity.
+     *
+     * @param in Input stream (UTF-8). Caller is responsible for closing it.
+     * @return   Parsed {@link ImportResult}.
+     * @throws IOException if the stream cannot be read.
+     */
+    public ImportResult importFromMarkdown(InputStream in) throws IOException {
+        String text = readStreamToString(in);
+        List<String> warnings = new ArrayList<>();
+        List<ChatMessage> messages = new ArrayList<>();
+
+        String sessionTitle = null;
+        String[] lines = text.split("\n", -1);
+
+        // State machine
+        int currentType = -1;
+        String currentToolName = null;
+        long currentTimestamp = System.currentTimeMillis();
+        StringBuilder currentContent = new StringBuilder();
+        boolean insideCodeBlock = false;
+
+        for (String rawLine : lines) {
+            String line = rawLine.stripTrailing();
+
+            // Extract session title from the first `**Session:**` line
+            if (line.startsWith("**Session:**")) {
+                sessionTitle = line.substring("**Session:**".length()).trim();
+                continue;
+            }
+
+            // Track code blocks (don't parse header patterns inside them)
+            if (line.startsWith("```") && !insideCodeBlock) {
+                insideCodeBlock = true;
+                currentContent.append(rawLine).append("\n");
+                continue;
+            }
+            if (insideCodeBlock) {
+                currentContent.append(rawLine).append("\n");
+                if (line.startsWith("```")) {
+                    insideCodeBlock = false;
+                }
+                continue;
+            }
+
+            Matcher userMatcher      = USER_HEADER.matcher(line);
+            Matcher assistantMatcher = ASSISTANT_HEADER.matcher(line);
+            Matcher toolCallMatcher  = TOOL_CALL_HEADER.matcher(line);
+            Matcher toolResultMatcher = TOOL_RESULT_HEADER.matcher(line);
+
+            if (userMatcher.matches()) {
+                flushMessage(messages, warnings, currentType, currentToolName,
+                        currentTimestamp, currentContent.toString());
+                currentType      = ChatMessage.TYPE_USER;
+                currentToolName  = null;
+                currentTimestamp = parseTimestamp(userMatcher.group(1), warnings);
+                currentContent   = new StringBuilder();
+            } else if (assistantMatcher.matches()) {
+                flushMessage(messages, warnings, currentType, currentToolName,
+                        currentTimestamp, currentContent.toString());
+                currentType      = ChatMessage.TYPE_ASSISTANT;
+                currentToolName  = null;
+                currentTimestamp = parseTimestamp(assistantMatcher.group(1), warnings);
+                currentContent   = new StringBuilder();
+            } else if (toolCallMatcher.matches()) {
+                flushMessage(messages, warnings, currentType, currentToolName,
+                        currentTimestamp, currentContent.toString());
+                currentType      = ChatMessage.TYPE_TOOL_CALL;
+                currentToolName  = toolCallMatcher.group(1);
+                String tsStr     = toolCallMatcher.group(2);
+                currentTimestamp = tsStr != null ? parseTimestamp(tsStr, warnings)
+                                                 : System.currentTimeMillis();
+                currentContent   = new StringBuilder();
+            } else if (toolResultMatcher.matches()) {
+                flushMessage(messages, warnings, currentType, currentToolName,
+                        currentTimestamp, currentContent.toString());
+                currentType      = ChatMessage.TYPE_TOOL_RESULT;
+                currentToolName  = toolResultMatcher.group(1);
+                currentTimestamp = System.currentTimeMillis();
+                currentContent   = new StringBuilder();
+            } else if (currentType != -1) {
+                // Skip document-level headers and horizontal rules
+                if (!line.equals("---") && !line.startsWith("# ") && !line.startsWith("**Exported:**")) {
+                    currentContent.append(rawLine).append("\n");
+                }
+            }
+        }
+
+        // Flush the last message
+        flushMessage(messages, warnings, currentType, currentToolName,
+                currentTimestamp, currentContent.toString());
+
+        Log.d(TAG, "Imported " + messages.size() + " messages from Markdown"
+                + (warnings.isEmpty() ? "" : " (" + warnings.size() + " warnings)"));
+        return new ImportResult(messages, sessionTitle, warnings);
+    }
+
+    private void flushMessage(List<ChatMessage> messages, List<String> warnings,
+                              int type, String toolName, long timestamp, String rawContent) {
+        if (type == -1) return;
+
+        String content = rawContent.stripLeading();
+        // Remove a trailing newline if present
+        if (content.endsWith("\n")) {
+            content = content.substring(0, content.length() - 1);
+        }
+
+        ChatMessage message;
+        switch (type) {
+            case ChatMessage.TYPE_USER:
+                message = new ChatMessage(content.isEmpty() ? null : content, ChatMessage.TYPE_USER);
+                break;
+
+            case ChatMessage.TYPE_ASSISTANT:
+                message = new ChatMessage(content.isEmpty() ? null : content, ChatMessage.TYPE_ASSISTANT);
+                break;
+
+            case ChatMessage.TYPE_TOOL_CALL: {
+                // Best-effort: reconstruct a single tool call from the code block content
+                String argsJson = extractCodeBlockContent(content);
+                JsonObject args;
+                try {
+                    args = JsonParser.parseString(argsJson.isEmpty() ? "{}" : argsJson)
+                                     .getAsJsonObject();
+                } catch (Exception e) {
+                    args = new JsonObject();
+                    warnings.add("Could not parse tool call arguments for '" + toolName + "'");
+                }
+                List<LlmApiService.ToolCall> toolCalls = new ArrayList<>();
+                toolCalls.add(new LlmApiService.ToolCall(
+                        "imported-" + System.nanoTime(), toolName != null ? toolName : "unknown", args));
+                message = ChatMessage.createToolCallMessage(toolCalls);
+                break;
+            }
+
+            case ChatMessage.TYPE_TOOL_RESULT: {
+                String resultContent = extractCodeBlockContent(content);
+                message = ChatMessage.createToolResultMessage(null, toolName, resultContent);
+                break;
+            }
+
+            default:
+                message = new ChatMessage(content.isEmpty() ? null : content, type);
+                break;
+        }
+
+        message.setTimestamp(timestamp);
+        messages.add(message);
+    }
+
+    /**
+     * Extracts the text inside the first ``` ... ``` code block in {@code content}.
+     * Returns the raw content unchanged if no code block is found.
+     */
+    private String extractCodeBlockContent(String content) {
+        if (content == null) return "";
+        int start = content.indexOf("```");
+        if (start < 0) return content.trim();
+        int bodyStart = content.indexOf('\n', start);
+        if (bodyStart < 0) return content.trim();
+        int end = content.indexOf("```", bodyStart);
+        if (end < 0) return content.substring(bodyStart).trim();
+        return content.substring(bodyStart, end).trim();
+    }
+
+    private long parseTimestamp(String ts, List<String> warnings) {
+        if (ts == null) return System.currentTimeMillis();
+        try {
+            Date date = TIMESTAMP_FMT.parse(ts.trim());
+            return date != null ? date.getTime() : System.currentTimeMillis();
+        } catch (ParseException e) {
+            warnings.add("Could not parse timestamp: " + ts);
+            return System.currentTimeMillis();
+        }
+    }
+
+
+    private String readStreamToString(InputStream in) throws IOException {
+        byte[] buf = new byte[8192];
+        StringBuilder sb = new StringBuilder();
+        int bytesRead;
+        while ((bytesRead = in.read(buf)) != -1) {
+            sb.append(new String(buf, 0, bytesRead, "UTF-8"));
+        }
+        return sb.toString();
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/util/ChatSearchManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/ChatSearchManager.java
@@ -1,0 +1,155 @@
+package io.finett.droidclaw.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.model.ChatMessage;
+
+public class ChatSearchManager {
+
+    public static class MatchRange {
+        public final int start;
+        public final int end;
+
+        public MatchRange(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+    }
+
+    public static class SearchResult {
+        public final ChatMessage message;
+        public final int position;
+        public final List<MatchRange> matches;
+
+        public SearchResult(ChatMessage message, int position, List<MatchRange> matches) {
+            this.message = message;
+            this.position = position;
+            this.matches = matches;
+        }
+    }
+
+    public List<SearchResult> search(List<ChatMessage> messages, String query, boolean useRegex) {
+        List<SearchResult> results = new ArrayList<>();
+
+        if (query == null || query.trim().isEmpty()) {
+            return results;
+        }
+
+        Pattern pattern = buildPattern(query, useRegex);
+        if (pattern == null) {
+            return results;
+        }
+
+        for (int i = 0; i < messages.size(); i++) {
+            ChatMessage message = messages.get(i);
+            List<String> searchableTexts = getSearchableTexts(message);
+
+            List<MatchRange> allMatches = new ArrayList<>();
+            for (String text : searchableTexts) {
+                if (text == null || text.isEmpty()) continue;
+                allMatches.addAll(findMatches(pattern, text));
+            }
+
+            if (!allMatches.isEmpty()) {
+                results.add(new SearchResult(message, i, allMatches));
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Convenience overload – performs a simple case-insensitive string search.
+     */
+    public List<SearchResult> search(List<ChatMessage> messages, String query) {
+        return search(messages, query, false);
+    }
+
+    private Pattern buildPattern(String query, boolean useRegex) {
+        try {
+            if (useRegex) {
+                return Pattern.compile(query, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+            } else {
+                return Pattern.compile(Pattern.quote(query),
+                        Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+            }
+        } catch (Exception e) {
+            // Malformed regex – fall back to literal search
+            return Pattern.compile(Pattern.quote(query),
+                    Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        }
+    }
+
+    /**
+     * Returns all text fields that should be searched for a message.
+     */
+    private List<String> getSearchableTexts(ChatMessage message) {
+        List<String> texts = new ArrayList<>();
+
+        texts.add(message.getContent());
+
+        if (message.getType() == ChatMessage.TYPE_TOOL_CALL
+                && message.getToolCalls() != null) {
+            for (LlmApiService.ToolCall toolCall : message.getToolCalls()) {
+                texts.add(toolCall.getName());
+                if (toolCall.getArguments() != null) {
+                    texts.add(toolCall.getArguments().toString());
+                }
+            }
+        }
+
+        if (message.getType() == ChatMessage.TYPE_TOOL_RESULT) {
+            texts.add(message.getToolName());
+        }
+
+        if (message.getType() == ChatMessage.TYPE_ATTACHMENT) {
+            texts.add(message.getDisplayName());
+            texts.add(message.getFilePath());
+        }
+
+        return texts;
+    }
+
+    private List<MatchRange> findMatches(Pattern pattern, String text) {
+        List<MatchRange> ranges = new ArrayList<>();
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            ranges.add(new MatchRange(matcher.start(), matcher.end()));
+        }
+        return ranges;
+    }
+
+    /**
+     * Returns the index of the next result position after {@code currentPosition},
+     * wrapping around to the beginning.
+     */
+    public int nextResultPosition(List<SearchResult> results, int currentPosition) {
+        if (results.isEmpty()) return -1;
+        for (SearchResult result : results) {
+            if (result.position > currentPosition) {
+                return result.position;
+            }
+        }
+        // Wrap around
+        return results.get(0).position;
+    }
+
+    /**
+     * Returns the index of the previous result position before {@code currentPosition},
+     * wrapping around to the end.
+     */
+    public int previousResultPosition(List<SearchResult> results, int currentPosition) {
+        if (results.isEmpty()) return -1;
+        for (int i = results.size() - 1; i >= 0; i--) {
+            if (results.get(i).position < currentPosition) {
+                return results.get(i).position;
+            }
+        }
+        // Wrap around
+        return results.get(results.size() - 1).position;
+    }
+}

--- a/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z" />
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_up.xml
+++ b/app/src/main/res/drawable/ic_arrow_up.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z" />
+</vector>

--- a/app/src/main/res/drawable/ic_export.xml
+++ b/app/src/main/res/drawable/ic_export.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_import.xml
+++ b/app/src/main/res/drawable/ic_import.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19,3H5v2h14V3zM5,15h4v6h6v-6h4l-7,-7 -7,7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+</vector>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -6,6 +6,17 @@
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground">
 
+    <!-- Search bar shown/hidden by ChatFragment -->
+    <include
+        android:id="@+id/searchBar"
+        layout="@layout/view_search_bar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="0dp"
@@ -15,7 +26,7 @@
         app:layout_constraintBottom_toTopOf="@id/inputContainer"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/searchBar"
         tools:listitem="@layout/item_message_user" />
 
     <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/view_search_bar.xml
+++ b/app/src/main/res/layout/view_search_bar.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/colorBackground"
+    android:elevation="4dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingHorizontal="8dp"
+    android:paddingVertical="6dp">
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="8dp"
+        android:contentDescription="@string/search"
+        android:src="@drawable/ic_search"
+        app:tint="?android:attr/textColorSecondary" />
+
+    <EditText
+        android:id="@+id/searchInput"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:background="@null"
+        android:hint="@string/search_hint"
+        android:imeOptions="actionSearch"
+        android:inputType="text"
+        android:maxLines="1"
+        android:singleLine="true"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textColorHint="?android:attr/textColorHint"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/searchResultCount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="12sp"
+        android:visibility="gone" />
+
+    <ImageButton
+        android:id="@+id/searchPrevButton"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/search_prev"
+        android:src="@drawable/ic_arrow_up"
+        android:visibility="gone"
+        app:tint="?android:attr/textColorSecondary" />
+
+    <ImageButton
+        android:id="@+id/searchNextButton"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/search_next"
+        android:src="@drawable/ic_arrow_down"
+        android:visibility="gone"
+        app:tint="?android:attr/textColorSecondary" />
+
+    <ImageButton
+        android:id="@+id/searchCloseButton"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/cancel"
+        android:src="@drawable/ic_close"
+        app:tint="?android:attr/textColorSecondary" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_chat.xml
+++ b/app/src/main/res/menu/menu_chat.xml
@@ -2,6 +2,24 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_search"
+        android:icon="@drawable/ic_search"
+        android:title="@string/search"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_export"
+        android:icon="@drawable/ic_export"
+        android:title="@string/export_chat"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_import"
+        android:icon="@drawable/ic_import"
+        android:title="@string/import_chat"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/action_menu"
         android:icon="@drawable/ic_menu"
         android:title="@string/menu"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,4 +289,30 @@
 
     <!-- SearXNG Search Tool -->
     <string name="searxng_url_hint">e.g. SEARXNG_URL = https://searx.example.com</string>
+
+    <!-- Chat Search -->
+    <string name="search">Search</string>
+    <string name="search_hint">Search messages…</string>
+    <string name="search_prev">Previous result</string>
+    <string name="search_next">Next result</string>
+    <string name="search_result_count">%1$d of %2$d</string>
+    <string name="no_search_results">No results found</string>
+
+    <!-- Chat Export / Import -->
+    <string name="export_chat">Export Chat</string>
+    <string name="import_chat">Import Chat</string>
+    <string name="export_as_markdown">Export as Markdown (.md)</string>
+    <string name="export_as_json">Export as JSON (.json)</string>
+    <string name="export_as_pdf">Export as PDF (.pdf)</string>
+    <string name="import_from_json">Import from JSON</string>
+    <string name="import_from_markdown">Import from Markdown</string>
+    <string name="import_append">Append to current chat</string>
+    <string name="import_replace">Replace current chat (new session)</string>
+    <string name="export_success">Chat exported successfully</string>
+    <string name="export_error">Export failed: %1$s</string>
+    <string name="import_success">Imported %1$d messages</string>
+    <string name="import_error">Import failed: %1$s</string>
+    <string name="import_warnings">%1$d warning(s) during import</string>
+    <string name="import_choose_action">Choose import action</string>
+    <string name="export_choose_format">Choose export format</string>
 </resources>

--- a/app/src/test/java/io/finett/droidclaw/util/ChatExportImportTest.java
+++ b/app/src/test/java/io/finett/droidclaw/util/ChatExportImportTest.java
@@ -1,0 +1,235 @@
+package io.finett.droidclaw.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.ChatSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * JVM unit tests for {@link ChatExportManager} (Markdown only) and
+ * {@link ChatImportManager} (Markdown + JSON parsing that uses only java.* APIs).
+ *
+ * JSON export is excluded here because it relies on org.json.JSONObject which is
+ * Android-only and not available without Robolectric. Full JSON round-trip coverage
+ * lives in the instrumented test suite.
+ */
+public class ChatExportImportTest {
+
+    // ChatExportManager requires a Context for PDF only; Markdown paths don't use it.
+    private ChatExportManager exportManager;
+    private ChatImportManager importManager;
+
+    private List<ChatMessage> sampleMessages;
+    private ChatSession sampleSession;
+
+    @Before
+    public void setUp() {
+        // Pass null context — only Markdown code paths are tested here (no PDF, no Context needed).
+        exportManager = new ChatExportManager(null);
+        importManager = new ChatImportManager();
+
+        sampleMessages = new ArrayList<>();
+        sampleMessages.add(new ChatMessage("Hello from user", ChatMessage.TYPE_USER));
+        sampleMessages.add(new ChatMessage("Hello from assistant!", ChatMessage.TYPE_ASSISTANT));
+        sampleMessages.add(ChatMessage.createToolResultMessage("tc1", "read_file", "file contents here"));
+
+        sampleSession = new ChatSession("session-1", "Test Session", System.currentTimeMillis());
+    }
+
+    // ==================== Markdown Export ====================
+
+    @Test
+    public void markdownExport_containsDocumentHeader() throws IOException {
+        String md = exportToMarkdown(null, sampleMessages);
+        assertTrue("Should start with DroidClaw header", md.contains("# DroidClaw Chat Export"));
+    }
+
+    @Test
+    public void markdownExport_containsSessionMetadata() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        assertTrue("Should contain session title", md.contains("Test Session"));
+    }
+
+    @Test
+    public void markdownExport_containsUserHeader() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        assertTrue("Should contain ### User header", md.contains("### User"));
+    }
+
+    @Test
+    public void markdownExport_containsUserContent() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        assertTrue("Should contain user message content", md.contains("Hello from user"));
+    }
+
+    @Test
+    public void markdownExport_containsAssistantHeader() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        assertTrue("Should contain ### Assistant header", md.contains("### Assistant"));
+    }
+
+    @Test
+    public void markdownExport_containsAssistantContent() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        assertTrue("Should contain assistant message content", md.contains("Hello from assistant!"));
+    }
+
+    @Test
+    public void markdownExport_containsToolResultHeader() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        assertTrue("Should contain tool result header",
+                md.contains("#### Tool Result: `read_file`"));
+    }
+
+    @Test
+    public void markdownExport_containsToolResultContent() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        assertTrue("Should contain tool result content", md.contains("file contents here"));
+    }
+
+    @Test
+    public void markdownExport_withNullSession_stillProducesOutput() throws IOException {
+        String md = exportToMarkdown(null, sampleMessages);
+        assertNotNull(md);
+        assertTrue(md.contains("Hello from user"));
+    }
+
+    @Test
+    public void markdownExport_systemMessageIsBlockquoted() throws IOException {
+        List<ChatMessage> msgs = new ArrayList<>();
+        msgs.add(new ChatMessage("System notice here", ChatMessage.TYPE_SYSTEM));
+        String md = exportToMarkdown(null, msgs);
+        assertTrue("System messages should start with >", md.contains("> **System:**"));
+        assertTrue(md.contains("System notice here"));
+    }
+
+    // ==================== Markdown Round-trip ====================
+
+    @Test
+    public void markdownRoundTrip_preservesMessageCount() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertEquals(sampleMessages.size(), result.messages.size());
+    }
+
+    @Test
+    public void markdownRoundTrip_firstMessageIsUser() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertEquals(ChatMessage.TYPE_USER, result.messages.get(0).getType());
+    }
+
+    @Test
+    public void markdownRoundTrip_userContentPreserved() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertNotNull(result.messages.get(0).getContent());
+        assertTrue(result.messages.get(0).getContent().contains("Hello from user"));
+    }
+
+    @Test
+    public void markdownRoundTrip_secondMessageIsAssistant() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertEquals(ChatMessage.TYPE_ASSISTANT, result.messages.get(1).getType());
+    }
+
+    @Test
+    public void markdownRoundTrip_assistantContentPreserved() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertNotNull(result.messages.get(1).getContent());
+        assertTrue(result.messages.get(1).getContent().contains("Hello from assistant!"));
+    }
+
+    @Test
+    public void markdownRoundTrip_toolResultPreserved() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertEquals(ChatMessage.TYPE_TOOL_RESULT, result.messages.get(2).getType());
+        assertEquals("read_file", result.messages.get(2).getToolName());
+    }
+
+    @Test
+    public void markdownRoundTrip_toolResultContentPreserved() throws IOException {
+        String md = exportToMarkdown(sampleSession, sampleMessages);
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertNotNull(result.messages.get(2).getContent());
+        assertTrue(result.messages.get(2).getContent().contains("file contents here"));
+    }
+
+    @Test
+    public void markdownImport_emptyInput_returnsEmptyList() throws IOException {
+        ChatImportManager.ImportResult result = importFromMarkdown("");
+        assertTrue("Empty input should produce no messages", result.messages.isEmpty());
+    }
+
+    @Test
+    public void markdownImport_onlyHeader_returnsEmptyList() throws IOException {
+        String md = "# DroidClaw Chat Export\n\n**Session:** My Session\n";
+        ChatImportManager.ImportResult result = importFromMarkdown(md);
+        assertTrue("Header-only Markdown should produce no messages", result.messages.isEmpty());
+    }
+
+    // ==================== Filename helper ====================
+
+    @Test
+    public void buildExportFileName_includesMdExtension() {
+        String name = exportManager.buildExportFileName(sampleSession, "md");
+        assertTrue("Should end with .md", name.endsWith(".md"));
+    }
+
+    @Test
+    public void buildExportFileName_includesJsonExtension() {
+        String name = exportManager.buildExportFileName(sampleSession, "json");
+        assertTrue("Should end with .json", name.endsWith(".json"));
+    }
+
+    @Test
+    public void buildExportFileName_includesPdfExtension() {
+        String name = exportManager.buildExportFileName(sampleSession, "pdf");
+        assertTrue("Should end with .pdf", name.endsWith(".pdf"));
+    }
+
+    @Test
+    public void buildExportFileName_fallsBackForNullSession() {
+        String name = exportManager.buildExportFileName(null, "json");
+        assertTrue("Should end with .json", name.endsWith(".json"));
+        assertTrue("Should use droidclaw-chat prefix", name.startsWith("droidclaw-chat"));
+    }
+
+    @Test
+    public void buildExportFileName_sanitizesTitle() {
+        ChatSession special = new ChatSession("s", "Hello: World! (Test)", 0);
+        String name = exportManager.buildExportFileName(special, "md");
+        assertTrue("Should not contain colon", !name.contains(":"));
+        assertTrue("Should not contain exclamation", !name.contains("!"));
+        assertTrue("Should end with .md", name.endsWith(".md"));
+    }
+
+    // ==================== Helpers ====================
+
+    private String exportToMarkdown(ChatSession session, List<ChatMessage> messages)
+            throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        exportManager.exportToMarkdown(session, messages, out);
+        return out.toString("UTF-8");
+    }
+
+    private ChatImportManager.ImportResult importFromMarkdown(String md) throws IOException {
+        return importManager.importFromMarkdown(
+                new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/util/ChatSearchManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/util/ChatSearchManagerTest.java
@@ -1,0 +1,117 @@
+package io.finett.droidclaw.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.finett.droidclaw.model.ChatMessage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ChatSearchManagerTest {
+
+    private ChatSearchManager manager;
+    private List<ChatMessage> messages;
+
+    @Before
+    public void setUp() {
+        manager = new ChatSearchManager();
+        messages = new ArrayList<>();
+        messages.add(new ChatMessage("Hello world", ChatMessage.TYPE_USER));
+        messages.add(new ChatMessage("How are you doing today?", ChatMessage.TYPE_ASSISTANT));
+        messages.add(new ChatMessage("Great, let me check the files for you.", ChatMessage.TYPE_ASSISTANT));
+        messages.add(ChatMessage.createToolResultMessage("id1", "read_file", "File contents here"));
+    }
+
+    @Test
+    public void emptyQuery_returnsEmptyList() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "");
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void nullQuery_returnsEmptyList() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void simpleMatch_findsCorrectPosition() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "world");
+        assertEquals(1, results.size());
+        assertEquals(0, results.get(0).position);
+    }
+
+    @Test
+    public void caseInsensitiveMatch() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "HELLO");
+        assertEquals(1, results.size());
+        assertEquals(0, results.get(0).position);
+    }
+
+    @Test
+    public void multipleMatches_returnsAll() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "the");
+        // "the files" in position 2 and "the" in tool result position 3
+        assertTrue(results.size() >= 1);
+    }
+
+    @Test
+    public void toolResultContent_isSearchable() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "File contents");
+        assertEquals(1, results.size());
+        assertEquals(3, results.get(0).position);
+    }
+
+    @Test
+    public void toolResultToolName_isSearchable() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "read_file");
+        assertEquals(1, results.size());
+        assertEquals(3, results.get(0).position);
+    }
+
+    @Test
+    public void noMatch_returnsEmptyList() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "xyzzy");
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void regexSearch_works() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "\\bworld\\b", true);
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    public void matchRanges_areCorrect() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "Hello");
+        assertEquals(1, results.size());
+        ChatSearchManager.SearchResult result = results.get(0);
+        assertEquals(1, result.matches.size());
+        assertEquals(0, result.matches.get(0).start);
+        assertEquals(5, result.matches.get(0).end);
+    }
+
+    @Test
+    public void nextResultPosition_wrapsAround() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "the");
+        if (results.size() < 2) return; // guard: need ≥2 results to test wrap
+
+        int last = results.get(results.size() - 1).position;
+        int next = manager.nextResultPosition(results, last);
+        assertEquals(results.get(0).position, next);
+    }
+
+    @Test
+    public void previousResultPosition_wrapsAround() {
+        List<ChatSearchManager.SearchResult> results = manager.search(messages, "the");
+        if (results.size() < 2) return;
+
+        int first = results.get(0).position;
+        int prev = manager.previousResultPosition(results, first);
+        assertEquals(results.get(results.size() - 1).position, prev);
+    }
+}


### PR DESCRIPTION
Add in-chat search with result navigation and highlighted matches across message, tool, and context content.

Support exporting sessions to Markdown, JSON, and PDF, plus importing Markdown or JSON into the current chat or a new session. Expose the new actions in the chat menu and cover the helpers with unit tests