### PR TITLE
feat(screen-control): accessibility screen tools + agent done notification

### DIFF
--- a/app/src/androidTest/java/io/finett/droidclaw/tool/ScreenControlToolsInstrumentedTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/tool/ScreenControlToolsInstrumentedTest.java
@@ -1,0 +1,236 @@
+package io.finett.droidclaw.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
+import io.finett.droidclaw.model.AgentConfig;
+import io.finett.droidclaw.tool.impl.ScreenGetUiTreeTool;
+import io.finett.droidclaw.tool.impl.ScreenPerformActionTool;
+import io.finett.droidclaw.tool.impl.ScreenSwipeTool;
+import io.finett.droidclaw.tool.impl.ScreenTapTool;
+import io.finett.droidclaw.tool.impl.ScreenTypeTextTool;
+import io.finett.droidclaw.util.SettingsManager;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Instrumented tests verifying:
+ * <ul>
+ *   <li>The {@link AccessibilityBridge} correctly reports disconnected state when the service
+ *       has not been registered.</li>
+ *   <li>Screen tools return a meaningful error (not a crash) when the service is not connected.</li>
+ *   <li>Trust-mode flag propagates correctly to {@link Tool#requiresApproval()}.</li>
+ *   <li>Screen tools are NOT registered in {@link ToolRegistry} when {@code screenControlEnabled}
+ *       is false (default).</li>
+ *   <li>Screen tools ARE registered when {@code screenControlEnabled} is true AND the
+ *       bridge is connected (simulated via a test double).</li>
+ * </ul>
+ */
+@RunWith(AndroidJUnit4.class)
+public class ScreenControlToolsInstrumentedTest {
+
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+    }
+
+    // ── AccessibilityBridge ────────────────────────────────────────────────────
+
+    @Test
+    public void bridge_isNotConnected_byDefault() {
+        // The real accessibility service is never connected in test environment
+        assertFalse("Bridge should not be connected without the accessibility service",
+                AccessibilityBridge.isConnected());
+    }
+
+    // ── Tool error messages when disconnected ──────────────────────────────────
+
+    @Test
+    public void screenGetUiTree_returnsError_whenNotConnected() {
+        ScreenGetUiTreeTool tool = new ScreenGetUiTreeTool();
+        ToolResult result = tool.execute(new JsonObject());
+        assertFalse("Should fail when not connected", result.isSuccess());
+        assertNotNull(result.getError());
+        assertTrue("Error should mention accessibility service",
+                result.getError().contains("Accessibility service"));
+    }
+
+    @Test
+    public void screenTap_returnsError_whenNotConnected() {
+        ScreenTapTool tool = new ScreenTapTool(false);
+        JsonObject args = new JsonObject();
+        args.addProperty("x", 100);
+        args.addProperty("y", 200);
+        ToolResult result = tool.execute(args);
+        assertFalse("Should fail when not connected", result.isSuccess());
+        assertNotNull(result.getError());
+    }
+
+    @Test
+    public void screenSwipe_returnsError_whenNotConnected() {
+        ScreenSwipeTool tool = new ScreenSwipeTool(false);
+        JsonObject args = new JsonObject();
+        args.addProperty("from_x", 100);
+        args.addProperty("from_y", 500);
+        args.addProperty("to_x", 100);
+        args.addProperty("to_y", 200);
+        ToolResult result = tool.execute(args);
+        assertFalse("Should fail when not connected", result.isSuccess());
+    }
+
+    @Test
+    public void screenTypeText_returnsError_whenNotConnected() {
+        ScreenTypeTextTool tool = new ScreenTypeTextTool(false);
+        JsonObject args = new JsonObject();
+        args.addProperty("text", "hello");
+        ToolResult result = tool.execute(args);
+        assertFalse("Should fail when not connected", result.isSuccess());
+    }
+
+    @Test
+    public void screenPerformAction_returnsError_whenNotConnected() {
+        ScreenPerformActionTool tool = new ScreenPerformActionTool(false);
+        JsonObject args = new JsonObject();
+        args.addProperty("action", "home");
+        ToolResult result = tool.execute(args);
+        assertFalse("Should fail when not connected", result.isSuccess());
+    }
+
+    // ── Trust mode propagation ─────────────────────────────────────────────────
+
+    @Test
+    public void screenTap_requiresApproval_whenTrustModeOff() {
+        ScreenTapTool tool = new ScreenTapTool(false);
+        assertTrue("Should require approval when trust mode is off",
+                tool.requiresApproval());
+    }
+
+    @Test
+    public void screenTap_doesNotRequireApproval_whenTrustModeOn() {
+        ScreenTapTool tool = new ScreenTapTool(true);
+        assertFalse("Should not require approval when trust mode is on",
+                tool.requiresApproval());
+    }
+
+    @Test
+    public void screenSwipe_trustModeAware() {
+        assertTrue(new ScreenSwipeTool(false).requiresApproval());
+        assertFalse(new ScreenSwipeTool(true).requiresApproval());
+    }
+
+    @Test
+    public void screenTypeText_trustModeAware() {
+        assertTrue(new ScreenTypeTextTool(false).requiresApproval());
+        assertFalse(new ScreenTypeTextTool(true).requiresApproval());
+    }
+
+    @Test
+    public void screenPerformAction_trustModeAware() {
+        assertTrue(new ScreenPerformActionTool(false).requiresApproval());
+        assertFalse(new ScreenPerformActionTool(true).requiresApproval());
+    }
+
+    @Test
+    public void screenGetUiTree_neverRequiresApproval() {
+        assertFalse("screen_get_ui_tree is read-only and never needs approval",
+                new ScreenGetUiTreeTool().requiresApproval());
+    }
+
+    // ── Tool registration gating ───────────────────────────────────────────────
+
+    @Test
+    public void toolRegistry_doesNotRegisterScreenTools_whenDisabled() {
+        // Clear any existing settings and use defaults (screenControlEnabled = false)
+        SettingsManager settings = new SettingsManager(context);
+        settings.clear();
+
+        ToolRegistry registry = new ToolRegistry(context, settings);
+
+        assertFalse("screen_get_ui_tree should not be registered when disabled",
+                registry.hasToolWithName("screen_get_ui_tree"));
+        assertFalse("screen_tap should not be registered when disabled",
+                registry.hasToolWithName("screen_tap"));
+        assertFalse("screen_swipe should not be registered when disabled",
+                registry.hasToolWithName("screen_swipe"));
+        assertFalse("screen_type_text should not be registered when disabled",
+                registry.hasToolWithName("screen_type_text"));
+        assertFalse("screen_perform_action should not be registered when disabled",
+                registry.hasToolWithName("screen_perform_action"));
+
+        registry.shutdown();
+    }
+
+    @Test
+    public void toolRegistry_doesNotRegisterScreenTools_whenEnabledButServiceNotConnected() {
+        // Enable screen control in settings but do NOT connect the service
+        SettingsManager settings = new SettingsManager(context);
+        settings.clear();
+        AgentConfig config = settings.getAgentConfig();
+        config.setScreenControlEnabled(true);
+        config.setScreenControlTrustMode(false);
+        settings.setAgentConfig(config);
+
+        // AccessibilityBridge.isConnected() returns false (no service in test environment)
+        ToolRegistry registry = new ToolRegistry(context, settings);
+
+        assertFalse("screen_tap should not be registered when service not connected",
+                registry.hasToolWithName("screen_tap"));
+
+        registry.shutdown();
+    }
+
+    // ── Argument validation ────────────────────────────────────────────────────
+
+    @Test
+    public void screenTap_returnsError_whenNoArguments() {
+        ScreenTapTool tool = new ScreenTapTool(false);
+        // Pass args with no position information — should fail validation before bridge check
+        JsonObject emptyArgs = new JsonObject();
+        ToolResult result = tool.execute(emptyArgs);
+        assertFalse("Should fail without position arguments", result.isSuccess());
+    }
+
+    @Test
+    public void screenSwipe_returnsError_whenMissingArgs() {
+        ScreenSwipeTool tool = new ScreenSwipeTool(false);
+        JsonObject partialArgs = new JsonObject();
+        partialArgs.addProperty("from_x", 100);
+        // Missing from_y, to_x, to_y
+        ToolResult result = tool.execute(partialArgs);
+        assertFalse("Should fail with incomplete arguments", result.isSuccess());
+    }
+
+    @Test
+    public void screenPerformAction_returnsError_forUnknownAction() {
+        ScreenPerformActionTool tool = new ScreenPerformActionTool(true); // trust mode so it's not approval-blocked
+        JsonObject args = new JsonObject();
+        args.addProperty("action", "fly_to_moon");
+        ToolResult result = tool.execute(args);
+        // Will fail at "not connected" before reaching action validation when no service,
+        // so we just verify it's not a crash
+        assertFalse("Should not succeed", result.isSuccess());
+    }
+
+    @Test
+    public void toolNames_areCorrect() {
+        assertEquals("screen_get_ui_tree", new ScreenGetUiTreeTool().getName());
+        assertEquals("screen_tap", new ScreenTapTool(false).getName());
+        assertEquals("screen_swipe", new ScreenSwipeTool(false).getName());
+        assertEquals("screen_type_text", new ScreenTypeTextTool(false).getName());
+        assertEquals("screen_perform_action", new ScreenPerformActionTool(false).getName());
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,19 @@
             android:foregroundServiceType="dataSync"
             android:exported="false" />
 
+        <service
+            android:name=".accessibility.DroidClawAccessibilityService"
+            android:exported="true"
+            android:label="@string/accessibility_service_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityBridge.java
+++ b/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityBridge.java
@@ -1,0 +1,125 @@
+package io.finett.droidclaw.accessibility;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Singleton bridge between agent tools and the {@link DroidClawAccessibilityService}.
+ *
+ * <p>Tools call {@link #execute(AccessibilityCommand)} synchronously on a background thread.
+ * The bridge posts the command to the service's main-thread handler and blocks on a
+ * {@link CompletableFuture} until the service completes the command (or a timeout fires).
+ */
+public final class AccessibilityBridge {
+
+    private static final String TAG = "AccessibilityBridge";
+    private static final long COMMAND_TIMEOUT_SECONDS = 10;
+
+    private static volatile DroidClawAccessibilityService serviceInstance;
+
+    private AccessibilityBridge() {
+        // Singleton — no instantiation
+    }
+
+    /**
+     * Called by {@link DroidClawAccessibilityService#onServiceConnected()} to register itself.
+     */
+    public static void register(DroidClawAccessibilityService service) {
+        serviceInstance = service;
+        Log.i(TAG, "Accessibility service registered");
+    }
+
+    /**
+     * Called by {@link DroidClawAccessibilityService#onDestroy()} to unregister itself.
+     */
+    public static void unregister() {
+        serviceInstance = null;
+        Log.i(TAG, "Accessibility service unregistered");
+    }
+
+    /**
+     * Returns {@code true} if the accessibility service is currently connected and usable.
+     */
+    public static boolean isConnected() {
+        return serviceInstance != null;
+    }
+
+    /**
+     * Execute an accessibility command synchronously.
+     *
+     * <p>This method MUST be called from a background thread — it blocks until the service
+     * completes the command or a timeout occurs.
+     *
+     * @param command the command to execute
+     * @return a {@link ToolResult} with the outcome
+     */
+    public static ToolResult execute(AccessibilityCommand command) {
+        DroidClawAccessibilityService service = serviceInstance;
+        if (service == null) {
+            return ToolResult.error("Accessibility service is not connected. "
+                    + "Please enable DroidClaw in Settings → Accessibility.");
+        }
+
+        CompletableFuture<ToolResult> future = new CompletableFuture<>();
+        boolean onMainThread = Looper.myLooper() == Looper.getMainLooper();
+
+        if (onMainThread) {
+            // We're already on the main thread — calling future.get() here would deadlock
+            // because the Handler.post() would never run. Invoke the service directly.
+            // For synchronous commands (GET_UI_TREE, CLICK_NODE, SET_TEXT, GLOBAL_ACTION),
+            // the future is completed inline and future.getNow(...) returns immediately.
+            // For gesture commands (TAP, SWIPE), we cannot block here at all — instead we
+            // return a synchronous result that informs the caller the gesture was dispatched.
+            try {
+                service.executeCommand(command, future);
+            } catch (Exception e) {
+                Log.e(TAG, "Command execution failed", e);
+                return ToolResult.error("Accessibility command failed: " + e.getMessage());
+            }
+
+            // If the command completed synchronously (non-gesture), return its result now.
+            if (future.isDone()) {
+                try {
+                    return future.get();
+                } catch (Exception e) {
+                    return ToolResult.error("Accessibility command failed: " + e.getMessage());
+                }
+            }
+
+            // Gesture commands are dispatched asynchronously by the framework. We cannot
+            // block the main thread waiting for their callback (it runs on the main thread
+            // too). Return a "dispatched" result so the agent loop can continue. The user
+            // should call screen_get_ui_tree afterwards to verify the gesture took effect.
+            return ToolResult.success("{\"status\":\"dispatched\","
+                    + "\"message\":\"Gesture dispatched. Wait briefly then call "
+                    + "screen_get_ui_tree to verify the effect.\"}");
+        }
+
+        // Background thread caller — safe to post and block on the future.
+        Handler mainHandler = new Handler(Looper.getMainLooper());
+        mainHandler.post(() -> {
+            try {
+                service.executeCommand(command, future);
+            } catch (Exception e) {
+                Log.e(TAG, "Command execution failed", e);
+                future.complete(ToolResult.error("Accessibility command failed: " + e.getMessage()));
+            }
+        });
+
+        try {
+            return future.get(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            return ToolResult.error("Accessibility command timed out after "
+                    + COMMAND_TIMEOUT_SECONDS + " seconds");
+        } catch (Exception e) {
+            return ToolResult.error("Accessibility command interrupted: " + e.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityCommand.java
+++ b/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityCommand.java
@@ -1,0 +1,129 @@
+package io.finett.droidclaw.accessibility;
+
+import android.os.Bundle;
+
+/**
+ * Immutable value object representing a single accessibility command dispatched through
+ * {@link AccessibilityBridge} to {@link DroidClawAccessibilityService}.
+ */
+public final class AccessibilityCommand {
+
+    public enum Type {
+        GET_UI_TREE,
+        TAP,
+        SWIPE,
+        SET_TEXT,
+        CLICK_NODE,
+        GLOBAL_ACTION
+    }
+
+    private final Type type;
+
+    // TAP / SWIPE coordinates
+    private final int x;
+    private final int y;
+    private final int x2;
+    private final int y2;
+    private final int durationMs;
+
+    // Node-targeted actions
+    private final String resourceId;
+    private final String nodeText;
+
+    // Text to type
+    private final String text;
+
+    // Global action constant (AccessibilityService.GLOBAL_ACTION_*)
+    private final int globalAction;
+
+    // UI tree depth cap
+    private final int depth;
+
+    private AccessibilityCommand(Builder b) {
+        this.type = b.type;
+        this.x = b.x;
+        this.y = b.y;
+        this.x2 = b.x2;
+        this.y2 = b.y2;
+        this.durationMs = b.durationMs;
+        this.resourceId = b.resourceId;
+        this.nodeText = b.nodeText;
+        this.text = b.text;
+        this.globalAction = b.globalAction;
+        this.depth = b.depth;
+    }
+
+    public Type getType() { return type; }
+    public int getX() { return x; }
+    public int getY() { return y; }
+    public int getX2() { return x2; }
+    public int getY2() { return y2; }
+    public int getDurationMs() { return durationMs; }
+    public String getResourceId() { return resourceId; }
+    public String getNodeText() { return nodeText; }
+    public String getText() { return text; }
+    public int getGlobalAction() { return globalAction; }
+    public int getDepth() { return depth; }
+
+    // ── Factory helpers ──────────────────────────────────────────────────────
+
+    public static AccessibilityCommand getUiTree(int depth) {
+        return new Builder(Type.GET_UI_TREE).depth(depth).build();
+    }
+
+    public static AccessibilityCommand tapAt(int x, int y) {
+        return new Builder(Type.TAP).x(x).y(y).build();
+    }
+
+    public static AccessibilityCommand tapByResourceId(String resourceId) {
+        return new Builder(Type.CLICK_NODE).resourceId(resourceId).build();
+    }
+
+    public static AccessibilityCommand tapByText(String text) {
+        return new Builder(Type.CLICK_NODE).nodeText(text).build();
+    }
+
+    public static AccessibilityCommand swipe(int x1, int y1, int x2, int y2, int durationMs) {
+        return new Builder(Type.SWIPE).x(x1).y(y1).x2(x2).y2(y2).durationMs(durationMs).build();
+    }
+
+    public static AccessibilityCommand setTextOnFocused(String text) {
+        return new Builder(Type.SET_TEXT).text(text).build();
+    }
+
+    public static AccessibilityCommand setTextOnNode(String resourceId, String text) {
+        return new Builder(Type.SET_TEXT).resourceId(resourceId).text(text).build();
+    }
+
+    public static AccessibilityCommand globalAction(int action) {
+        return new Builder(Type.GLOBAL_ACTION).globalAction(action).build();
+    }
+
+    // ── Builder ──────────────────────────────────────────────────────────────
+
+    public static final class Builder {
+        private final Type type;
+        private int x, y, x2, y2;
+        private int durationMs = 300;
+        private String resourceId;
+        private String nodeText;
+        private String text;
+        private int globalAction;
+        private int depth = 6;
+
+        public Builder(Type type) { this.type = type; }
+
+        public Builder x(int v)             { this.x = v; return this; }
+        public Builder y(int v)             { this.y = v; return this; }
+        public Builder x2(int v)            { this.x2 = v; return this; }
+        public Builder y2(int v)            { this.y2 = v; return this; }
+        public Builder durationMs(int v)    { this.durationMs = v; return this; }
+        public Builder resourceId(String v) { this.resourceId = v; return this; }
+        public Builder nodeText(String v)   { this.nodeText = v; return this; }
+        public Builder text(String v)       { this.text = v; return this; }
+        public Builder globalAction(int v)  { this.globalAction = v; return this; }
+        public Builder depth(int v)         { this.depth = v; return this; }
+
+        public AccessibilityCommand build() { return new AccessibilityCommand(this); }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityNodeSerializer.java
+++ b/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityNodeSerializer.java
@@ -1,6 +1,7 @@
 package io.finett.droidclaw.accessibility;
 
 import android.graphics.Rect;
+import android.os.Build;
 import android.view.accessibility.AccessibilityNodeInfo;
 
 import com.google.gson.JsonArray;
@@ -75,10 +76,12 @@ public final class AccessibilityNodeSerializer {
             obj.addProperty("contentDescription", cd.toString());
         }
 
-        // Hint text (input fields)
-        CharSequence hint = node.getHintText();
-        if (hint != null && hint.length() > 0) {
-            obj.addProperty("hint", hint.toString());
+        // Hint text (input fields) — API 26+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence hint = node.getHintText();
+            if (hint != null && hint.length() > 0) {
+                obj.addProperty("hint", hint.toString());
+            }
         }
 
         // Interactability

--- a/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityNodeSerializer.java
+++ b/app/src/main/java/io/finett/droidclaw/accessibility/AccessibilityNodeSerializer.java
@@ -1,0 +1,127 @@
+package io.finett.droidclaw.accessibility;
+
+import android.graphics.Rect;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * Converts an {@link AccessibilityNodeInfo} tree into a compact JSON representation
+ * suitable for inclusion in an LLM prompt.
+ *
+ * <p>Only semantically useful fields are included: class name, resource id, text,
+ * content description, interactability flags, and screen bounds. Depth is capped to
+ * keep token count manageable.
+ */
+public final class AccessibilityNodeSerializer {
+
+    private AccessibilityNodeSerializer() {}
+
+    /**
+     * Serialize an entire window tree starting from {@code root}.
+     *
+     * @param root      the root {@link AccessibilityNodeInfo} (may be null)
+     * @param maxDepth  maximum recursion depth (recommended: 6)
+     * @return a {@link JsonObject} with {@code package} and {@code nodes} keys
+     */
+    public static JsonObject serialize(AccessibilityNodeInfo root, int maxDepth) {
+        JsonObject result = new JsonObject();
+
+        if (root == null) {
+            result.addProperty("error", "No accessible window content available");
+            return result;
+        }
+
+        String pkg = root.getPackageName() != null ? root.getPackageName().toString() : "unknown";
+        result.addProperty("package", pkg);
+
+        JsonArray nodes = new JsonArray();
+        serializeNode(root, nodes, 0, maxDepth);
+        result.add("nodes", nodes);
+
+        return result;
+    }
+
+    private static void serializeNode(AccessibilityNodeInfo node, JsonArray out,
+                                      int depth, int maxDepth) {
+        if (node == null) return;
+
+        JsonObject obj = new JsonObject();
+
+        // Class name (short form for readability)
+        CharSequence cls = node.getClassName();
+        if (cls != null) {
+            String clsStr = cls.toString();
+            int dot = clsStr.lastIndexOf('.');
+            obj.addProperty("class", dot >= 0 ? clsStr.substring(dot + 1) : clsStr);
+        }
+
+        // Resource ID (most useful for targeting)
+        String rid = node.getViewIdResourceName();
+        if (rid != null && !rid.isEmpty()) {
+            obj.addProperty("resourceId", rid);
+        }
+
+        // Visible text
+        CharSequence text = node.getText();
+        if (text != null && text.length() > 0) {
+            obj.addProperty("text", text.toString());
+        }
+
+        // Content description (accessibility label)
+        CharSequence cd = node.getContentDescription();
+        if (cd != null && cd.length() > 0) {
+            obj.addProperty("contentDescription", cd.toString());
+        }
+
+        // Hint text (input fields)
+        CharSequence hint = node.getHintText();
+        if (hint != null && hint.length() > 0) {
+            obj.addProperty("hint", hint.toString());
+        }
+
+        // Interactability
+        if (node.isClickable())    obj.addProperty("clickable", true);
+        if (node.isLongClickable()) obj.addProperty("longClickable", true);
+        if (node.isScrollable())   obj.addProperty("scrollable", true);
+        if (node.isEditable())     obj.addProperty("editable", true);
+        if (node.isEnabled())      obj.addProperty("enabled", true);
+        if (node.isChecked())      obj.addProperty("checked", true);
+        if (node.isSelected())     obj.addProperty("selected", true);
+
+        // Screen bounds (for coordinate-based taps)
+        Rect bounds = new Rect();
+        node.getBoundsInScreen(bounds);
+        if (!bounds.isEmpty()) {
+            JsonObject boundsObj = new JsonObject();
+            boundsObj.addProperty("left", bounds.left);
+            boundsObj.addProperty("top", bounds.top);
+            boundsObj.addProperty("right", bounds.right);
+            boundsObj.addProperty("bottom", bounds.bottom);
+            boundsObj.addProperty("centerX", bounds.centerX());
+            boundsObj.addProperty("centerY", bounds.centerY());
+            obj.add("bounds", boundsObj);
+        }
+
+        out.add(obj);
+
+        // Recurse into children if within depth limit
+        if (depth < maxDepth) {
+            int childCount = node.getChildCount();
+            if (childCount > 0) {
+                JsonArray children = new JsonArray();
+                for (int i = 0; i < childCount; i++) {
+                    AccessibilityNodeInfo child = node.getChild(i);
+                    if (child != null) {
+                        serializeNode(child, children, depth + 1, maxDepth);
+                        child.recycle();
+                    }
+                }
+                if (children.size() > 0) {
+                    obj.add("children", children);
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/accessibility/DroidClawAccessibilityService.java
+++ b/app/src/main/java/io/finett/droidclaw/accessibility/DroidClawAccessibilityService.java
@@ -1,0 +1,342 @@
+package io.finett.droidclaw.accessibility;
+
+import android.accessibilityservice.AccessibilityService;
+import android.accessibilityservice.GestureDescription;
+import android.graphics.Path;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import com.google.gson.JsonObject;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Android Accessibility Service that allows the DroidClaw agent to read the visible UI
+ * hierarchy and perform gestures on any on-screen content.
+ *
+ * <p>This service registers itself with {@link AccessibilityBridge} when connected and
+ * unregisters on destroy. The bridge routes {@link AccessibilityCommand} objects here from
+ * agent tool calls, passing a {@link CompletableFuture} that the service must complete.
+ *
+ * <p>All {@link #executeCommand} calls MUST arrive on the main thread (enforced by the
+ * bridge posting via a main-thread Handler). Non-gesture commands complete the future
+ * synchronously; gesture commands complete it from the gesture result callback.
+ */
+public class DroidClawAccessibilityService extends AccessibilityService {
+
+    private static final String TAG = "DroidClawA11y";
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    @Override
+    protected void onServiceConnected() {
+        super.onServiceConnected();
+        AccessibilityBridge.register(this);
+        Log.i(TAG, "Service connected and registered with bridge");
+    }
+
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {
+        // No event-driven behaviour needed in v1 — the agent polls via GET_UI_TREE
+    }
+
+    @Override
+    public void onInterrupt() {
+        Log.w(TAG, "Service interrupted");
+    }
+
+    @Override
+    public void onDestroy() {
+        AccessibilityBridge.unregister();
+        super.onDestroy();
+        Log.i(TAG, "Service destroyed and unregistered from bridge");
+    }
+
+    // ── Command dispatch ──────────────────────────────────────────────────────
+
+    /**
+     * Execute an {@link AccessibilityCommand}, completing {@code future} when done.
+     * Must be called on the main thread.
+     *
+     * <p>Gesture commands complete the future from the gesture callback (async within the
+     * main thread loop). All other commands complete the future synchronously before returning.
+     */
+    public void executeCommand(AccessibilityCommand command, CompletableFuture<ToolResult> future) {
+        switch (command.getType()) {
+            case GET_UI_TREE:
+                future.complete(handleGetUiTree(command));
+                break;
+            case TAP:
+                handleTapAsync(command, future);
+                break;
+            case SWIPE:
+                handleSwipeAsync(command, future);
+                break;
+            case CLICK_NODE:
+                future.complete(handleClickNode(command));
+                break;
+            case SET_TEXT:
+                future.complete(handleSetText(command));
+                break;
+            case GLOBAL_ACTION:
+                future.complete(handleGlobalAction(command));
+                break;
+            default:
+                future.complete(ToolResult.error(
+                        "Unknown accessibility command type: " + command.getType()));
+        }
+    }
+
+    // ── GET_UI_TREE ───────────────────────────────────────────────────────────
+
+    private ToolResult handleGetUiTree(AccessibilityCommand command) {
+        AccessibilityNodeInfo root = getRootInActiveWindow();
+        if (root == null) {
+            return ToolResult.error("No active window available. "
+                    + "The screen may be locked or no app is in the foreground.");
+        }
+        try {
+            JsonObject tree = AccessibilityNodeSerializer.serialize(root, command.getDepth());
+            return ToolResult.success(tree);
+        } finally {
+            root.recycle();
+        }
+    }
+
+    // ── TAP ───────────────────────────────────────────────────────────────────
+
+    private void handleTapAsync(AccessibilityCommand command,
+                                CompletableFuture<ToolResult> future) {
+        int x = command.getX();
+        int y = command.getY();
+
+        Path path = new Path();
+        path.moveTo(x, y);
+
+        GestureDescription.StrokeDescription stroke =
+                new GestureDescription.StrokeDescription(path, 0, 50);
+        GestureDescription gesture = new GestureDescription.Builder()
+                .addStroke(stroke)
+                .build();
+
+        boolean accepted = dispatchGesture(gesture, new GestureResultCallback() {
+            @Override
+            public void onCompleted(GestureDescription gestureDescription) {
+                JsonObject result = new JsonObject();
+                result.addProperty("action", "tap");
+                result.addProperty("x", x);
+                result.addProperty("y", y);
+                result.addProperty("success", true);
+                future.complete(ToolResult.success(result));
+            }
+
+            @Override
+            public void onCancelled(GestureDescription gestureDescription) {
+                future.complete(ToolResult.error(
+                        "Tap gesture was cancelled at (" + x + ", " + y + ")"));
+            }
+        }, null);
+
+        if (!accepted) {
+            future.complete(ToolResult.error(
+                    "Failed to dispatch tap gesture at (" + x + ", " + y + ")"));
+        }
+    }
+
+    // ── SWIPE ─────────────────────────────────────────────────────────────────
+
+    private void handleSwipeAsync(AccessibilityCommand command,
+                                  CompletableFuture<ToolResult> future) {
+        int x1 = command.getX();
+        int y1 = command.getY();
+        int x2 = command.getX2();
+        int y2 = command.getY2();
+        int duration = Math.max(50, command.getDurationMs());
+
+        Path path = new Path();
+        path.moveTo(x1, y1);
+        path.lineTo(x2, y2);
+
+        GestureDescription.StrokeDescription stroke =
+                new GestureDescription.StrokeDescription(path, 0, duration);
+        GestureDescription gesture = new GestureDescription.Builder()
+                .addStroke(stroke)
+                .build();
+
+        boolean accepted = dispatchGesture(gesture, new GestureResultCallback() {
+            @Override
+            public void onCompleted(GestureDescription gestureDescription) {
+                JsonObject result = new JsonObject();
+                result.addProperty("action", "swipe");
+                result.addProperty("from_x", x1);
+                result.addProperty("from_y", y1);
+                result.addProperty("to_x", x2);
+                result.addProperty("to_y", y2);
+                result.addProperty("duration_ms", duration);
+                result.addProperty("success", true);
+                future.complete(ToolResult.success(result));
+            }
+
+            @Override
+            public void onCancelled(GestureDescription gestureDescription) {
+                future.complete(ToolResult.error("Swipe gesture was cancelled"));
+            }
+        }, null);
+
+        if (!accepted) {
+            future.complete(ToolResult.error("Failed to dispatch swipe gesture"));
+        }
+    }
+
+    // ── CLICK_NODE ────────────────────────────────────────────────────────────
+
+    private ToolResult handleClickNode(AccessibilityCommand command) {
+        AccessibilityNodeInfo root = getRootInActiveWindow();
+        if (root == null) {
+            return ToolResult.error("No active window to find node in");
+        }
+
+        try {
+            AccessibilityNodeInfo target = findNode(root, command.getResourceId(), command.getNodeText());
+            if (target == null) {
+                String selector = command.getResourceId() != null
+                        ? "resourceId=" + command.getResourceId()
+                        : "text=" + command.getNodeText();
+                return ToolResult.error("No node found matching: " + selector);
+            }
+
+            boolean clicked = target.performAction(AccessibilityNodeInfo.ACTION_CLICK);
+            target.recycle();
+
+            JsonObject result = new JsonObject();
+            result.addProperty("action", "click_node");
+            if (command.getResourceId() != null) {
+                result.addProperty("resourceId", command.getResourceId());
+            }
+            if (command.getNodeText() != null) {
+                result.addProperty("text", command.getNodeText());
+            }
+            result.addProperty("success", clicked);
+            if (!clicked) {
+                result.addProperty("error", "performAction(ACTION_CLICK) returned false");
+            }
+            return ToolResult.success(result);
+        } finally {
+            root.recycle();
+        }
+    }
+
+    // ── SET_TEXT ──────────────────────────────────────────────────────────────
+
+    private ToolResult handleSetText(AccessibilityCommand command) {
+        AccessibilityNodeInfo root = getRootInActiveWindow();
+        if (root == null) {
+            return ToolResult.error("No active window to find editable node in");
+        }
+
+        try {
+            AccessibilityNodeInfo target;
+
+            if (command.getResourceId() != null) {
+                target = findNode(root, command.getResourceId(), null);
+                if (target == null) {
+                    return ToolResult.error("No editable node found with resourceId="
+                            + command.getResourceId());
+                }
+            } else {
+                target = findFocusedEditable(root);
+                if (target == null) {
+                    return ToolResult.error(
+                            "No focused editable field found. Tap a text field first.");
+                }
+            }
+
+            Bundle args = new Bundle();
+            args.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE,
+                    command.getText());
+            boolean set = target.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args);
+            target.recycle();
+
+            JsonObject result = new JsonObject();
+            result.addProperty("action", "set_text");
+            result.addProperty("text", command.getText());
+            result.addProperty("success", set);
+            if (!set) {
+                result.addProperty("error",
+                        "ACTION_SET_TEXT returned false — field may not be editable");
+            }
+            return ToolResult.success(result);
+        } finally {
+            root.recycle();
+        }
+    }
+
+    // ── GLOBAL_ACTION ─────────────────────────────────────────────────────────
+
+    private ToolResult handleGlobalAction(AccessibilityCommand command) {
+        boolean performed = performGlobalAction(command.getGlobalAction());
+
+        JsonObject result = new JsonObject();
+        result.addProperty("action", "global_action");
+        result.addProperty("global_action_id", command.getGlobalAction());
+        result.addProperty("success", performed);
+        if (!performed) {
+            result.addProperty("error", "performGlobalAction returned false");
+        }
+        return ToolResult.success(result);
+    }
+
+    // ── Utilities ─────────────────────────────────────────────────────────────
+
+    /**
+     * BFS through the node tree to find the first node matching resourceId OR text.
+     * Caller is responsible for recycling the returned node.
+     */
+    private AccessibilityNodeInfo findNode(AccessibilityNodeInfo root,
+                                           String resourceId, String text) {
+        if (resourceId != null) {
+            List<AccessibilityNodeInfo> found =
+                    root.findAccessibilityNodeInfosByViewId(resourceId);
+            if (!found.isEmpty()) {
+                for (int i = 1; i < found.size(); i++) found.get(i).recycle();
+                return found.get(0);
+            }
+        }
+
+        if (text != null) {
+            List<AccessibilityNodeInfo> found =
+                    root.findAccessibilityNodeInfosByText(text);
+            if (!found.isEmpty()) {
+                for (int i = 1; i < found.size(); i++) found.get(i).recycle();
+                return found.get(0);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Walk the tree to find an editable, focused node (for typing without a resource id).
+     */
+    private AccessibilityNodeInfo findFocusedEditable(AccessibilityNodeInfo node) {
+        if (node == null) return null;
+        if (node.isFocused() && node.isEditable()) return node;
+
+        for (int i = 0; i < node.getChildCount(); i++) {
+            AccessibilityNodeInfo child = node.getChild(i);
+            if (child == null) continue;
+            AccessibilityNodeInfo found = findFocusedEditable(child);
+            if (found != null) {
+                if (found != child) child.recycle();
+                return found;
+            }
+            child.recycle();
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
@@ -1,12 +1,15 @@
 package io.finett.droidclaw.fragment;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -14,6 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.google.android.material.textfield.TextInputEditText;
 
@@ -21,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.finett.droidclaw.R;
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
 import io.finett.droidclaw.model.AgentConfig;
 import io.finett.droidclaw.util.SettingsManager;
 
@@ -38,6 +43,13 @@ public class AgentSettingsFragment extends Fragment {
     private TextInputEditText inputLlmConnectTimeout;
     private TextInputEditText inputLlmReadTimeout;
     private TextInputEditText inputLlmWriteTimeout;
+
+    // Screen control views
+    private SwitchMaterial switchScreenControl;
+    private SwitchMaterial switchScreenControlTrustMode;
+    private TextView textAccessibilityStatus;
+    private MaterialButton buttonOpenAccessibilitySettings;
+
     private Button buttonSave;
 
     private SettingsManager settingsManager;
@@ -54,7 +66,8 @@ public class AgentSettingsFragment extends Fragment {
 
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_agent_settings, container, false);
     }
 
@@ -66,6 +79,14 @@ public class AgentSettingsFragment extends Fragment {
         setupDropdowns();
         loadAgentSettings();
         setupListeners();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Refresh accessibility status every time the fragment resumes (user may have
+        // just come back from the system Accessibility Settings screen)
+        updateAccessibilityStatus();
     }
 
     private void initViews(View view) {
@@ -81,11 +102,16 @@ public class AgentSettingsFragment extends Fragment {
         inputLlmConnectTimeout = view.findViewById(R.id.input_llm_connect_timeout);
         inputLlmReadTimeout = view.findViewById(R.id.input_llm_read_timeout);
         inputLlmWriteTimeout = view.findViewById(R.id.input_llm_write_timeout);
+
+        switchScreenControl = view.findViewById(R.id.switch_screen_control);
+        switchScreenControlTrustMode = view.findViewById(R.id.switch_screen_control_trust_mode);
+        textAccessibilityStatus = view.findViewById(R.id.text_accessibility_status);
+        buttonOpenAccessibilitySettings = view.findViewById(R.id.button_open_accessibility_settings);
+
         buttonSave = view.findViewById(R.id.button_save);
     }
 
     private void setupDropdowns() {
-
         if (availableModels.isEmpty()) {
             String[] noModels = {getString(R.string.agent_default_model_hint)};
             ArrayAdapter<String> modelAdapter = new ArrayAdapter<>(
@@ -108,7 +134,6 @@ public class AgentSettingsFragment extends Fragment {
             dropdownDefaultModel.setAdapter(modelAdapter);
         }
 
-
         String[] sandboxModes = {
                 getString(R.string.sandbox_strict),
                 getString(R.string.sandbox_relaxed),
@@ -124,7 +149,6 @@ public class AgentSettingsFragment extends Fragment {
 
     private void loadAgentSettings() {
         if (agentConfig != null) {
-
             String defaultModel = agentConfig.getDefaultModel();
             if (defaultModel != null && !defaultModel.isEmpty() && !availableModels.isEmpty()) {
                 String displayName = settingsManager.getModelDisplayName(defaultModel);
@@ -132,7 +156,6 @@ public class AgentSettingsFragment extends Fragment {
             } else if (!availableModels.isEmpty()) {
                 dropdownDefaultModel.setText(getString(R.string.agent_default_model_hint), false);
             }
-
 
             switchShellAccess.setChecked(agentConfig.isShellAccess());
 
@@ -157,23 +180,62 @@ public class AgentSettingsFragment extends Fragment {
                 allowlistText.append(path);
             }
             inputCustomAllowlist.setText(allowlistText.toString());
-        }
 
-        if (agentConfig != null) {
             inputLlmConnectTimeout.setText(String.valueOf(agentConfig.getLlmConnectTimeout()));
             inputLlmReadTimeout.setText(String.valueOf(agentConfig.getLlmReadTimeout()));
             inputLlmWriteTimeout.setText(String.valueOf(agentConfig.getLlmWriteTimeout()));
+
+            // Screen control
+            switchScreenControl.setChecked(agentConfig.isScreenControlEnabled());
+            switchScreenControlTrustMode.setChecked(agentConfig.isScreenControlTrustMode());
+        }
+
+        updateAccessibilityStatus();
+    }
+
+    /**
+     * Update the accessibility permission status text and "Open Settings" button visibility
+     * based on whether the accessibility service is currently connected.
+     */
+    private void updateAccessibilityStatus() {
+        if (textAccessibilityStatus == null) return;
+        boolean connected = AccessibilityBridge.isConnected();
+        if (connected) {
+            textAccessibilityStatus.setText(R.string.screen_control_accessibility_granted);
+            textAccessibilityStatus.setTextColor(
+                    requireContext().getColor(android.R.color.holo_green_dark));
+        } else {
+            textAccessibilityStatus.setText(R.string.screen_control_accessibility_not_granted);
+            textAccessibilityStatus.setTextColor(
+                    requireContext().getColor(android.R.color.darker_gray));
         }
     }
 
     private void setupListeners() {
         buttonSave.setOnClickListener(v -> saveAgentSettings());
+
+        // When user enables screen control and permission is not granted, open system settings
+        switchScreenControl.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked && !AccessibilityBridge.isConnected()) {
+                openAccessibilitySettings();
+            }
+        });
+
+        buttonOpenAccessibilitySettings.setOnClickListener(v -> openAccessibilitySettings());
+    }
+
+    private void openAccessibilitySettings() {
+        try {
+            startActivity(new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS));
+        } catch (Exception e) {
+            Toast.makeText(requireContext(),
+                    "Could not open Accessibility Settings", Toast.LENGTH_SHORT).show();
+        }
     }
 
     private void saveAgentSettings() {
         String maxIterationsStr = inputMaxIterations.getText().toString().trim();
         String shellTimeoutStr = inputShellTimeout.getText().toString().trim();
-
 
         int maxIterations;
         try {
@@ -199,7 +261,6 @@ public class AgentSettingsFragment extends Fragment {
             return;
         }
 
-
         String selectedModelDisplay = dropdownDefaultModel.getText().toString();
         String selectedModel = "";
         if (!availableModels.isEmpty()) {
@@ -210,7 +271,6 @@ public class AgentSettingsFragment extends Fragment {
                 }
             }
         }
-
 
         String sandboxMode = "strict";
         String selectedSandbox = dropdownSandboxMode.getText().toString();
@@ -256,6 +316,8 @@ public class AgentSettingsFragment extends Fragment {
         agentConfig.setLlmConnectTimeout(llmConnectTimeout);
         agentConfig.setLlmReadTimeout(llmReadTimeout);
         agentConfig.setLlmWriteTimeout(llmWriteTimeout);
+        agentConfig.setScreenControlEnabled(switchScreenControl.isChecked());
+        agentConfig.setScreenControlTrustMode(switchScreenControlTrustMode.isChecked());
 
         settingsManager.setAgentConfig(agentConfig);
 

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -1,10 +1,12 @@
 package io.finett.droidclaw.fragment;
 
+import android.Manifest;
 import android.app.AlertDialog;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -31,6 +33,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -238,6 +241,9 @@ public class ChatFragment extends Fragment {
     private ActivityResultLauncher<String> exportJsonLauncher;
     private ActivityResultLauncher<String> exportPdfLauncher;
 
+    // Notification permission launcher (Android 13+)
+    private ActivityResultLauncher<String> notificationPermissionLauncher;
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -311,6 +317,19 @@ public class ChatFragment extends Fragment {
             }
         );
 
+        notificationPermissionLauncher = registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(),
+            granted -> {
+                // Retry the pending agent request now that the user has decided.
+                // If granted, notifications will work; if denied, the agent loop
+                // still runs but no notifications will be posted.
+                if (pendingServiceConversationHistory != null) {
+                    startAgentExecutionServiceIfNeeded();
+                    bindAgentExecutionService();
+                }
+            }
+        );
+
         chatSearchManager = new ChatSearchManager();
         chatExportManager = new ChatExportManager(requireContext());
         chatImportManager = new ChatImportManager();
@@ -358,6 +377,18 @@ public class ChatFragment extends Fragment {
     private void dispatchAgentRequest(List<ChatMessage> conversationHistory) {
         pendingServiceConversationHistory = new ArrayList<>(conversationHistory);
         pendingServiceContextWindow = getModelContextWindow();
+
+        // On Android 13+ we need POST_NOTIFICATIONS for the foreground service
+        // notification (and the completion notification). Request it if not granted.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(requireContext(),
+                    Manifest.permission.POST_NOTIFICATIONS)
+                    != PackageManager.PERMISSION_GRANTED) {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+                // The launcher callback retries starting the service after the user responds.
+                return;
+            }
+        }
 
         startAgentExecutionServiceIfNeeded();
 

--- a/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
+++ b/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
@@ -13,6 +13,8 @@ public class AgentConfig {
     private boolean backgroundShellEnabled; // allow shell/python in background workers
     private boolean backgroundExecEnabled; // allow agent to dispatch any tool with background=true
     private List<String> customAllowlist; // extra executable paths for relaxed mode
+    private boolean screenControlEnabled;  // allow agent to read UI and control screen via accessibility
+    private boolean screenControlTrustMode; // skip per-action approval for screen control tools
     private int llmConnectTimeout;   // seconds
     private int llmReadTimeout;      // seconds
     private int llmWriteTimeout;     // seconds
@@ -22,6 +24,8 @@ public class AgentConfig {
         this.llmConnectTimeout = 30;
         this.llmReadTimeout = 120;
         this.llmWriteTimeout = 30;
+        this.screenControlEnabled = false;
+        this.screenControlTrustMode = false;
     }
 
     public AgentConfig(String defaultModel, boolean shellAccess, String sandboxMode,
@@ -39,6 +43,8 @@ public class AgentConfig {
         this.llmConnectTimeout = 30;
         this.llmReadTimeout = 120;
         this.llmWriteTimeout = 30;
+        this.screenControlEnabled = false;
+        this.screenControlTrustMode = false;
     }
 
     public static AgentConfig getDefaults() {
@@ -148,6 +154,22 @@ public class AgentConfig {
 
     public void setCustomAllowlist(List<String> customAllowlist) {
         this.customAllowlist = customAllowlist != null ? new ArrayList<>(customAllowlist) : new ArrayList<>();
+    }
+
+    public boolean isScreenControlEnabled() {
+        return screenControlEnabled;
+    }
+
+    public void setScreenControlEnabled(boolean screenControlEnabled) {
+        this.screenControlEnabled = screenControlEnabled;
+    }
+
+    public boolean isScreenControlTrustMode() {
+        return screenControlTrustMode;
+    }
+
+    public void setScreenControlTrustMode(boolean screenControlTrustMode) {
+        this.screenControlTrustMode = screenControlTrustMode;
     }
 
     public String getDefaultProviderId() {

--- a/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
@@ -52,6 +52,10 @@ public class AgentExecutionService extends Service {
     static final String CHANNEL_ID = "droidclaw_agent_exec";
     private static final int NOTIFICATION_ID = 8802;
 
+    /** Channel and ID for agent-completion notifications (non-foreground). */
+    private static final String CHANNEL_ID_DONE = "droidclaw_agent_done";
+    private static final int NOTIFICATION_ID_DONE = 8803;
+
     // ==================== Session state ====================
 
     /** Per-session state kept for the lifetime of the loop. */
@@ -134,6 +138,7 @@ public class AgentExecutionService extends Service {
         super.onCreate();
         notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         createNotificationChannel();
+        createDoneNotificationChannel();
         Log.d(TAG, "AgentExecutionService created");
     }
 
@@ -333,8 +338,10 @@ public class AgentExecutionService extends Service {
                         UICallback cb = uiCallbacks.remove(session.sessionId);
                         if (cb != null) {
                             cb.onComplete(finalResponse, history);
+                        } else {
+                            // App is not in the foreground — post a completion notification.
+                            showCompletionNotification(session.sessionId, finalResponse);
                         }
-                        // Session delivered — remove it.
                         sessions.remove(session.sessionId);
                         checkIdleAndStop();
                     });
@@ -349,6 +356,9 @@ public class AgentExecutionService extends Service {
                         UICallback cb = uiCallbacks.remove(session.sessionId);
                         if (cb != null) {
                             cb.onError(error);
+                        } else {
+                            // App is not in the foreground — post an error notification.
+                            showErrorNotification(session.sessionId, error);
                         }
                         sessions.remove(session.sessionId);
                         checkIdleAndStop();
@@ -480,6 +490,120 @@ public class AgentExecutionService extends Service {
             channel.setShowBadge(false);
             notificationManager.createNotificationChannel(channel);
         }
+    }
+
+    /**
+     * Channel for agent-done notifications. Uses DEFAULT importance so the
+     * user actually hears/sees when the agent finishes while the app is away.
+     */
+    private void createDoneNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID_DONE,
+                    "DroidClaw Agent Status",
+                    NotificationManager.IMPORTANCE_DEFAULT
+            );
+            channel.setDescription("Posted when the agent completes a task while the app is closed");
+            channel.setShowBadge(true);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    // ==================== Completion / error notifications ====================
+
+    /**
+     * Show a non-foreground notification when the agent completes and the UI is detached.
+     */
+    private void showCompletionNotification(String sessionId, String responseText) {
+        // Replace the old foreground notification and then show the done notification.
+        stopForeground(false);
+        notificationManager.notify(NOTIFICATION_ID_DONE,
+                buildCompletionNotification(sessionId, responseText));
+    }
+
+    /**
+     * Show a non-foreground notification when the agent errors and the UI is detached.
+     */
+    private void showErrorNotification(String sessionId, String error) {
+        stopForeground(false);
+        notificationManager.notify(NOTIFICATION_ID_DONE,
+                buildErrorNotification(sessionId, error));
+    }
+
+    /**
+     * Build a notification that the agent has completed its work.
+     * The response preview is truncated to ~200 chars for the notification.
+     */
+    private Notification buildCompletionNotification(String sessionId, String responseText) {
+        Intent openIntent = new Intent(this, MainActivity.class);
+        openIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        openIntent.putExtra("session_id", sessionId);
+        int piFlags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                ? PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
+                : PendingIntent.FLAG_UPDATE_CURRENT;
+        PendingIntent openPending = PendingIntent.getActivity(this, 1, openIntent, piFlags);
+
+        // Strip markdown-ish formatting for notification readability.
+        String preview = stripMarkdown(responseText);
+        if (preview.length() > 200) {
+            preview = preview.substring(0, 200) + "…";
+        }
+
+        return new NotificationCompat.Builder(this, CHANNEL_ID_DONE)
+                .setSmallIcon(android.R.drawable.ic_popup_sync)
+                .setContentTitle("DroidClaw — agent completed")
+                .setContentText(preview)
+                .setStyle(new NotificationCompat.BigTextStyle()
+                        .bigText(preview))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true)
+                .setOngoing(false)
+                .setContentIntent(openPending)
+                .setShowWhen(true)
+                .build();
+    }
+
+    /**
+     * Build a notification that the agent encountered an error.
+     */
+    private Notification buildErrorNotification(String sessionId, String error) {
+        Intent openIntent = new Intent(this, MainActivity.class);
+        openIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        openIntent.putExtra("session_id", sessionId);
+        int piFlags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                ? PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
+                : PendingIntent.FLAG_UPDATE_CURRENT;
+        PendingIntent openPending = PendingIntent.getActivity(this, 2, openIntent, piFlags);
+
+        return new NotificationCompat.Builder(this, CHANNEL_ID_DONE)
+                .setSmallIcon(android.R.drawable.ic_dialog_alert)
+                .setContentTitle("DroidClaw — agent error")
+                .setContentText(error)
+                .setStyle(new NotificationCompat.BigTextStyle()
+                        .bigText(error))
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true)
+                .setOngoing(false)
+                .setContentIntent(openPending)
+                .setShowWhen(true)
+                .build();
+    }
+
+    /**
+     * Remove common markdown markers so the notification text is readable.
+     */
+    private static String stripMarkdown(String text) {
+        if (text == null) return "";
+        return text
+                .replaceAll("(?m)^#{1,6}\\s+", "")     // headings
+                .replaceAll("\\*\\*(.+?)\\*\\*", "$1") // bold
+                .replaceAll("\\*(.+?)\\*", "$1")        // italic
+                .replaceAll("`{1,3}[^`]*`{1,3}", "")    // inline code / code blocks
+                .replaceAll("\\[([^]]+)]\\([^)]+\\)", "$1") // links
+                .replaceAll("(?m)^[-*+]\\s+", "")       // list markers
+                .replaceAll("(?m)^>\\s+", "")            // blockquotes
+                .replaceAll("\\n{3,}", "\n\n")           // collapse excessive newlines
+                .trim();
     }
 
     // ==================== WakeLock ====================

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -35,8 +35,14 @@ import io.finett.droidclaw.tool.impl.ResumeTaskTool;
 import io.finett.droidclaw.tool.impl.DeleteTaskTool;
 import io.finett.droidclaw.tool.impl.ViewTaskHistoryTool;
 import io.finett.droidclaw.tool.impl.TaskStatsTool;
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
 import io.finett.droidclaw.tool.impl.KillBackgroundProcessTool;
 import io.finett.droidclaw.tool.impl.ListBackgroundProcessesTool;
+import io.finett.droidclaw.tool.impl.ScreenGetUiTreeTool;
+import io.finett.droidclaw.tool.impl.ScreenPerformActionTool;
+import io.finett.droidclaw.tool.impl.ScreenSwipeTool;
+import io.finett.droidclaw.tool.impl.ScreenTapTool;
+import io.finett.droidclaw.tool.impl.ScreenTypeTextTool;
 import io.finett.droidclaw.tool.impl.SetupHeartbeatTool;
 import io.finett.droidclaw.tool.impl.SubmitNotificationTool;
 import io.finett.droidclaw.tool.impl.SearxngSearchTool;
@@ -123,6 +129,19 @@ public class ToolRegistry {
 
         registerTool(new KillBackgroundProcessTool(context));
         registerTool(new ListBackgroundProcessesTool(context));
+
+        // Screen control via Android Accessibility — only when both enabled in settings
+        // AND the accessibility service is currently connected
+        if (settingsManager != null
+                && settingsManager.getAgentConfig().isScreenControlEnabled()
+                && AccessibilityBridge.isConnected()) {
+            boolean trustMode = settingsManager.getAgentConfig().isScreenControlTrustMode();
+            registerTool(new ScreenGetUiTreeTool());
+            registerTool(new ScreenTapTool(trustMode));
+            registerTool(new ScreenSwipeTool(trustMode));
+            registerTool(new ScreenTypeTextTool(trustMode));
+            registerTool(new ScreenPerformActionTool(trustMode));
+        }
 
         // Web search via SearXNG — reads SEARXNG_URL from env vars
         if (settingsManager != null) {

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenGetUiTreeTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenGetUiTreeTool.java
@@ -1,0 +1,83 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
+import io.finett.droidclaw.accessibility.AccessibilityCommand;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Read-only tool that returns a compact JSON representation of the currently visible UI.
+ *
+ * <p>The agent can use this to understand what is on screen before deciding which element
+ * to interact with. Does NOT require approval (read-only, no side effects).
+ */
+public class ScreenGetUiTreeTool implements Tool {
+
+    private static final String NAME = "screen_get_ui_tree";
+
+    private final ToolDefinition definition;
+
+    public ScreenGetUiTreeTool() {
+        this.definition = buildDefinition();
+    }
+
+    private ToolDefinition buildDefinition() {
+        JsonObject params = new ToolDefinition.ParametersBuilder()
+                .addInteger("depth",
+                        "Maximum depth of the UI tree to retrieve (1–10). Default is 6. "
+                        + "Lower values return faster but may miss deeply nested elements.",
+                        false)
+                .build();
+
+        return new ToolDefinition(
+                NAME,
+                "Read the current screen's UI hierarchy as JSON. Returns all visible elements "
+                + "with their text, resource IDs, content descriptions, clickability flags, "
+                + "and screen coordinates (bounds with centerX/centerY). Use this before "
+                + "calling any screen interaction tool so you know what is visible and where "
+                + "each element is located. Works on any app currently in the foreground.",
+                params
+        );
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return false; // Read-only
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        if (!AccessibilityBridge.isConnected()) {
+            return ToolResult.error("Accessibility service is not connected. "
+                    + "Enable DroidClaw in Settings → Accessibility and turn on "
+                    + "Screen Control in Agent Settings.");
+        }
+
+        int depth = 6;
+        if (arguments != null && arguments.has("depth")
+                && !arguments.get("depth").isJsonNull()) {
+            try {
+                depth = arguments.get("depth").getAsInt();
+                depth = Math.max(1, Math.min(10, depth));
+            } catch (Exception e) {
+                // Use default
+            }
+        }
+
+        AccessibilityCommand command = AccessibilityCommand.getUiTree(depth);
+        return AccessibilityBridge.execute(command);
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenPerformActionTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenPerformActionTool.java
@@ -1,0 +1,119 @@
+package io.finett.droidclaw.tool.impl;
+
+import android.accessibilityservice.AccessibilityService;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
+import io.finett.droidclaw.accessibility.AccessibilityCommand;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Performs Android system-level global actions: back, home, recents, notifications,
+ * quick settings, and lock screen.
+ *
+ * <p>Trust-mode aware: when {@code trustMode} is true, approval is bypassed so the agent
+ * can navigate across apps uninterrupted.
+ */
+public class ScreenPerformActionTool implements Tool {
+
+    private static final String NAME = "screen_perform_action";
+
+    private final boolean trustMode;
+    private final ToolDefinition definition;
+
+    public ScreenPerformActionTool(boolean trustMode) {
+        this.trustMode = trustMode;
+        this.definition = buildDefinition();
+    }
+
+    private ToolDefinition buildDefinition() {
+        JsonObject params = new ToolDefinition.ParametersBuilder()
+                .addString("action",
+                        "The global action to perform. One of:\n"
+                        + "  • back — press the Back button\n"
+                        + "  • home — press the Home button\n"
+                        + "  • recents — open the Recents/Overview screen\n"
+                        + "  • notifications — pull down the notification shade\n"
+                        + "  • quick_settings — open Quick Settings panel\n"
+                        + "  • lock_screen — lock the device screen",
+                        true)
+                .build();
+
+        return new ToolDefinition(
+                NAME,
+                "Perform a system-level navigation action on the Android device. "
+                + "Use 'back' to go back, 'home' to go to the home screen, "
+                + "'recents' to see recent apps, 'notifications' to open the notification shade, "
+                + "'quick_settings' for the quick-settings tiles, or 'lock_screen' to lock the device.",
+                params
+        );
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return !trustMode;
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        if (arguments == null) return "Perform system action";
+        String action = arguments.has("action") && !arguments.get("action").isJsonNull()
+                ? arguments.get("action").getAsString() : "unknown";
+        return "Perform system action: " + action;
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        if (!AccessibilityBridge.isConnected()) {
+            return ToolResult.error("Accessibility service is not connected. "
+                    + "Enable DroidClaw in Settings → Accessibility.");
+        }
+
+        if (arguments == null || !arguments.has("action") || arguments.get("action").isJsonNull()) {
+            return ToolResult.error("Missing required parameter: action");
+        }
+
+        String action = arguments.get("action").getAsString().trim().toLowerCase();
+        int globalActionId;
+
+        switch (action) {
+            case "back":
+                globalActionId = AccessibilityService.GLOBAL_ACTION_BACK;
+                break;
+            case "home":
+                globalActionId = AccessibilityService.GLOBAL_ACTION_HOME;
+                break;
+            case "recents":
+                globalActionId = AccessibilityService.GLOBAL_ACTION_RECENTS;
+                break;
+            case "notifications":
+                globalActionId = AccessibilityService.GLOBAL_ACTION_NOTIFICATIONS;
+                break;
+            case "quick_settings":
+                globalActionId = AccessibilityService.GLOBAL_ACTION_QUICK_SETTINGS;
+                break;
+            case "lock_screen":
+                globalActionId = AccessibilityService.GLOBAL_ACTION_LOCK_SCREEN;
+                break;
+            default:
+                return ToolResult.error("Unknown action: \"" + action + "\". "
+                        + "Valid actions: back, home, recents, notifications, quick_settings, lock_screen");
+        }
+
+        AccessibilityCommand command = AccessibilityCommand.globalAction(globalActionId);
+        return AccessibilityBridge.execute(command);
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenSwipeTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenSwipeTool.java
@@ -1,0 +1,116 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
+import io.finett.droidclaw.accessibility.AccessibilityCommand;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Performs a swipe gesture between two screen coordinates.
+ *
+ * <p>Useful for scrolling lists, swiping between pages, or dismissing notifications.
+ * Trust-mode aware: when {@code trustMode} is true, approval is bypassed.
+ */
+public class ScreenSwipeTool implements Tool {
+
+    private static final String NAME = "screen_swipe";
+
+    private final boolean trustMode;
+    private final ToolDefinition definition;
+
+    public ScreenSwipeTool(boolean trustMode) {
+        this.trustMode = trustMode;
+        this.definition = buildDefinition();
+    }
+
+    private ToolDefinition buildDefinition() {
+        JsonObject params = new ToolDefinition.ParametersBuilder()
+                .addInteger("from_x", "Starting X coordinate of the swipe (in screen pixels)", true)
+                .addInteger("from_y", "Starting Y coordinate of the swipe (in screen pixels)", true)
+                .addInteger("to_x",   "Ending X coordinate of the swipe (in screen pixels)", true)
+                .addInteger("to_y",   "Ending Y coordinate of the swipe (in screen pixels)", true)
+                .addInteger("duration_ms",
+                        "Duration of the swipe gesture in milliseconds (50–3000). Default is 300. "
+                        + "Slower swipes (e.g. 800ms) work better for scrolling; faster for flings.",
+                        false)
+                .build();
+
+        return new ToolDefinition(
+                NAME,
+                "Perform a swipe gesture on the screen between two coordinates. "
+                + "Use this for scrolling (swipe up to scroll down), pulling down the notification "
+                + "shade, swiping between pages, or dismissing items. "
+                + "Get valid coordinates from screen_get_ui_tree bounds first.",
+                params
+        );
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return !trustMode;
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        if (arguments == null) return "Swipe screen";
+        try {
+            int fx = arguments.get("from_x").getAsInt();
+            int fy = arguments.get("from_y").getAsInt();
+            int tx = arguments.get("to_x").getAsInt();
+            int ty = arguments.get("to_y").getAsInt();
+            return "Swipe screen from (" + fx + ", " + fy + ") to (" + tx + ", " + ty + ")";
+        } catch (Exception e) {
+            return "Swipe screen";
+        }
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        if (!AccessibilityBridge.isConnected()) {
+            return ToolResult.error("Accessibility service is not connected. "
+                    + "Enable DroidClaw in Settings → Accessibility.");
+        }
+
+        if (arguments == null) {
+            return ToolResult.error("Missing required arguments: from_x, from_y, to_x, to_y");
+        }
+
+        String[] required = {"from_x", "from_y", "to_x", "to_y"};
+        for (String key : required) {
+            if (!arguments.has(key) || arguments.get(key).isJsonNull()) {
+                return ToolResult.error("Missing required parameter: " + key);
+            }
+        }
+
+        try {
+            int fromX = arguments.get("from_x").getAsInt();
+            int fromY = arguments.get("from_y").getAsInt();
+            int toX   = arguments.get("to_x").getAsInt();
+            int toY   = arguments.get("to_y").getAsInt();
+
+            int duration = 300;
+            if (arguments.has("duration_ms") && !arguments.get("duration_ms").isJsonNull()) {
+                duration = arguments.get("duration_ms").getAsInt();
+                duration = Math.max(50, Math.min(3000, duration));
+            }
+
+            AccessibilityCommand command = AccessibilityCommand.swipe(fromX, fromY, toX, toY, duration);
+            return AccessibilityBridge.execute(command);
+        } catch (Exception e) {
+            return ToolResult.error("Invalid argument values: " + e.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenTapTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenTapTool.java
@@ -1,0 +1,134 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
+import io.finett.droidclaw.accessibility.AccessibilityCommand;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Taps a point on the screen either by coordinates or by locating a node via
+ * its resource ID or visible text.
+ *
+ * <p>When {@code trustMode} is {@code true} (set at registration time by
+ * {@link io.finett.droidclaw.tool.ToolRegistry}), approval is skipped so the
+ * agent can operate uninterrupted across apps. When {@code false}, the existing
+ * {@link io.finett.droidclaw.agent.AgentLoop} approval dialog fires before execution.
+ */
+public class ScreenTapTool implements Tool {
+
+    private static final String NAME = "screen_tap";
+
+    private final boolean trustMode;
+    private final ToolDefinition definition;
+
+    public ScreenTapTool(boolean trustMode) {
+        this.trustMode = trustMode;
+        this.definition = buildDefinition();
+    }
+
+    private ToolDefinition buildDefinition() {
+        JsonObject params = new ToolDefinition.ParametersBuilder()
+                .addInteger("x",
+                        "X coordinate to tap (in screen pixels). Provide either x+y OR resource_id OR text.",
+                        false)
+                .addInteger("y",
+                        "Y coordinate to tap (in screen pixels). Provide either x+y OR resource_id OR text.",
+                        false)
+                .addString("resource_id",
+                        "Tap the first node with this Android resource ID (e.g. 'com.example.app:id/button'). "
+                        + "Use screen_get_ui_tree to discover resource IDs.",
+                        false)
+                .addString("text",
+                        "Tap the first node whose visible text exactly or partially matches this string. "
+                        + "Use screen_get_ui_tree to discover text values.",
+                        false)
+                .build();
+
+        return new ToolDefinition(
+                NAME,
+                "Tap an element on the phone screen. Provide either:\n"
+                + "  • x + y — tap by screen coordinates (use centerX/centerY from screen_get_ui_tree)\n"
+                + "  • resource_id — tap by Android view resource ID\n"
+                + "  • text — tap the first element whose text matches\n"
+                + "Always call screen_get_ui_tree first to verify what is visible and get coordinates.",
+                params
+        );
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return !trustMode;
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        if (arguments == null) return "Tap screen";
+
+        if (arguments.has("resource_id") && !arguments.get("resource_id").isJsonNull()) {
+            String rid = arguments.get("resource_id").getAsString();
+            return "Tap element with resource ID: " + rid;
+        }
+        if (arguments.has("text") && !arguments.get("text").isJsonNull()) {
+            String t = arguments.get("text").getAsString();
+            return "Tap element with text: \"" + t + "\"";
+        }
+        if (arguments.has("x") && arguments.has("y")) {
+            int x = arguments.get("x").getAsInt();
+            int y = arguments.get("y").getAsInt();
+            return "Tap screen at coordinates (" + x + ", " + y + ")";
+        }
+        return "Tap screen";
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        if (!AccessibilityBridge.isConnected()) {
+            return ToolResult.error("Accessibility service is not connected. "
+                    + "Enable DroidClaw in Settings → Accessibility.");
+        }
+
+        if (arguments == null) {
+            return ToolResult.error("Missing arguments: provide x+y, resource_id, or text");
+        }
+
+        // Prefer coordinate tap
+        boolean hasX = arguments.has("x") && !arguments.get("x").isJsonNull();
+        boolean hasY = arguments.has("y") && !arguments.get("y").isJsonNull();
+        if (hasX && hasY) {
+            int x = arguments.get("x").getAsInt();
+            int y = arguments.get("y").getAsInt();
+            return AccessibilityBridge.execute(AccessibilityCommand.tapAt(x, y));
+        }
+
+        // Fall back to resource_id
+        if (arguments.has("resource_id") && !arguments.get("resource_id").isJsonNull()) {
+            String rid = arguments.get("resource_id").getAsString().trim();
+            if (!rid.isEmpty()) {
+                return AccessibilityBridge.execute(AccessibilityCommand.tapByResourceId(rid));
+            }
+        }
+
+        // Fall back to text match
+        if (arguments.has("text") && !arguments.get("text").isJsonNull()) {
+            String text = arguments.get("text").getAsString().trim();
+            if (!text.isEmpty()) {
+                return AccessibilityBridge.execute(AccessibilityCommand.tapByText(text));
+            }
+        }
+
+        return ToolResult.error("Provide at least one of: x+y, resource_id, or text");
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenTypeTextTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ScreenTypeTextTool.java
@@ -1,0 +1,112 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.accessibility.AccessibilityBridge;
+import io.finett.droidclaw.accessibility.AccessibilityCommand;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Types text into an editable field using Android's {@code ACTION_SET_TEXT} accessibility action.
+ *
+ * <p>Optionally targets a specific field by resource ID. When no resource ID is provided,
+ * the currently focused editable field is used — call {@code screen_tap} on the field first.
+ * Trust-mode aware: when {@code trustMode} is true, approval is bypassed.
+ */
+public class ScreenTypeTextTool implements Tool {
+
+    private static final String NAME = "screen_type_text";
+
+    private final boolean trustMode;
+    private final ToolDefinition definition;
+
+    public ScreenTypeTextTool(boolean trustMode) {
+        this.trustMode = trustMode;
+        this.definition = buildDefinition();
+    }
+
+    private ToolDefinition buildDefinition() {
+        JsonObject params = new ToolDefinition.ParametersBuilder()
+                .addString("text",
+                        "The text to type into the field. Replaces any existing content.",
+                        true)
+                .addString("resource_id",
+                        "Optional: the resource ID of the target text field "
+                        + "(e.g. 'com.example.app:id/search_input'). "
+                        + "If omitted, the currently focused editable field is used — "
+                        + "tap the field first with screen_tap.",
+                        false)
+                .build();
+
+        return new ToolDefinition(
+                NAME,
+                "Type text into an editable field on the screen using the accessibility API. "
+                + "This replaces the field's current content with the provided text. "
+                + "If resource_id is not specified, the currently focused editable field is used. "
+                + "Tip: use screen_tap to focus a field before calling this tool without resource_id.",
+                params
+        );
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return !trustMode;
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        if (arguments == null) return "Type text into field";
+        String text = arguments.has("text") && !arguments.get("text").isJsonNull()
+                ? arguments.get("text").getAsString() : "";
+        String rid = arguments.has("resource_id") && !arguments.get("resource_id").isJsonNull()
+                ? arguments.get("resource_id").getAsString() : null;
+
+        // Truncate long text for display
+        String displayText = text.length() > 50 ? text.substring(0, 47) + "..." : text;
+
+        if (rid != null && !rid.isEmpty()) {
+            return "Type \"" + displayText + "\" into field: " + rid;
+        }
+        return "Type \"" + displayText + "\" into focused field";
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        if (!AccessibilityBridge.isConnected()) {
+            return ToolResult.error("Accessibility service is not connected. "
+                    + "Enable DroidClaw in Settings → Accessibility.");
+        }
+
+        if (arguments == null || !arguments.has("text") || arguments.get("text").isJsonNull()) {
+            return ToolResult.error("Missing required parameter: text");
+        }
+
+        String text = arguments.get("text").getAsString();
+
+        String resourceId = null;
+        if (arguments.has("resource_id") && !arguments.get("resource_id").isJsonNull()) {
+            String rid = arguments.get("resource_id").getAsString().trim();
+            if (!rid.isEmpty()) {
+                resourceId = rid;
+            }
+        }
+
+        AccessibilityCommand command = resourceId != null
+                ? AccessibilityCommand.setTextOnNode(resourceId, text)
+                : AccessibilityCommand.setTextOnFocused(text);
+
+        return AccessibilityBridge.execute(command);
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -228,6 +228,8 @@ public class SettingsManager {
         config.setShellTimeout(json.optInt("shellTimeout", 30));
         config.setBackgroundShellEnabled(json.optBoolean("backgroundShellEnabled", false));
         config.setBackgroundExecEnabled(json.optBoolean("backgroundExecEnabled", false));
+        config.setScreenControlEnabled(json.optBoolean("screenControlEnabled", false));
+        config.setScreenControlTrustMode(json.optBoolean("screenControlTrustMode", false));
 
         List<String> customAllowlist = new ArrayList<>();
         if (json.has("customAllowlist")) {
@@ -317,6 +319,8 @@ public class SettingsManager {
         json.put("shellTimeout", config.getShellTimeout());
         json.put("backgroundShellEnabled", config.isBackgroundShellEnabled());
         json.put("backgroundExecEnabled", config.isBackgroundExecEnabled());
+        json.put("screenControlEnabled", config.isScreenControlEnabled());
+        json.put("screenControlTrustMode", config.isScreenControlTrustMode());
 
         JSONArray allowlistArr = new JSONArray();
         for (String path : config.getCustomAllowlist()) {

--- a/app/src/main/res/layout/fragment_agent_settings.xml
+++ b/app/src/main/res/layout/fragment_agent_settings.xml
@@ -265,6 +265,120 @@
             android:layout_marginBottom="8dp"
             android:background="?android:attr/listDivider" />
 
+        <!-- Screen Control Header -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Screen Control"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp" />
+
+        <!-- Screen Control Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/screen_control"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/screen_control_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_screen_control"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <!-- Screen Control Trust Mode Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/screen_control_trust_mode"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/screen_control_trust_mode_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_screen_control_trust_mode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <!-- Accessibility Permission Status -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="24dp">
+
+            <TextView
+                android:id="@+id/text_accessibility_status"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/screen_control_accessibility_not_granted"
+                android:textAppearance="?attr/textAppearanceCaption"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_open_accessibility_settings"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/screen_control_open_accessibility_settings" />
+
+        </LinearLayout>
+
+        <!-- Divider -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="8dp"
+            android:background="?android:attr/listDivider" />
+
         <!-- Network Timeouts Header -->
         <TextView
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,15 @@
     <string name="background_exec_description">Allow the agent to run any tool asynchronously with background=true</string>
     <string name="custom_allowlist">Custom Command Allowlist</string>
     <string name="custom_allowlist_description">Extra executable paths allowed in Relaxed mode (one per line)</string>
+    <string name="screen_control">Screen Control</string>
+    <string name="screen_control_description">Allow the agent to read the visible UI and control the phone via Accessibility</string>
+    <string name="screen_control_trust_mode">Screen Control Trust Mode</string>
+    <string name="screen_control_trust_mode_description">Auto-approve screen taps, swipes, typing, and navigation actions</string>
+    <string name="screen_control_accessibility_granted">Accessibility access granted</string>
+    <string name="screen_control_accessibility_not_granted">Accessibility access not granted</string>
+    <string name="screen_control_open_accessibility_settings">Open Accessibility Settings</string>
+    <string name="accessibility_service_label">DroidClaw Accessibility</string>
+    <string name="accessibility_service_description">Lets DroidClaw read the visible UI and control the phone screen for agent tasks</string>
     <string name="network_timeouts">Network Timeouts</string>
     <string name="llm_connect_timeout">LLM Connect Timeout (seconds)</string>
     <string name="llm_connect_timeout_description">Connection timeout for LLM API</string>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagReportViewIds|flagRetrieveInteractiveWindows"
+    android:canPerformGestures="true"
+    android:canRetrieveWindowContent="true"
+    android:description="@string/accessibility_service_description"
+    android:notificationTimeout="100" />


### PR DESCRIPTION
## Summary

Adds Accessibility-based screen control tools and an agent completion notification when the app is not in the foreground.

### Screen Control

- **AccessibilityService** (`DroidClawAccessibilityService`) with bridge pattern for reading UI hierarchy and performing actions
- **New tools**: `get_ui_tree`, `screen_tap`, `screen_swipe`, `screen_type_text`, `screen_perform_action`
- **Settings**: toggles for screen control enable/disable and trust mode (skip per-action approval)
- Conditionally registered in ToolRegistry — only when enabled AND service is connected
- Accessibility permission status display in agent settings

### Agent Done Notification

- When the agent completes/errors and the app is **not in the foreground**, posts a notification with the response preview
- Separate notification channel (`droidclaw_agent_done`) with `IMPORTANCE_DEFAULT` (makes sound/vibrate)
- Markdown-stripped preview, `BigTextStyle`, auto-cancels on tap
- **Error notification** uses alert icon and `PRIORITY_HIGH`
- Proper `POST_NOTIFICATIONS` runtime permission request on Android 13+ (API 33+)

### Testing

- Build: `compileDebugJavaWithJavac` ✅
- Install and run on Infinix X6851B (Android 15): ✅
- Notifications confirmed working after granting `POST_NOTIFICATIONS` permission