### PR TITLE
feat(chat): reorganize toolbar menu with search icon and overflow

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -316,17 +316,6 @@ public class ChatFragment extends Fragment {
         } else if (id == R.id.action_import) {
             showImportDialog();
             return true;
-        } else if (id == R.id.action_chats) {
-            if (requireActivity() instanceof MainActivity) {
-                ((MainActivity) requireActivity()).openDrawer();
-            }
-            return true;
-        } else if (id == R.id.action_files) {
-            Navigation.findNavController(requireView()).navigate(R.id.fileBrowserFragment);
-            return true;
-        } else if (id == R.id.action_settings) {
-            Navigation.findNavController(requireView()).navigate(R.id.settingsFragment);
-            return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -2,8 +2,9 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
     <path
-        android:fillColor="#000000"
+        android:fillColor="@android:color/white"
         android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
 </vector>

--- a/app/src/main/res/menu/menu_chat.xml
+++ b/app/src/main/res/menu/menu_chat.xml
@@ -9,31 +9,12 @@
 
     <item
         android:id="@+id/action_export"
-        android:icon="@drawable/ic_export"
         android:title="@string/export_chat"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/action_import"
-        android:icon="@drawable/ic_import"
         android:title="@string/import_chat"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
 
-    <item
-        android:id="@+id/action_menu"
-        android:icon="@drawable/ic_menu"
-        android:title="@string/menu"
-        app:showAsAction="always">
-        <menu>
-            <item
-                android:id="@+id/action_chats"
-                android:title="@string/chats" />
-            <item
-                android:id="@+id/action_files"
-                android:title="@string/files" />
-            <item
-                android:id="@+id/action_settings"
-                android:title="@string/settings" />
-        </menu>
-    </item>
 </menu>


### PR DESCRIPTION
Remove the hamburger menu dropdown containing Chats, Files, and Settings. Move Export and Import actions to the overflow menu (three dots). Keep Search as the only visible toolbar icon and fix its theme-aware tinting.