### PR TITLE
feat(agent): add configurable network timeouts for LLM and SearXNG

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
+++ b/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
@@ -180,10 +180,16 @@ public class LlmApiService {
         this.settingsManager = settingsManager;
         this.gson = new Gson();
         this.mainHandler = new Handler(Looper.getMainLooper());
+
+        io.finett.droidclaw.model.AgentConfig config = settingsManager.getAgentConfig();
+        long connectTimeout = config != null ? config.getLlmConnectTimeout() : 30;
+        long readTimeout = config != null ? config.getLlmReadTimeout() : 120;
+        long writeTimeout = config != null ? config.getLlmWriteTimeout() : 30;
+
         this.client = new OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(120, TimeUnit.SECONDS)
-                .writeTimeout(30, TimeUnit.SECONDS)
+                .connectTimeout(connectTimeout, TimeUnit.SECONDS)
+                .readTimeout(readTimeout, TimeUnit.SECONDS)
+                .writeTimeout(writeTimeout, TimeUnit.SECONDS)
                 .retryOnConnectionFailure(true)
                 .build();
     }

--- a/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
@@ -35,6 +35,9 @@ public class AgentSettingsFragment extends Fragment {
     private SwitchMaterial switchBackgroundShellAccess;
     private SwitchMaterial switchBackgroundExec;
     private TextInputEditText inputCustomAllowlist;
+    private TextInputEditText inputLlmConnectTimeout;
+    private TextInputEditText inputLlmReadTimeout;
+    private TextInputEditText inputLlmWriteTimeout;
     private Button buttonSave;
 
     private SettingsManager settingsManager;
@@ -75,6 +78,9 @@ public class AgentSettingsFragment extends Fragment {
         switchBackgroundShellAccess = view.findViewById(R.id.switch_background_shell_access);
         switchBackgroundExec = view.findViewById(R.id.switch_background_exec);
         inputCustomAllowlist = view.findViewById(R.id.input_custom_allowlist);
+        inputLlmConnectTimeout = view.findViewById(R.id.input_llm_connect_timeout);
+        inputLlmReadTimeout = view.findViewById(R.id.input_llm_read_timeout);
+        inputLlmWriteTimeout = view.findViewById(R.id.input_llm_write_timeout);
         buttonSave = view.findViewById(R.id.button_save);
     }
 
@@ -152,6 +158,12 @@ public class AgentSettingsFragment extends Fragment {
             }
             inputCustomAllowlist.setText(allowlistText.toString());
         }
+
+        if (agentConfig != null) {
+            inputLlmConnectTimeout.setText(String.valueOf(agentConfig.getLlmConnectTimeout()));
+            inputLlmReadTimeout.setText(String.valueOf(agentConfig.getLlmReadTimeout()));
+            inputLlmWriteTimeout.setText(String.valueOf(agentConfig.getLlmWriteTimeout()));
+        }
     }
 
     private void setupListeners() {
@@ -219,6 +231,19 @@ public class AgentSettingsFragment extends Fragment {
             }
         }
 
+        // Validate network timeouts
+        String llmConnectTimeoutStr = inputLlmConnectTimeout.getText().toString().trim();
+        String llmReadTimeoutStr = inputLlmReadTimeout.getText().toString().trim();
+        String llmWriteTimeoutStr = inputLlmWriteTimeout.getText().toString().trim();
+
+        if (!validateTimeout(inputLlmConnectTimeout, llmConnectTimeoutStr)) return;
+        if (!validateTimeout(inputLlmReadTimeout, llmReadTimeoutStr)) return;
+        if (!validateTimeout(inputLlmWriteTimeout, llmWriteTimeoutStr)) return;
+
+        int llmConnectTimeout = Integer.parseInt(llmConnectTimeoutStr);
+        int llmReadTimeout = Integer.parseInt(llmReadTimeoutStr);
+        int llmWriteTimeout = Integer.parseInt(llmWriteTimeoutStr);
+
         agentConfig.setDefaultModel(selectedModel);
         agentConfig.setShellAccess(switchShellAccess.isChecked());
         agentConfig.setSandboxMode(sandboxMode);
@@ -228,11 +253,27 @@ public class AgentSettingsFragment extends Fragment {
         agentConfig.setBackgroundShellEnabled(switchBackgroundShellAccess.isChecked());
         agentConfig.setBackgroundExecEnabled(switchBackgroundExec.isChecked());
         agentConfig.setCustomAllowlist(customAllowlist);
-
+        agentConfig.setLlmConnectTimeout(llmConnectTimeout);
+        agentConfig.setLlmReadTimeout(llmReadTimeout);
+        agentConfig.setLlmWriteTimeout(llmWriteTimeout);
 
         settingsManager.setAgentConfig(agentConfig);
 
         Toast.makeText(requireContext(), R.string.save_settings, Toast.LENGTH_SHORT).show();
         Navigation.findNavController(requireView()).navigateUp();
+    }
+
+    private boolean validateTimeout(TextInputEditText input, String value) {
+        try {
+            int seconds = Integer.parseInt(value);
+            if (seconds < 1 || seconds > 600) {
+                input.setError("Timeout must be between 1 and 600 seconds");
+                return false;
+            }
+            return true;
+        } catch (NumberFormatException e) {
+            input.setError(getString(R.string.validation_invalid_number));
+            return false;
+        }
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
+++ b/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
@@ -13,9 +13,15 @@ public class AgentConfig {
     private boolean backgroundShellEnabled; // allow shell/python in background workers
     private boolean backgroundExecEnabled; // allow agent to dispatch any tool with background=true
     private List<String> customAllowlist; // extra executable paths for relaxed mode
+    private int llmConnectTimeout;   // seconds
+    private int llmReadTimeout;      // seconds
+    private int llmWriteTimeout;     // seconds
 
     public AgentConfig() {
         this.customAllowlist = new ArrayList<>();
+        this.llmConnectTimeout = 30;
+        this.llmReadTimeout = 120;
+        this.llmWriteTimeout = 30;
     }
 
     public AgentConfig(String defaultModel, boolean shellAccess, String sandboxMode,
@@ -30,6 +36,9 @@ public class AgentConfig {
         this.backgroundShellEnabled = backgroundShellEnabled;
         this.backgroundExecEnabled = false;
         this.customAllowlist = customAllowlist != null ? new ArrayList<>(customAllowlist) : new ArrayList<>();
+        this.llmConnectTimeout = 30;
+        this.llmReadTimeout = 120;
+        this.llmWriteTimeout = 30;
     }
 
     public static AgentConfig getDefaults() {
@@ -91,6 +100,30 @@ public class AgentConfig {
 
     public void setShellTimeout(int shellTimeout) {
         this.shellTimeout = shellTimeout;
+    }
+
+    public int getLlmConnectTimeout() {
+        return llmConnectTimeout;
+    }
+
+    public void setLlmConnectTimeout(int llmConnectTimeout) {
+        this.llmConnectTimeout = llmConnectTimeout;
+    }
+
+    public int getLlmReadTimeout() {
+        return llmReadTimeout;
+    }
+
+    public void setLlmReadTimeout(int llmReadTimeout) {
+        this.llmReadTimeout = llmReadTimeout;
+    }
+
+    public int getLlmWriteTimeout() {
+        return llmWriteTimeout;
+    }
+
+    public void setLlmWriteTimeout(int llmWriteTimeout) {
+        this.llmWriteTimeout = llmWriteTimeout;
     }
 
     public boolean isBackgroundShellEnabled() {

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/SearxngSearchTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/SearxngSearchTool.java
@@ -40,16 +40,36 @@ public class SearxngSearchTool implements Tool {
     private final OkHttpClient httpClient;
 
     public SearxngSearchTool(SettingsManager settingsManager) {
-        this(settingsManager, new OkHttpClient.Builder()
-                .connectTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .readTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .build());
+        this.settingsManager = settingsManager;
+        long timeout = parseSearxngTimeout(settingsManager, DEFAULT_TIMEOUT_SECONDS);
+        this.httpClient = new OkHttpClient.Builder()
+                .connectTimeout(timeout, TimeUnit.SECONDS)
+                .readTimeout(timeout, TimeUnit.SECONDS)
+                .build();
     }
 
     /** Package-private constructor for tests that need to inject a mock OkHttpClient. */
     SearxngSearchTool(SettingsManager settingsManager, OkHttpClient httpClient) {
         this.settingsManager = settingsManager;
         this.httpClient = httpClient;
+    }
+
+    private static long parseSearxngTimeout(SettingsManager sm, long defaultSeconds) {
+        String value = sm.getEnvVar("SEARXNG_TIMEOUT");
+        if (value == null || value.trim().isEmpty()) {
+            return defaultSeconds;
+        }
+        try {
+            long seconds = Long.parseLong(value.trim());
+            if (seconds <= 0) {
+                Log.w(TAG, "SEARXNG_TIMEOUT is not positive, using default " + defaultSeconds + "s");
+                return defaultSeconds;
+            }
+            return seconds;
+        } catch (NumberFormatException e) {
+            Log.w(TAG, "Invalid SEARXNG_TIMEOUT value '" + value + "', using default " + defaultSeconds + "s");
+            return defaultSeconds;
+        }
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_agent_settings.xml
+++ b/app/src/main/res/layout/fragment_agent_settings.xml
@@ -258,6 +258,73 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <!-- Divider -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="8dp"
+            android:background="?android:attr/listDivider" />
+
+        <!-- Network Timeouts Header -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/network_timeouts"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp" />
+
+        <!-- LLM Connect Timeout -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/llm_connect_timeout"
+            app:helperText="@string/llm_connect_timeout_description"
+            app:boxBackgroundMode="outline">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_llm_connect_timeout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- LLM Read Timeout -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/llm_read_timeout"
+            app:helperText="@string/llm_read_timeout_description"
+            app:boxBackgroundMode="outline">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_llm_read_timeout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- LLM Write Timeout -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/llm_write_timeout"
+            app:helperText="@string/llm_write_timeout_description"
+            app:boxBackgroundMode="outline">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_llm_write_timeout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
         <!-- Save Button -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/button_save"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,15 @@
     <string name="background_exec_description">Allow the agent to run any tool asynchronously with background=true</string>
     <string name="custom_allowlist">Custom Command Allowlist</string>
     <string name="custom_allowlist_description">Extra executable paths allowed in Relaxed mode (one per line)</string>
+    <string name="network_timeouts">Network Timeouts</string>
+    <string name="llm_connect_timeout">LLM Connect Timeout (seconds)</string>
+    <string name="llm_connect_timeout_description">Connection timeout for LLM API</string>
+    <string name="llm_read_timeout">LLM Read Timeout (seconds)</string>
+    <string name="llm_read_timeout_description">Response read timeout for LLM API</string>
+    <string name="llm_write_timeout">LLM Write Timeout (seconds)</string>
+    <string name="llm_write_timeout_description">Request write timeout for LLM API</string>
+    <string name="searxng_timeout">SearXNG Timeout (seconds)</string>
+    <string name="searxng_timeout_description">Search request timeout for SearXNG</string>
 
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Welcome to DroidClaw</string>


### PR DESCRIPTION
Add LLM connect, read, and write timeout fields to AgentConfig and expose them in the Agent Settings UI. LlmApiService now reads these values from AgentConfig instead of using hardcoded defaults.

SearXNG search timeout is now configurable via the SEARXNG_TIMEOUT environment variable, falling back to the default 30 seconds when unset.