### PR TITLE
feat(tool): add searxng web search tool with env var config

### DIFF
--- a/app/src/main/assets/skills/web_search/SKILL.md
+++ b/app/src/main/assets/skills/web_search/SKILL.md
@@ -5,7 +5,7 @@ description: Search the web for information. Use when you need to find current i
 
 # Web Search Skill
 
-This skill enables you to search the web for information using the MCP SearXNG server.
+This skill enables you to search the web for information using the built-in `searxng_web_search` tool.
 
 ## When to Use This Skill
 
@@ -18,30 +18,43 @@ Use this skill when:
 
 ## Capabilities
 
-- Search the web via the MCP `searxng_web_search` tool
+- Search the web via the `searxng_web_search` tool
 - Extract and parse search results
 - Follow links to gather detailed information
 - Summarize findings for the user
 
 ## Available Tools and Commands
 
-### MCP SearXNG Tool
-Use the MCP `searxng_web_search` tool for all web searches.
+### `searxng_web_search`
 
-Example parameters:
-- `query`: the user search query
-- `pageno`: optional, page number (starts at 1)
-- `time_range`: optional, `day`, `month`, or `year`
-- `language`: optional, such as `en` or `all`
+The built-in tool for all web searches.
+
+Parameters:
+- `query` (required): the user search query
+- `pageno` (optional): page number for pagination (starts at 1)
+- `time_range` (optional): filter by time — `day`, `month`, or `year`
+- `language` (optional): language code such as `en`, `ru`, or `all` (default: `all`)
 
 ### Basic Web Page Fetch
+
+For fetching a specific page after finding its URL via search:
+
 ```bash
 curl -L "URL"
 ```
 
+## Configuration
+
+The tool reads the `SEARXNG_URL` environment variable to determine which SearXNG instance to use.
+
+- **Set in:** Settings → Environment Variables
+- **Key:** `SEARXNG_URL`
+- **Value:** `https://searx.example.com` (your instance URL)
+- **Fallback:** if not set, a default public instance is used
+
 ## Guidelines
 
-1. Always use the MCP `searxng_web_search` tool for web searches
+1. Always use the `searxng_web_search` tool for web searches
 2. Cite sources by including URLs in your responses
 3. For complex research, break down the query into multiple searches
 4. Be mindful of rate limiting and respectful of web resources
@@ -61,23 +74,6 @@ curl -L "URL"
 
 **Your approach:**
 1. Use `searxng_web_search` with query "recent news AI" and `time_range: month`
-2. Extract relevant headlines and summaries
-3. Present findings to user
-
-## Limitations
-
-- No JavaScript execution (static content only)
-- Rate limits on API calls
-- Some sites may block automated access
-- Complex pages may require parsing
-1. Use DuckDuckGo API to get instant answer
-2. Parse JSON response for weather data
-3. Present formatted result to user
-
-**User:** "Find recent news about AI"
-
-**Your approach:**
-1. Search with curl to a news site or search engine
 2. Extract relevant headlines and summaries
 3. Present findings to user
 

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -39,6 +39,7 @@ import io.finett.droidclaw.tool.impl.KillBackgroundProcessTool;
 import io.finett.droidclaw.tool.impl.ListBackgroundProcessesTool;
 import io.finett.droidclaw.tool.impl.SetupHeartbeatTool;
 import io.finett.droidclaw.tool.impl.SubmitNotificationTool;
+import io.finett.droidclaw.tool.impl.SearxngSearchTool;
 import io.finett.droidclaw.util.SettingsManager;
 
 public class ToolRegistry {
@@ -122,6 +123,11 @@ public class ToolRegistry {
 
         registerTool(new KillBackgroundProcessTool(context));
         registerTool(new ListBackgroundProcessesTool(context));
+
+        // Web search via SearXNG — reads SEARXNG_URL from env vars
+        if (settingsManager != null) {
+            registerTool(new SearxngSearchTool(settingsManager));
+        }
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/SearxngSearchTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/SearxngSearchTool.java
@@ -1,0 +1,268 @@
+package io.finett.droidclaw.tool.impl;
+
+import android.util.Log;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+import io.finett.droidclaw.util.SettingsManager;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Tool that searches the web via a SearXNG instance.
+ *
+ * <p>The SearXNG URL is resolved from the {@code SEARXNG_URL} environment variable
+ * configured in Settings. If unset, a sensible public default is used.
+ */
+public class SearxngSearchTool implements Tool {
+
+    private static final String TAG = "SearxngSearchTool";
+    private static final String TOOL_NAME = "searxng_web_search";
+    private static final String DEFAULT_SEARXNG_URL = "https://search.sapti.me";
+    private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+
+    private final SettingsManager settingsManager;
+    private final OkHttpClient httpClient;
+
+    public SearxngSearchTool(SettingsManager settingsManager) {
+        this(settingsManager, new OkHttpClient.Builder()
+                .connectTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .build());
+    }
+
+    /** Package-private constructor for tests that need to inject a mock OkHttpClient. */
+    SearxngSearchTool(SettingsManager settingsManager, OkHttpClient httpClient) {
+        this.settingsManager = settingsManager;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addString("query", "The search query string", true)
+                .addInteger("pageno", "Page number for pagination (starts at 1). Default: 1.", false)
+                .addString("time_range", "Time range filter: 'day', 'month', or 'year'. Optional.", false)
+                .addString("language", "Language code (e.g., 'en', 'ru', 'all'). Default: 'all'.", false)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "Search the web using a SearXNG instance. Returns search results with titles, URLs, "
+                + "and snippets. Configure the SearXNG URL via the SEARXNG_URL environment variable "
+                + "in Settings -> Environment Variables.",
+                parameters
+        );
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        try {
+            if (!arguments.has("query")) {
+                return ToolResult.error("Missing required parameter: query");
+            }
+
+            String query = arguments.get("query").getAsString();
+            if (query.trim().isEmpty()) {
+                return ToolResult.error("Query must not be empty");
+            }
+
+            // Resolve SearXNG URL from env vars or fall back to default
+            String searxngUrl = resolveSearxngUrl();
+            if (searxngUrl == null || searxngUrl.isEmpty()) {
+                return ToolResult.error(
+                        "SearXNG URL is not configured. Set the SEARXNG_URL environment variable "
+                        + "in Settings -> Environment Variables."
+                );
+            }
+
+            // Build request URL
+            StringBuilder urlBuilder = new StringBuilder(searxngUrl);
+            if (!searxngUrl.endsWith("/")) {
+                urlBuilder.append("/");
+            }
+            urlBuilder.append("search?format=json&q=")
+                    .append(URLEncoder.encode(query, StandardCharsets.UTF_8.toString()));
+
+            // Optional: pagination
+            int pageNo = 1;
+            if (arguments.has("pageno") && !arguments.get("pageno").isJsonNull()) {
+                pageNo = arguments.get("pageno").getAsInt();
+                if (pageNo < 1) {
+                    pageNo = 1;
+                }
+            }
+            urlBuilder.append("&pageno=").append(pageNo);
+
+            // Optional: time range filter
+            if (arguments.has("time_range") && !arguments.get("time_range").isJsonNull()) {
+                String timeRange = arguments.get("time_range").getAsString();
+                if (isValidTimeRange(timeRange)) {
+                    urlBuilder.append("&time_range=")
+                            .append(URLEncoder.encode(timeRange, StandardCharsets.UTF_8.toString()));
+                }
+            }
+
+            // Optional: language
+            if (arguments.has("language") && !arguments.get("language").isJsonNull()) {
+                String language = arguments.get("language").getAsString();
+                urlBuilder.append("&language=")
+                        .append(URLEncoder.encode(language, StandardCharsets.UTF_8.toString()));
+            } else {
+                urlBuilder.append("&language=all");
+            }
+
+            String requestUrl = urlBuilder.toString();
+            Log.d(TAG, "Searching: " + requestUrl);
+
+            Request request = new Request.Builder()
+                    .url(requestUrl)
+                    .header("Accept", "application/json")
+                    .header("User-Agent", "DroidClaw/1.0")
+                    .build();
+
+            // Execute asynchronously to avoid NetworkOnMainThreadException,
+            // but block the calling thread with a CountDownLatch so the Tool
+            // interface remains synchronous.
+            return executeAsync(request);
+
+        } catch (Exception e) {
+            Log.e(TAG, "Unexpected error", e);
+            String msg = e.getMessage();
+            return ToolResult.error(msg != null ? msg : "Search failed: " + e.getClass().getSimpleName());
+        }
+    }
+
+    private ToolResult executeAsync(Request request) {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ToolResult> resultRef = new AtomicReference<>();
+
+        httpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                Log.e(TAG, "Search request failed", e);
+                String msg = e.getMessage();
+                resultRef.set(ToolResult.error(
+                        msg != null ? msg : "Network request failed: " + e.getClass().getSimpleName()
+                ));
+                latch.countDown();
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                try {
+                    if (!response.isSuccessful()) {
+                        resultRef.set(ToolResult.error(
+                                "HTTP error " + response.code() + ": " + response.message()
+                        ));
+                        return;
+                    }
+
+                    String responseBody = response.body() != null ? response.body().string() : "{}";
+                    resultRef.set(ToolResult.success(parseResults(responseBody)));
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+
+        try {
+            boolean completed = latch.await(DEFAULT_TIMEOUT_SECONDS + 5, TimeUnit.SECONDS);
+            if (!completed) {
+                return ToolResult.error("Search request timed out");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return ToolResult.error("Search was interrupted");
+        }
+
+        ToolResult result = resultRef.get();
+        return result != null ? result : ToolResult.error("No response from search");
+    }
+
+    /** Resolve SearXNG base URL from env vars, or fall back to the built-in default. */
+    private String resolveSearxngUrl() {
+        if (settingsManager != null) {
+            String envUrl = settingsManager.getEnvVar("SEARXNG_URL");
+            if (envUrl != null && !envUrl.trim().isEmpty()) {
+                return envUrl.trim();
+            }
+        }
+        return DEFAULT_SEARXNG_URL;
+    }
+
+    private boolean isValidTimeRange(String timeRange) {
+        return "day".equals(timeRange) || "month".equals(timeRange) || "year".equals(timeRange);
+    }
+
+    /** Parse SearXNG JSON response into a simplified result object. */
+    private JsonObject parseResults(String jsonResponse) {
+        JsonObject result = new JsonObject();
+        JsonArray resultsArray = new JsonArray();
+
+        try {
+            JsonObject root = JsonParser.parseString(jsonResponse).getAsJsonObject();
+
+            if (root.has("results") && root.get("results").isJsonArray()) {
+                JsonArray rawResults = root.getAsJsonArray("results");
+                for (int i = 0; i < rawResults.size(); i++) {
+                    JsonObject rawResult = rawResults.get(i).getAsJsonObject();
+                    JsonObject simplified = new JsonObject();
+
+                    if (rawResult.has("title")) {
+                        simplified.addProperty("title", rawResult.get("title").getAsString());
+                    }
+                    if (rawResult.has("url")) {
+                        simplified.addProperty("url", rawResult.get("url").getAsString());
+                    }
+                    if (rawResult.has("content")) {
+                        simplified.addProperty("snippet", rawResult.get("content").getAsString());
+                    } else if (rawResult.has("snippet")) {
+                        simplified.addProperty("snippet", rawResult.get("snippet").getAsString());
+                    }
+                    if (rawResult.has("engine")) {
+                        simplified.addProperty("engine", rawResult.get("engine").getAsString());
+                    }
+
+                    resultsArray.add(simplified);
+                }
+            }
+
+            result.addProperty("query", root.has("query")
+                    ? root.get("query").getAsString() : "");
+            result.addProperty("result_count", resultsArray.size());
+            result.add("results", resultsArray);
+
+            if (root.has("suggestions") && root.get("suggestions").isJsonArray()) {
+                result.add("suggestions", root.getAsJsonArray("suggestions"));
+            }
+
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to parse search results", e);
+            result.addProperty("error", "Failed to parse response: " + e.getMessage());
+            result.addProperty("raw_response", jsonResponse);
+        }
+
+        return result;
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/tool/impl/SearxngSearchToolTest.java
+++ b/app/src/test/java/io/finett/droidclaw/tool/impl/SearxngSearchToolTest.java
@@ -1,0 +1,209 @@
+package io.finett.droidclaw.tool.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+import io.finett.droidclaw.util.SettingsManager;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SearxngSearchToolTest {
+
+    @Mock
+    private SettingsManager settingsManager;
+
+    @Mock
+    private OkHttpClient mockHttpClient;
+
+    @Mock
+    private Call mockCall;
+
+    private SearxngSearchTool tool;
+
+    @Before
+    public void setUp() {
+        when(mockHttpClient.newCall(any(Request.class))).thenReturn(mockCall);
+        tool = new SearxngSearchTool(settingsManager, mockHttpClient);
+    }
+
+    @Test
+    public void getName_returnsSearxngWebSearch() {
+        assertEquals("searxng_web_search", tool.getName());
+    }
+
+    @Test
+    public void getDefinition_hasCorrectNameAndParameters() {
+        ToolDefinition definition = tool.getDefinition();
+
+        assertNotNull(definition);
+        assertEquals("searxng_web_search", definition.getFunction().getName());
+
+        JsonObject params = definition.getFunction().getParameters();
+        assertTrue(params.has("properties"));
+        assertTrue(params.getAsJsonObject("properties").has("query"));
+        assertTrue(params.getAsJsonObject("properties").has("pageno"));
+        assertTrue(params.getAsJsonObject("properties").has("time_range"));
+        assertTrue(params.getAsJsonObject("properties").has("language"));
+    }
+
+    @Test
+    public void execute_missingQuery_returnsError() {
+        JsonObject args = new JsonObject();
+        ToolResult result = tool.execute(args);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Missing required parameter: query"));
+    }
+
+    @Test
+    public void execute_emptyQuery_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("query", "   ");
+        ToolResult result = tool.execute(args);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Query must not be empty"));
+    }
+
+    @Test
+    public void execute_successfulResponse_returnsParsedResults() {
+        when(settingsManager.getEnvVar("SEARXNG_URL")).thenReturn(null);
+
+        String jsonResponse = "{"
+                + "\"query\":\"kotlin\","
+                + "\"results\":["
+                + "  {\"title\":\"Kotlin Lang\",\"url\":\"https://kotlinlang.org\",\"content\":\"Official site\"}"
+                + "]"
+                + "}";
+
+        // Capture the callback and invoke it with a mock response
+        doAnswer(invocation -> {
+            Callback callback = invocation.getArgument(0);
+            Response response = new Response.Builder()
+                    .request(new Request.Builder().url("https://example.com").build())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(ResponseBody.create(jsonResponse, okhttp3.MediaType.parse("application/json")))
+                    .build();
+            callback.onResponse(mockCall, response);
+            return null;
+        }).when(mockCall).enqueue(any(Callback.class));
+
+        JsonObject args = new JsonObject();
+        args.addProperty("query", "kotlin");
+        ToolResult result = tool.execute(args);
+
+        assertTrue(result.isSuccess());
+        JsonObject parsed = JsonParser.parseString(result.getContent()).getAsJsonObject();
+        assertEquals("kotlin", parsed.get("query").getAsString());
+        assertEquals(1, parsed.get("result_count").getAsInt());
+    }
+
+    @Test
+    public void execute_httpError_returnsError() {
+        when(settingsManager.getEnvVar("SEARXNG_URL")).thenReturn(null);
+
+        doAnswer(invocation -> {
+            Callback callback = invocation.getArgument(0);
+            Response response = new Response.Builder()
+                    .request(new Request.Builder().url("https://example.com").build())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(500)
+                    .message("Internal Server Error")
+                    .body(ResponseBody.create("error", okhttp3.MediaType.parse("text/plain")))
+                    .build();
+            callback.onResponse(mockCall, response);
+            return null;
+        }).when(mockCall).enqueue(any(Callback.class));
+
+        JsonObject args = new JsonObject();
+        args.addProperty("query", "test");
+        ToolResult result = tool.execute(args);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("HTTP error 500"));
+    }
+
+    @Test
+    public void execute_networkFailure_returnsError() {
+        when(settingsManager.getEnvVar("SEARXNG_URL")).thenReturn(null);
+
+        doAnswer(invocation -> {
+            Callback callback = invocation.getArgument(0);
+            callback.onFailure(mockCall, new IOException("Connection refused"));
+            return null;
+        }).when(mockCall).enqueue(any(Callback.class));
+
+        JsonObject args = new JsonObject();
+        args.addProperty("query", "test");
+        ToolResult result = tool.execute(args);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Connection refused"));
+    }
+
+    @Test
+    public void parseResults_extractsResultsCorrectly() {
+        String json = "{"
+                + "\"query\":\"kotlin\","
+                + "\"results\":["
+                + "  {\"title\":\"Kotlin Lang\",\"url\":\"https://kotlinlang.org\",\"content\":\"Official site\"},"
+                + "  {\"title\":\"Wiki\",\"url\":\"https://wikipedia.org/wiki/Kotlin\",\"snippet\":\"Programming language\"}"
+                + "],"
+                + "\"suggestions\":[\"kotlin coroutines\"]"
+                + "}";
+
+        JsonObject parsed = parseResultsViaReflection(json);
+
+        assertEquals("kotlin", parsed.get("query").getAsString());
+        assertEquals(2, parsed.get("result_count").getAsInt());
+        assertTrue(parsed.has("results"));
+        assertTrue(parsed.has("suggestions"));
+    }
+
+    @Test
+    public void parseResults_handlesMalformedJson() {
+        String badJson = "not json";
+
+        JsonObject parsed = parseResultsViaReflection(badJson);
+
+        assertTrue(parsed.has("error"));
+        assertTrue(parsed.has("raw_response"));
+    }
+
+    // Helper to access private parseResults method
+    private JsonObject parseResultsViaReflection(String json) {
+        try {
+            java.lang.reflect.Method method = SearxngSearchTool.class.getDeclaredMethod("parseResults", String.class);
+            method.setAccessible(true);
+            return (JsonObject) method.invoke(tool, json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Add a built-in `searxng_web_search` tool that queries a SearXNG instance via JSON API. The tool resolves the SearXNG URL from the `SEARXNG_URL` environment variable (configured in Settings → Environment Variables) and falls back to a default public instance when unset.

To avoid NetworkOnMainThreadException on Android, HTTP requests are executed asynchronously via OkHttp's enqueue() and synchronized with a CountDownLatch, preserving the synchronous Tool interface.

Register the tool in ToolRegistry and update the web_search skill documentation to remove stale MCP references.

Includes unit tests covering success, HTTP error, network failure, and result parsing paths.