### PR TITLE
feat: agent loop in foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,11 @@
             android:foregroundServiceType="dataSync"
             android:exported="false" />
 
+        <service
+            android:name=".service.AgentExecutionService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -192,6 +192,17 @@ public class ChatFragment extends Fragment {
                 agentExecutionService.registerUICallback(currentSessionId, agentUiCallback);
                 if (agentExecutionService.isSessionActive(currentSessionId)) {
                     setLoading(true);
+                } else {
+                    // Session completed or errored while UI was detached — the service
+                    // already persisted the final messages.  Reload from repository and
+                    // clear the stale loading spinner so the user sees the response.
+                    setLoading(false);
+                    List<ChatMessage> savedMessages = chatRepository.loadMessages(currentSessionId);
+                    if (!savedMessages.isEmpty()) {
+                        chatAdapter.setMessages(savedMessages);
+                        scrollToBottom();
+                    }
+                    updateToolbarTitle();
                 }
             }
 

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -1,9 +1,14 @@
 package io.finett.droidclaw.fragment;
 
 import android.app.AlertDialog;
+import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
+import android.content.ServiceConnection;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -44,9 +49,6 @@ import io.finett.droidclaw.MainActivity;
 import io.finett.droidclaw.R;
 import io.finett.droidclaw.adapter.ChatAdapter;
 import io.finett.droidclaw.agent.AgentLoop;
-import io.finett.droidclaw.agent.ConversationSummarizer;
-import io.finett.droidclaw.agent.IdentityManager;
-import io.finett.droidclaw.agent.MemoryContextBuilder;
 import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.filesystem.FileUploadManager;
 import io.finett.droidclaw.filesystem.WorkspaceManager;
@@ -55,9 +57,8 @@ import io.finett.droidclaw.model.ChatSession;
 import io.finett.droidclaw.model.FileAttachment;
 import io.finett.droidclaw.model.TaskResult;
 import io.finett.droidclaw.repository.ChatRepository;
-import io.finett.droidclaw.repository.MemoryRepository;
+import io.finett.droidclaw.service.AgentExecutionService;
 import io.finett.droidclaw.service.ChatContinuationService;
-import io.finett.droidclaw.tool.ToolRegistry;
 import io.finett.droidclaw.util.ChatExportManager;
 import io.finett.droidclaw.util.ChatImportManager;
 import io.finett.droidclaw.util.ChatSearchManager;
@@ -92,15 +93,118 @@ public class ChatFragment extends Fragment {
     private LlmApiService apiService;
     private SettingsManager settingsManager;
     private ChatRepository chatRepository;
-    private MemoryRepository memoryRepository;
-    private ToolRegistry toolRegistry;
-    private AgentLoop agentLoop;
-    private IdentityManager identityManager;
     private WorkspaceManager workspaceManager;
     private FileUploadManager fileUploadManager;
     private ChatContinuationService continuationService;
     private String currentSessionId;
     private TaskResult pendingTaskResult;
+    private AgentExecutionService agentExecutionService;
+    private boolean serviceBound;
+    private boolean serviceBinding;
+    private List<ChatMessage> pendingServiceConversationHistory;
+    private int pendingServiceContextWindow;
+
+    private final AgentExecutionService.UICallback agentUiCallback = new AgentExecutionService.UICallback() {
+        @Override
+        public void onProgress(String status) {
+            if (!isAdded()) {
+                return;
+            }
+            updateStatus(status, null);
+        }
+
+        @Override
+        public void onToolCall(String toolName, String arguments) {
+            if (!isAdded()) {
+                return;
+            }
+            Log.d(TAG, "Tool call: " + toolName + " with args: " + arguments);
+
+            boolean isBackground = arguments.contains("\"background\":true")
+                    || arguments.contains("\"background\": true");
+            String statusMessage = isBackground
+                    ? "Dispatching " + formatToolName(toolName) + " to background..."
+                    : getToolStatusMessage(toolName, arguments);
+            updateStatus(statusMessage, null);
+        }
+
+        @Override
+        public void onToolResult(String toolName, String result) {
+            if (!isAdded()) {
+                return;
+            }
+            Log.d(TAG, "Tool result: " + toolName + " -> "
+                    + result.substring(0, Math.min(100, result.length())));
+            updateStatus("✓ " + formatToolName(toolName) + " completed", null);
+        }
+
+        @Override
+        public void onComplete(String finalResponse, List<ChatMessage> updatedHistory) {
+            if (!isAdded() || getContext() == null) {
+                return;
+            }
+
+            setLoading(false);
+            chatAdapter.setMessages(updatedHistory);
+            scrollToBottom();
+
+            saveMessages();
+            updateSessionMetadata(null);
+            Log.d(TAG, "onComplete: Agent completed. Total messages: "
+                    + chatAdapter.getItemCount());
+
+            generateTitleIfNeeded(updatedHistory);
+            updateToolbarTitle();
+        }
+
+        @Override
+        public void onError(String error) {
+            if (!isAdded() || getContext() == null) {
+                Log.w(TAG, "onError: Fragment not attached, ignoring error: " + error);
+                return;
+            }
+            setLoading(false);
+            Toast.makeText(requireContext(), error, Toast.LENGTH_LONG).show();
+        }
+
+        @Override
+        public void onApprovalRequired(String toolName, String description,
+                                       JsonObject arguments,
+                                       AgentLoop.ApprovalCallback approvalCallback) {
+            if (!isAdded() || getContext() == null) {
+                approvalCallback.onDenied();
+                return;
+            }
+            requireActivity().runOnUiThread(() ->
+                    showApprovalDialog(toolName, description, approvalCallback));
+        }
+    };
+
+    private final ServiceConnection agentServiceConnection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            AgentExecutionService.LocalBinder binder = (AgentExecutionService.LocalBinder) service;
+            agentExecutionService = binder.getService();
+            serviceBound = true;
+            serviceBinding = false;
+
+            if (currentSessionId != null) {
+                agentExecutionService.registerUICallback(currentSessionId, agentUiCallback);
+                if (agentExecutionService.isSessionActive(currentSessionId)) {
+                    setLoading(true);
+                }
+            }
+
+            runPendingAgentRequest();
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            serviceBound = false;
+            serviceBinding = false;
+            agentExecutionService = null;
+        }
+    };
 
     // Search state
     private ChatSearchManager chatSearchManager;
@@ -196,18 +300,6 @@ public class ChatFragment extends Fragment {
             }
         );
 
-        identityManager = new IdentityManager(requireContext(), workspaceManager);
-        memoryRepository = new MemoryRepository(workspaceManager);
-
-        int contextWindow = getModelContextWindow();
-        ConversationSummarizer summarizer = new ConversationSummarizer(apiService, memoryRepository, contextWindow);
-        MemoryContextBuilder memoryContext = new MemoryContextBuilder(memoryRepository);
-
-        toolRegistry = new ToolRegistry(requireContext(), settingsManager);
-        agentLoop = new AgentLoop(apiService, toolRegistry, settingsManager, summarizer, memoryContext);
-
-        loadIdentityContext();
-
         chatSearchManager = new ChatSearchManager();
         chatExportManager = new ChatExportManager(requireContext());
         chatImportManager = new ChatImportManager();
@@ -221,17 +313,61 @@ public class ChatFragment extends Fragment {
         }
     }
 
-    /**
-     * Loads identity context (soul.md and user.md) and sets it in the agent loop.
-     */
-    private void loadIdentityContext() {
-        try {
-            List<ChatMessage> identityMessages = identityManager.getIdentityMessages();
-            agentLoop.setIdentityContext(identityMessages);
-            Log.d(TAG, "Loaded identity context: " + identityMessages.size() + " message(s)");
-        } catch (Exception e) {
-            Log.w(TAG, "Failed to load identity context, continuing without it", e);
+    private void bindAgentExecutionService() {
+        if (!isAdded() || serviceBound || serviceBinding) {
+            return;
         }
+
+        Intent intent = new Intent(requireContext(), AgentExecutionService.class);
+        serviceBinding = true;
+        boolean bound = requireContext().bindService(
+                intent,
+                agentServiceConnection,
+                Context.BIND_AUTO_CREATE
+        );
+        if (!bound) {
+            serviceBinding = false;
+            Log.w(TAG, "Failed to bind AgentExecutionService");
+        }
+    }
+
+    private void startAgentExecutionServiceIfNeeded() {
+        if (!isAdded()) {
+            return;
+        }
+
+        Intent intent = new Intent(requireContext(), AgentExecutionService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            requireContext().startForegroundService(intent);
+        } else {
+            requireContext().startService(intent);
+        }
+    }
+
+    private void dispatchAgentRequest(List<ChatMessage> conversationHistory) {
+        pendingServiceConversationHistory = new ArrayList<>(conversationHistory);
+        pendingServiceContextWindow = getModelContextWindow();
+
+        startAgentExecutionServiceIfNeeded();
+
+        if (serviceBound && agentExecutionService != null) {
+            runPendingAgentRequest();
+        } else {
+            bindAgentExecutionService();
+        }
+    }
+
+    private void runPendingAgentRequest() {
+        if (!serviceBound || agentExecutionService == null || currentSessionId == null
+                || pendingServiceConversationHistory == null) {
+            return;
+        }
+
+        List<ChatMessage> history = pendingServiceConversationHistory;
+        int contextWindow = pendingServiceContextWindow;
+        pendingServiceConversationHistory = null;
+
+        agentExecutionService.startAgentLoop(currentSessionId, history, contextWindow);
     }
 
     @Nullable
@@ -860,67 +996,7 @@ public class ChatFragment extends Fragment {
 
         List<ChatMessage> conversationHistory = new ArrayList<>(chatAdapter.getMessages());
 
-        agentLoop.start(conversationHistory, new AgentLoop.AgentCallback() {
-            @Override
-            public void onProgress(String status) {
-                updateStatus(status, null);
-            }
-
-            @Override
-            public void onToolCall(String toolName, String arguments) {
-                Log.d(TAG, "Tool call: " + toolName + " with args: " + arguments);
-
-                boolean isBackground = arguments.contains("\"background\":true")
-                        || arguments.contains("\"background\": true");
-                String statusMessage = isBackground
-                        ? "Dispatching " + formatToolName(toolName) + " to background..."
-                        : getToolStatusMessage(toolName, arguments);
-                String iterationInfo = "Step " + agentLoop.getIterationCount() + "/20";
-                updateStatus(statusMessage, iterationInfo);
-            }
-
-            @Override
-            public void onToolResult(String toolName, String result) {
-                Log.d(TAG, "Tool result: " + toolName + " -> "
-                        + result.substring(0, Math.min(100, result.length())));
-                String iterationInfo = "Step " + agentLoop.getIterationCount() + "/20";
-                updateStatus("✓ " + formatToolName(toolName) + " completed", iterationInfo);
-            }
-
-            @Override
-            public void onComplete(String finalResponse, List<ChatMessage> updatedHistory) {
-                setLoading(false);
-
-                chatAdapter.setMessages(updatedHistory);
-                scrollToBottom();
-
-                saveMessages();
-                updateSessionMetadata(null);
-                Log.d(TAG, "onComplete: Agent completed. Total messages: "
-                        + chatAdapter.getItemCount());
-
-                generateTitleIfNeeded(updatedHistory);
-                updateToolbarTitle();
-            }
-
-            @Override
-            public void onError(String error) {
-                if (!isAdded() || getContext() == null) {
-                    Log.w(TAG, "onError: Fragment not attached, ignoring error: " + error);
-                    return;
-                }
-                setLoading(false);
-                Toast.makeText(requireContext(), error, Toast.LENGTH_LONG).show();
-            }
-
-            @Override
-            public void onApprovalRequired(String toolName, String description,
-                                           JsonObject arguments,
-                                           AgentLoop.ApprovalCallback approvalCallback) {
-                requireActivity().runOnUiThread(() ->
-                    showApprovalDialog(toolName, description, approvalCallback));
-            }
-        });
+        dispatchAgentRequest(conversationHistory);
     }
 
     /**
@@ -1032,6 +1108,25 @@ public class ChatFragment extends Fragment {
     }
 
     @Override
+    public void onStart() {
+        super.onStart();
+        bindAgentExecutionService();
+    }
+
+    @Override
+    public void onStop() {
+        if (serviceBound && agentExecutionService != null) {
+            if (currentSessionId != null) {
+                agentExecutionService.unregisterUICallback(currentSessionId);
+            }
+            requireContext().unbindService(agentServiceConnection);
+            serviceBound = false;
+            agentExecutionService = null;
+        }
+        super.onStop();
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
         // Reload settings in case the user changed provider/model in the Settings screen
@@ -1040,24 +1135,11 @@ public class ChatFragment extends Fragment {
         if (requireActivity() instanceof MainActivity) {
             apiService = ((MainActivity) requireActivity()).getApiService();
         }
-        // Propagate the refreshed service to the agent loop components
-        int contextWindow = getModelContextWindow();
-        io.finett.droidclaw.agent.ConversationSummarizer summarizer =
-                new io.finett.droidclaw.agent.ConversationSummarizer(
-                        apiService, memoryRepository, contextWindow);
-        io.finett.droidclaw.agent.MemoryContextBuilder memoryContext =
-                new io.finett.droidclaw.agent.MemoryContextBuilder(memoryRepository);
-        agentLoop = new AgentLoop(apiService, toolRegistry, settingsManager, summarizer, memoryContext);
-        loadIdentityContext();
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        // Do NOT cancel requests here — the API service is Activity-scoped
-        // and requests should survive chat switches. Only shut down tools.
-        if (toolRegistry != null) {
-            toolRegistry.shutdown();
-        }
+        // Requests now live in AgentExecutionService and continue after the UI is destroyed.
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
@@ -1,0 +1,502 @@
+package io.finett.droidclaw.service;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.PowerManager;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+
+import com.google.gson.JsonObject;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.SynchronousQueue;
+
+import io.finett.droidclaw.MainActivity;
+import io.finett.droidclaw.R;
+import io.finett.droidclaw.agent.AgentLoop;
+import io.finett.droidclaw.agent.ConversationSummarizer;
+import io.finett.droidclaw.agent.IdentityManager;
+import io.finett.droidclaw.agent.MemoryContextBuilder;
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.filesystem.WorkspaceManager;
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.repository.ChatRepository;
+import io.finett.droidclaw.repository.MemoryRepository;
+import io.finett.droidclaw.tool.ToolRegistry;
+import io.finett.droidclaw.util.SettingsManager;
+
+/**
+ * Foreground service that hosts the AgentLoop so API requests survive app minimization.
+ *
+ * <p>UI clients (ChatFragment) bind to this service, register a UICallback, and delegate
+ * all agent interactions through it. When the UI unbinds, the loop keeps running and posts
+ * a foreground notification. If a tool requires approval while the UI is detached, the
+ * worker thread parks on a SynchronousQueue until the user returns and approves/denies.</p>
+ */
+public class AgentExecutionService extends Service {
+
+    private static final String TAG = "AgentExecutionService";
+
+    static final String CHANNEL_ID = "droidclaw_agent_exec";
+    private static final int NOTIFICATION_ID = 8802;
+
+    // ==================== Session state ====================
+
+    /** Per-session state kept for the lifetime of the loop. */
+    public static class AgentSession {
+        public enum State { RUNNING, PAUSED_APPROVAL, COMPLETED, ERROR }
+
+        public final String sessionId;
+
+        volatile State state = State.RUNNING;
+
+        /** Queued approval request waiting for the user to return. */
+        volatile PendingApproval pendingApproval;
+
+        /** Worker thread parks here when approval is needed and UI is detached. */
+        final SynchronousQueue<Boolean> approvalQueue = new SynchronousQueue<>();
+
+        /** Snapshot of conversation history after the loop completes. */
+        volatile List<ChatMessage> finalHistory;
+
+        /** Final response text. */
+        volatile String finalResponse;
+
+        /** Error text if state == ERROR. */
+        volatile String errorMessage;
+
+        AgentSession(String sessionId) {
+            this.sessionId = sessionId;
+        }
+    }
+
+    /** Approval request paused until UI reconnects. */
+    public static class PendingApproval {
+        public final String toolName;
+        public final String description;
+        public final JsonObject arguments;
+
+        PendingApproval(String toolName, String description, JsonObject arguments) {
+            this.toolName = toolName;
+            this.description = description;
+            this.arguments = arguments;
+        }
+    }
+
+    // ==================== UI callback ====================
+
+    public interface UICallback {
+        void onProgress(String status);
+        void onToolCall(String toolName, String arguments);
+        void onToolResult(String toolName, String result);
+        void onComplete(String response, List<ChatMessage> history);
+        void onError(String error);
+        void onApprovalRequired(String toolName, String description, JsonObject arguments,
+                                AgentLoop.ApprovalCallback approvalCallback);
+    }
+
+    // ==================== Binder ====================
+
+    public class LocalBinder extends Binder {
+        public AgentExecutionService getService() {
+            return AgentExecutionService.this;
+        }
+    }
+
+    private final IBinder binder = new LocalBinder();
+
+    // ==================== Fields ====================
+
+    private final ConcurrentHashMap<String, AgentSession> sessions = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, UICallback> uiCallbacks = new ConcurrentHashMap<>();
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    private NotificationManager notificationManager;
+    private PowerManager.WakeLock wakeLock;
+
+    // ==================== Lifecycle ====================
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        createNotificationChannel();
+        Log.d(TAG, "AgentExecutionService created");
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        // Must call startForeground() immediately to satisfy Android's
+        // ForegroundServiceDidNotStartInTimeException requirement (5-second window).
+        // The notification is updated later when the agent loop actually starts.
+        createNotificationChannel();
+        startForeground(NOTIFICATION_ID, buildNotification(false));
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        releaseWakeLock();
+        // Unblock any parked approval threads so they can terminate cleanly.
+        for (AgentSession session : sessions.values()) {
+            if (session.state == AgentSession.State.PAUSED_APPROVAL) {
+                try {
+                    session.approvalQueue.offer(false);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        Log.d(TAG, "AgentExecutionService destroyed");
+    }
+
+    // ==================== Public API ====================
+
+    /**
+     * Start the AgentLoop for the given session on a background thread.
+     *
+     * <p>If the session is already active this call is a no-op; the caller should
+     * register a UICallback first and then check {@link #getSession} to see if the
+     * session is in PAUSED_APPROVAL state and resume it.</p>
+     *
+     * @param sessionId          chat session identifier
+     * @param conversationHistory snapshot of messages to pass to the loop
+     * @param modelContextWindow  context window tokens for the selected model
+     */
+    public void startAgentLoop(String sessionId, List<ChatMessage> conversationHistory,
+                               int modelContextWindow) {
+        if (sessions.containsKey(sessionId)) {
+            Log.d(TAG, "Session already active: " + sessionId);
+            return;
+        }
+
+        AgentSession session = new AgentSession(sessionId);
+        sessions.put(sessionId, session);
+
+        acquireWakeLock();
+        ensureForeground();
+
+        Thread worker = new Thread(() -> runAgentLoop(session, conversationHistory, modelContextWindow),
+                "agent-loop-" + sessionId);
+        worker.setDaemon(true);
+        worker.start();
+
+        Log.d(TAG, "Started agent loop for session: " + sessionId);
+    }
+
+    /**
+     * Register a UI callback for the given session. Must be called on the main thread.
+     *
+     * <p>If the session already completed or errored, the callback will be invoked
+     * immediately with the cached result.</p>
+     */
+    public void registerUICallback(String sessionId, UICallback callback) {
+        uiCallbacks.put(sessionId, callback);
+
+        AgentSession session = sessions.get(sessionId);
+        if (session == null) return;
+
+        // Deliver buffered result if loop already finished while UI was detached.
+        if (session.state == AgentSession.State.COMPLETED && session.finalHistory != null) {
+            callback.onComplete(session.finalResponse, session.finalHistory);
+            sessions.remove(sessionId);
+        } else if (session.state == AgentSession.State.ERROR) {
+            callback.onError(session.errorMessage != null ? session.errorMessage : "Unknown error");
+            sessions.remove(sessionId);
+        } else if (session.state == AgentSession.State.PAUSED_APPROVAL
+                && session.pendingApproval != null) {
+            // Resume approval dialog now that the UI is back.
+            PendingApproval pa = session.pendingApproval;
+            callback.onApprovalRequired(pa.toolName, pa.description, pa.arguments,
+                    new AgentLoop.ApprovalCallback() {
+                        @Override
+                        public void onApproved() {
+                            session.state = AgentSession.State.RUNNING;
+                            session.pendingApproval = null;
+                            session.approvalQueue.offer(true);
+                            updateNotification();
+                        }
+
+                        @Override
+                        public void onDenied() {
+                            session.state = AgentSession.State.RUNNING;
+                            session.pendingApproval = null;
+                            session.approvalQueue.offer(false);
+                            updateNotification();
+                        }
+                    });
+        }
+    }
+
+    /** Unregister the UI callback for a session. The loop keeps running. */
+    public void unregisterUICallback(String sessionId) {
+        uiCallbacks.remove(sessionId);
+        updateNotification();
+    }
+
+    /** Return the current session state, or null if no session exists. */
+    public AgentSession getSession(String sessionId) {
+        return sessions.get(sessionId);
+    }
+
+    /** Return true if there is an active (non-terminal) session for this id. */
+    public boolean isSessionActive(String sessionId) {
+        AgentSession session = sessions.get(sessionId);
+        return session != null
+                && session.state != AgentSession.State.COMPLETED
+                && session.state != AgentSession.State.ERROR;
+    }
+
+    // ==================== Worker thread ====================
+
+    private void runAgentLoop(AgentSession session, List<ChatMessage> conversationHistory,
+                               int modelContextWindow) {
+        try {
+            SettingsManager settingsManager = new SettingsManager(getApplicationContext());
+            LlmApiService apiService = new LlmApiService(settingsManager);
+            ToolRegistry toolRegistry = new ToolRegistry(getApplicationContext(), settingsManager);
+
+            WorkspaceManager workspaceManager = new WorkspaceManager(getApplicationContext());
+            MemoryRepository memoryRepository = new MemoryRepository(workspaceManager);
+
+            ConversationSummarizer summarizer = new ConversationSummarizer(
+                    apiService, memoryRepository, modelContextWindow);
+            MemoryContextBuilder memoryContext = new MemoryContextBuilder(memoryRepository);
+
+            IdentityManager identityManager = new IdentityManager(
+                    getApplicationContext(), workspaceManager);
+
+            AgentLoop agentLoop = new AgentLoop(
+                    apiService, toolRegistry, settingsManager, summarizer, memoryContext);
+
+            try {
+                List<ChatMessage> identityMessages = identityManager.getIdentityMessages();
+                agentLoop.setIdentityContext(identityMessages);
+            } catch (Exception e) {
+                Log.w(TAG, "Could not load identity context", e);
+            }
+
+            agentLoop.start(conversationHistory, new AgentLoop.AgentCallback() {
+                @Override
+                public void onProgress(String status) {
+                    mainHandler.post(() -> {
+                        UICallback cb = uiCallbacks.get(session.sessionId);
+                        if (cb != null) cb.onProgress(status);
+                    });
+                }
+
+                @Override
+                public void onToolCall(String toolName, String arguments) {
+                    mainHandler.post(() -> {
+                        UICallback cb = uiCallbacks.get(session.sessionId);
+                        if (cb != null) cb.onToolCall(toolName, arguments);
+                    });
+                }
+
+                @Override
+                public void onToolResult(String toolName, String result) {
+                    mainHandler.post(() -> {
+                        UICallback cb = uiCallbacks.get(session.sessionId);
+                        if (cb != null) cb.onToolResult(toolName, result);
+                    });
+                }
+
+                @Override
+                public void onComplete(String finalResponse, List<ChatMessage> history) {
+                    session.state = AgentSession.State.COMPLETED;
+                    session.finalResponse = finalResponse;
+                    session.finalHistory = history;
+
+                    // Persist messages regardless of UI state.
+                    ChatRepository chatRepository = new ChatRepository(getApplicationContext());
+                    chatRepository.saveMessages(session.sessionId, history);
+
+                    mainHandler.post(() -> {
+                        UICallback cb = uiCallbacks.remove(session.sessionId);
+                        if (cb != null) {
+                            cb.onComplete(finalResponse, history);
+                        }
+                        // Session delivered — remove it.
+                        sessions.remove(session.sessionId);
+                        checkIdleAndStop();
+                    });
+                }
+
+                @Override
+                public void onError(String error) {
+                    session.state = AgentSession.State.ERROR;
+                    session.errorMessage = error;
+
+                    mainHandler.post(() -> {
+                        UICallback cb = uiCallbacks.remove(session.sessionId);
+                        if (cb != null) {
+                            cb.onError(error);
+                        }
+                        sessions.remove(session.sessionId);
+                        checkIdleAndStop();
+                    });
+                }
+
+                @Override
+                public void onApprovalRequired(String toolName, String description,
+                                               JsonObject arguments,
+                                               AgentLoop.ApprovalCallback approvalCallback) {
+                    UICallback cb = uiCallbacks.get(session.sessionId);
+                    if (cb != null) {
+                        // UI is attached — delegate directly.
+                        mainHandler.post(() ->
+                                cb.onApprovalRequired(toolName, description, arguments,
+                                        approvalCallback));
+                    } else {
+                        // UI is detached — park the worker thread and show notification.
+                        session.state = AgentSession.State.PAUSED_APPROVAL;
+                        session.pendingApproval = new PendingApproval(
+                                toolName, description, arguments);
+                        mainHandler.post(AgentExecutionService.this::updateNotification);
+
+                        Log.d(TAG, "Approval required while UI detached — parking thread for: "
+                                + toolName);
+
+                        // Block until the user returns and approves/denies.
+                        Boolean approved;
+                        try {
+                            approved = session.approvalQueue.take();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            approved = false;
+                        }
+
+                        if (Boolean.TRUE.equals(approved)) {
+                            approvalCallback.onApproved();
+                        } else {
+                            approvalCallback.onDenied();
+                        }
+                    }
+                }
+            });
+
+            try {
+                toolRegistry.shutdown();
+            } catch (Exception ignored) {
+            }
+
+        } catch (Exception e) {
+            Log.e(TAG, "Unexpected error in agent loop worker", e);
+            session.state = AgentSession.State.ERROR;
+            session.errorMessage = "Internal error: " + e.getMessage();
+
+            mainHandler.post(() -> {
+                UICallback cb = uiCallbacks.remove(session.sessionId);
+                if (cb != null) cb.onError(session.errorMessage);
+                sessions.remove(session.sessionId);
+                checkIdleAndStop();
+            });
+        }
+    }
+
+    // ==================== Foreground / notification ====================
+
+    private void ensureForeground() {
+        startForeground(NOTIFICATION_ID, buildNotification(false));
+        acquireWakeLock();
+    }
+
+    private void checkIdleAndStop() {
+        if (sessions.isEmpty()) {
+            stopForeground(true);
+            releaseWakeLock();
+            stopSelf();
+            Log.d(TAG, "All sessions complete — service stopped");
+        } else {
+            updateNotification();
+        }
+    }
+
+    private void updateNotification() {
+        boolean hasPausedApproval = false;
+        for (AgentSession s : sessions.values()) {
+            if (s.state == AgentSession.State.PAUSED_APPROVAL) {
+                hasPausedApproval = true;
+                break;
+            }
+        }
+        notificationManager.notify(NOTIFICATION_ID, buildNotification(hasPausedApproval));
+    }
+
+    private Notification buildNotification(boolean waitingForApproval) {
+        Intent openIntent = new Intent(this, MainActivity.class);
+        openIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        int piFlags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                ? PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
+                : PendingIntent.FLAG_UPDATE_CURRENT;
+        PendingIntent openPending = PendingIntent.getActivity(this, 0, openIntent, piFlags);
+
+        String title = waitingForApproval
+                ? "DroidClaw — approval required"
+                : "DroidClaw — agent is running";
+        String text = waitingForApproval
+                ? "Tap to approve or deny the pending action"
+                : "Processing your request in the background…";
+
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.ic_popup_sync)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setPriority(waitingForApproval
+                        ? NotificationCompat.PRIORITY_HIGH
+                        : NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true)
+                .setAutoCancel(false)
+                .setContentIntent(openPending)
+                .build();
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID,
+                    "DroidClaw Agent",
+                    NotificationManager.IMPORTANCE_LOW
+            );
+            channel.setDescription("Shows when the agent is processing a request in the background");
+            channel.setShowBadge(false);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    // ==================== WakeLock ====================
+
+    private void acquireWakeLock() {
+        if (wakeLock != null && wakeLock.isHeld()) return;
+        PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        if (pm != null) {
+            wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "DroidClaw:AgentExec");
+            wakeLock.acquire();
+        }
+    }
+
+    private void releaseWakeLock() {
+        if (wakeLock != null && wakeLock.isHeld()) {
+            wakeLock.release();
+            wakeLock = null;
+        }
+    }
+}


### PR DESCRIPTION
Move agent execution logic from ChatFragment to a new
AgentExecutionService to ensure LLM requests and tool execution
continue when the app is minimized. The fragment now binds to the
service to handle callbacks and UI updates, while the service manages
the agent lifecycle, wake locks, and foreground notifications.