### PR TITLE
feat: add per-tool approval settings screen

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/adapter/ToolApprovalAdapter.java
+++ b/app/src/main/java/io/finett/droidclaw/adapter/ToolApprovalAdapter.java
@@ -1,0 +1,138 @@
+package io.finett.droidclaw.adapter;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.finett.droidclaw.R;
+import io.finett.droidclaw.model.ToolApprovalMode;
+import io.finett.droidclaw.util.SettingsManager;
+
+/**
+ * ArrayAdapter that renders one row per registered tool with an inline
+ * {@link AutoCompleteTextView} dropdown for per-tool approval mode.
+ */
+public class ToolApprovalAdapter extends ArrayAdapter<ToolApprovalAdapter.ToolApprovalEntry> {
+
+    public static class ToolApprovalEntry {
+        public final String toolName;
+        public final String toolDescription;
+        public ToolApprovalMode mode;
+
+        public ToolApprovalEntry(String toolName, String toolDescription, ToolApprovalMode mode) {
+            this.toolName = toolName;
+            this.toolDescription = toolDescription;
+            this.mode = mode;
+        }
+    }
+
+    private static final String[] MODE_LABELS = {
+            "Follow global setting",   // DEFAULT
+            "Always approve",          // ALWAYS_APPROVE
+            "Always reject"            // ALWAYS_REJECT
+    };
+
+    private final Context context;
+    private final SettingsManager settingsManager;
+
+    public ToolApprovalAdapter(@NonNull Context context,
+                               @NonNull List<ToolApprovalEntry> entries,
+                               @NonNull SettingsManager settingsManager) {
+        super(context, 0, entries);
+        this.context = context;
+        this.settingsManager = settingsManager;
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        return bindView(position, convertView, parent);
+    }
+
+    @NonNull
+    @Override
+    public View getDropDownView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        return bindView(position, convertView, parent);
+    }
+
+    private View bindView(int position, View convertView, ViewGroup parent) {
+        if (convertView == null) {
+            convertView = LayoutInflater.from(context)
+                    .inflate(R.layout.item_tool_approval_row, parent, false);
+        }
+
+        ToolApprovalEntry entry = getItem(position);
+
+        ((TextView) convertView.findViewById(R.id.text_tool_name)).setText(entry.toolName);
+        ((TextView) convertView.findViewById(R.id.text_tool_desc)).setText(entry.toolDescription);
+
+        AutoCompleteTextView dropdown = convertView.findViewById(R.id.dropdown_approval_mode);
+
+        // Rebuild adapter each time to avoid stale listeners / state
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                context,
+                android.R.layout.simple_dropdown_item_1line,
+                MODE_LABELS
+        );
+        dropdown.setAdapter(adapter);
+
+        // Restore current selection
+        String label = getLabelForMode(entry.mode);
+        dropdown.setText(label, false);
+
+        // Attach text watcher to persist selection changes
+        dropdown.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            @Override
+            public void afterTextChanged(Editable s) {
+                String selected = s.toString();
+                ToolApprovalMode newMode = ToolApprovalMode.DEFAULT;
+                for (int i = 0; i < MODE_LABELS.length; i++) {
+                    if (MODE_LABELS[i].equals(selected)) {
+                        newMode = ToolApprovalMode.values()[i];
+                        break;
+                    }
+                }
+                entry.mode = newMode;
+                persistOverride(entry.toolName, newMode);
+            }
+        });
+
+        return convertView;
+    }
+
+    private String getLabelForMode(ToolApprovalMode mode) {
+        switch (mode) {
+            case ALWAYS_APPROVE: return MODE_LABELS[1];
+            case ALWAYS_REJECT:  return MODE_LABELS[2];
+            case DEFAULT:
+            default:             return MODE_LABELS[0];
+        }
+    }
+
+    private void persistOverride(String toolName, ToolApprovalMode mode) {
+        Map<String, String> overrides = new HashMap<>(
+                settingsManager.getAgentConfig().getToolApprovalOverrides());
+        if (mode == ToolApprovalMode.DEFAULT) {
+            overrides.remove(toolName);
+        } else {
+            overrides.put(toolName, mode.name());
+        }
+        settingsManager.getAgentConfig().setToolApprovalOverrides(overrides);
+        settingsManager.setAgentConfig(settingsManager.getAgentConfig());
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/adapter/ToolApprovalAdapter.java
+++ b/app/src/main/java/io/finett/droidclaw/adapter/ToolApprovalAdapter.java
@@ -31,11 +31,38 @@ public class ToolApprovalAdapter extends ArrayAdapter<ToolApprovalAdapter.ToolAp
         public final String toolName;
         public final String toolDescription;
         public ToolApprovalMode mode;
+        // Tracks the TextWatcher attached to the dropdown so it can be removed on view recycling.
+        private TextWatcher watcher;
 
         public ToolApprovalEntry(String toolName, String toolDescription, ToolApprovalMode mode) {
             this.toolName = toolName;
             this.toolDescription = toolDescription;
             this.mode = mode;
+        }
+
+        private TextWatcher getOrCreateWatcher(AutoCompleteTextView dropdown, ToolApprovalAdapter adapter) {
+            if (watcher == null) {
+                watcher = new TextWatcher() {
+                    @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+                    @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+                    @Override
+                    public void afterTextChanged(Editable s) {
+                        String selected = s.toString();
+                        ToolApprovalMode newMode = ToolApprovalMode.DEFAULT;
+                        for (int i = 0; i < MODE_LABELS.length; i++) {
+                            if (MODE_LABELS[i].equals(selected)) {
+                                newMode = ToolApprovalMode.values()[i];
+                                break;
+                            }
+                        }
+                        mode = newMode;
+                        adapter.persistOverride(toolName, newMode);
+                    }
+                };
+            }
+            dropdown.removeTextChangedListener(watcher);
+            dropdown.addTextChangedListener(watcher);
+            return watcher;
         }
     }
 
@@ -93,24 +120,8 @@ public class ToolApprovalAdapter extends ArrayAdapter<ToolApprovalAdapter.ToolAp
         String label = getLabelForMode(entry.mode);
         dropdown.setText(label, false);
 
-        // Attach text watcher to persist selection changes
-        dropdown.addTextChangedListener(new TextWatcher() {
-            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
-            @Override
-            public void afterTextChanged(Editable s) {
-                String selected = s.toString();
-                ToolApprovalMode newMode = ToolApprovalMode.DEFAULT;
-                for (int i = 0; i < MODE_LABELS.length; i++) {
-                    if (MODE_LABELS[i].equals(selected)) {
-                        newMode = ToolApprovalMode.values()[i];
-                        break;
-                    }
-                }
-                entry.mode = newMode;
-                persistOverride(entry.toolName, newMode);
-            }
-        });
+        // Attach (or re-attach on recycled views) the per-entry text watcher.
+        entry.getOrCreateWatcher(dropdown, this);
 
         return convertView;
     }
@@ -132,7 +143,6 @@ public class ToolApprovalAdapter extends ArrayAdapter<ToolApprovalAdapter.ToolAp
         } else {
             overrides.put(toolName, mode.name());
         }
-        settingsManager.getAgentConfig().setToolApprovalOverrides(overrides);
         settingsManager.setAgentConfig(settingsManager.getAgentConfig());
     }
 }

--- a/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 import io.finett.droidclaw.api.LlmApiService;
 import io.finett.droidclaw.model.ChatMessage;
 import io.finett.droidclaw.model.FileAttachment;
+import io.finett.droidclaw.model.ToolApprovalMode;
 import io.finett.droidclaw.service.BackgroundProcessManager;
 import io.finett.droidclaw.shell.ExecPlan;
 import io.finett.droidclaw.tool.Tool;
@@ -40,6 +41,27 @@ public class AgentLoop {
     private boolean requireApproval;
     private List<ChatMessage> identityMessages;
     private JsonObject responseSchema;
+
+    /**
+     * Look up the per-tool approval override for a given tool name.
+     * Returns {@link ToolApprovalMode#DEFAULT} if no override is set.
+     */
+    private ToolApprovalMode getPerToolApprovalMode(String toolName) {
+        try {
+            java.util.Map<String, String> overrides = settingsManager.getAgentConfig()
+                    .getToolApprovalOverrides();
+            if (overrides == null) return ToolApprovalMode.DEFAULT;
+            String value = overrides.get(toolName);
+            if (value == null) return ToolApprovalMode.DEFAULT;
+            try {
+                return ToolApprovalMode.valueOf(value);
+            } catch (IllegalArgumentException ignored) {
+                return ToolApprovalMode.DEFAULT;
+            }
+        } catch (Exception e) {
+            return ToolApprovalMode.DEFAULT;
+        }
+    }
 
     // Token tracking - "Last Usage" algorithm
     // Current context tokens (from last API response - this is the ACTUAL context size)
@@ -320,7 +342,39 @@ public class AgentLoop {
 
         // Check if this tool requires approval
         Tool tool = toolRegistry.getTool(toolName);
-        boolean needsApproval = requireApproval && tool != null && tool.requiresApproval();
+        ToolApprovalMode mode = getPerToolApprovalMode(toolName);
+        boolean needsApproval;
+
+        switch (mode) {
+            case ALWAYS_APPROVE:
+                needsApproval = false;
+                break;
+            case ALWAYS_REJECT:
+                needsApproval = false;
+                break;
+            case DEFAULT:
+            default:
+                needsApproval = requireApproval && tool != null && tool.requiresApproval();
+                break;
+        }
+
+        // Auto-reject: skip prompt, return block result immediately
+        if (mode == ToolApprovalMode.ALWAYS_REJECT) {
+            String resultContent = "Tool execution blocked by per-tool setting";
+            Log.d(TAG, "Tool " + toolName + " blocked (ALWAYS_REJECT)");
+            callback.onToolResult(toolName, resultContent);
+
+            ChatMessage toolResultMessage = ChatMessage.createToolResultMessage(
+                    toolCall.getId(),
+                    toolName,
+                    resultContent
+            );
+            conversationHistory.add(toolResultMessage);
+
+            // Process next tool call
+            processToolCallsWithApproval(toolCalls, index + 1, conversationHistory, callback);
+            return;
+        }
 
         if (needsApproval) {
             // Build a normalised ExecPlan for exec-type tools (shell, etc.).

--- a/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
@@ -44,7 +44,8 @@ public class AgentLoop {
 
     /**
      * Look up the per-tool approval override for a given tool name.
-     * Returns {@link ToolApprovalMode#DEFAULT} if no override is set.
+     * Returns {@link ToolApprovalMode#DEFAULT} if no override is set or if
+     * reading the overrides fails (logged at warn level).
      */
     private ToolApprovalMode getPerToolApprovalMode(String toolName) {
         try {
@@ -59,6 +60,7 @@ public class AgentLoop {
                 return ToolApprovalMode.DEFAULT;
             }
         } catch (Exception e) {
+            Log.w(TAG, "Error reading tool approval override for " + toolName, e);
             return ToolApprovalMode.DEFAULT;
         }
     }
@@ -343,22 +345,8 @@ public class AgentLoop {
         // Check if this tool requires approval
         Tool tool = toolRegistry.getTool(toolName);
         ToolApprovalMode mode = getPerToolApprovalMode(toolName);
-        boolean needsApproval;
 
-        switch (mode) {
-            case ALWAYS_APPROVE:
-                needsApproval = false;
-                break;
-            case ALWAYS_REJECT:
-                needsApproval = false;
-                break;
-            case DEFAULT:
-            default:
-                needsApproval = requireApproval && tool != null && tool.requiresApproval();
-                break;
-        }
-
-        // Auto-reject: skip prompt, return block result immediately
+        // ALWAYS_REJECT: block immediately, no prompt
         if (mode == ToolApprovalMode.ALWAYS_REJECT) {
             String resultContent = "Tool execution blocked by per-tool setting";
             Log.d(TAG, "Tool " + toolName + " blocked (ALWAYS_REJECT)");
@@ -375,6 +363,11 @@ public class AgentLoop {
             processToolCallsWithApproval(toolCalls, index + 1, conversationHistory, callback);
             return;
         }
+
+        // Determine whether we need user approval
+        boolean needsApproval = (mode == ToolApprovalMode.ALWAYS_APPROVE)
+                ? false
+                : requireApproval && tool != null && tool.requiresApproval();
 
         if (needsApproval) {
             // Build a normalised ExecPlan for exec-type tools (shell, etc.).

--- a/app/src/main/java/io/finett/droidclaw/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/SettingsFragment.java
@@ -28,6 +28,7 @@ public class SettingsFragment extends Fragment {
     private static final String ITEM_ENV_VARS = "env_vars";
     private static final String ITEM_HEARTBEAT = "heartbeat";
     private static final String ITEM_CRON_JOBS = "cron_jobs";
+    private static final String ITEM_TOOL_APPROVAL = "tool_approval";
     private static final String ITEM_SKILLS = "skills";
     private static final String ITEM_INFO = "info";
     private static final String ITEM_RESET_ONBOARDING = "reset_onboarding";
@@ -120,6 +121,14 @@ public class SettingsFragment extends Fragment {
 
 
         items.add(new SettingsAdapter.SettingsItem(
+                ITEM_TOOL_APPROVAL,
+                R.drawable.ic_settings_agent,
+                getString(R.string.settings_tool_approval),
+                getString(R.string.settings_tool_approval_subtitle),
+                true
+        ));
+
+        items.add(new SettingsAdapter.SettingsItem(
                 ITEM_SKILLS,
                 R.drawable.ic_tool_generic,
                 getString(R.string.settings_skills),
@@ -169,6 +178,10 @@ public class SettingsFragment extends Fragment {
             case ITEM_CRON_JOBS:
                 Navigation.findNavController(requireView())
                         .navigate(R.id.action_settingsFragment_to_cronJobListFragment);
+                break;
+            case ITEM_TOOL_APPROVAL:
+                Navigation.findNavController(requireView())
+                        .navigate(R.id.action_settingsFragment_to_toolApprovalSettingsFragment);
                 break;
             case ITEM_SKILLS:
                 Navigation.findNavController(requireView())

--- a/app/src/main/java/io/finett/droidclaw/fragment/ToolApprovalSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ToolApprovalSettingsFragment.java
@@ -1,0 +1,98 @@
+package io.finett.droidclaw.fragment;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import android.widget.ListView;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.finett.droidclaw.R;
+import io.finett.droidclaw.adapter.ToolApprovalAdapter;
+import io.finett.droidclaw.model.ToolApprovalMode;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolRegistry;
+import io.finett.droidclaw.util.SettingsManager;
+
+/**
+ * Per-tool approval settings screen. Each registered tool gets a row with an
+ * inline dropdown for choosing {@link ToolApprovalMode}.
+ */
+public class ToolApprovalSettingsFragment extends Fragment {
+
+    private ListView listView;
+    private ToolApprovalAdapter adapter;
+    private SettingsManager settingsManager;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        settingsManager = new SettingsManager(requireContext());
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_tool_approval_settings, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        listView = view.findViewById(R.id.list_tools);
+
+        List<ToolApprovalAdapter.ToolApprovalEntry> entries = buildEntries();
+        adapter = new ToolApprovalAdapter(requireContext(), entries, settingsManager);
+        listView.setAdapter(adapter);
+    }
+
+    private List<ToolApprovalAdapter.ToolApprovalEntry> buildEntries() {
+        List<ToolApprovalAdapter.ToolApprovalEntry> entries = new ArrayList<>();
+
+        Map<String, String> overrides = settingsManager.getAgentConfig()
+                .getToolApprovalOverrides();
+
+        // Build a lightweight registry just to enumerate tool names/descriptions.
+        // We avoid constructing the full AgentLoop-owned registry to keep settings
+        // navigation cheap. ToolRegistry can be created standalone with just context.
+        ToolRegistry registry = null;
+        try {
+            registry = new ToolRegistry(requireContext(), settingsManager);
+        } catch (Exception e) {
+            android.util.Log.w("ToolApprovalSettings", "Could not build tool list", e);
+        }
+
+        if (registry == null) {
+            return entries;
+        }
+
+        for (Tool tool : registry.getAllTools()) {
+            ToolApprovalMode mode = ToolApprovalMode.DEFAULT;
+
+            String toolName = tool.getName();
+            if (overrides.containsKey(toolName)) {
+                String value = overrides.get(toolName);
+                try {
+                    mode = ToolApprovalMode.valueOf(value);
+                } catch (IllegalArgumentException ignored) {
+                    // Unknown value — treat as DEFAULT
+                }
+            }
+
+            String desc = tool.getDefinition().getFunction().getDescription();
+            entries.add(new ToolApprovalAdapter.ToolApprovalEntry(toolName, desc, mode));
+        }
+
+        return entries;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/fragment/ToolApprovalSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ToolApprovalSettingsFragment.java
@@ -30,11 +30,13 @@ public class ToolApprovalSettingsFragment extends Fragment {
     private ListView listView;
     private ToolApprovalAdapter adapter;
     private SettingsManager settingsManager;
+    private ToolRegistry toolRegistry;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         settingsManager = new SettingsManager(requireContext());
+        toolRegistry = new ToolRegistry(requireContext(), settingsManager);
     }
 
     @Nullable
@@ -62,21 +64,11 @@ public class ToolApprovalSettingsFragment extends Fragment {
         Map<String, String> overrides = settingsManager.getAgentConfig()
                 .getToolApprovalOverrides();
 
-        // Build a lightweight registry just to enumerate tool names/descriptions.
-        // We avoid constructing the full AgentLoop-owned registry to keep settings
-        // navigation cheap. ToolRegistry can be created standalone with just context.
-        ToolRegistry registry = null;
-        try {
-            registry = new ToolRegistry(requireContext(), settingsManager);
-        } catch (Exception e) {
-            android.util.Log.w("ToolApprovalSettings", "Could not build tool list", e);
-        }
-
-        if (registry == null) {
+        if (toolRegistry == null) {
             return entries;
         }
 
-        for (Tool tool : registry.getAllTools()) {
+        for (Tool tool : toolRegistry.getAllTools()) {
             ToolApprovalMode mode = ToolApprovalMode.DEFAULT;
 
             String toolName = tool.getName();

--- a/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
+++ b/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
@@ -1,7 +1,9 @@
 package io.finett.droidclaw.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AgentConfig {
     private String defaultModel; // Format: "provider-id/model-id"
@@ -18,6 +20,7 @@ public class AgentConfig {
     private int llmConnectTimeout;   // seconds
     private int llmReadTimeout;      // seconds
     private int llmWriteTimeout;     // seconds
+    private Map<String, String> toolApprovalOverrides = new HashMap<>(); // toolName -> ToolApprovalMode.name()
 
     public AgentConfig() {
         this.customAllowlist = new ArrayList<>();
@@ -26,6 +29,7 @@ public class AgentConfig {
         this.llmWriteTimeout = 30;
         this.screenControlEnabled = false;
         this.screenControlTrustMode = false;
+        this.toolApprovalOverrides = new HashMap<>();
     }
 
     public AgentConfig(String defaultModel, boolean shellAccess, String sandboxMode,
@@ -170,6 +174,16 @@ public class AgentConfig {
 
     public void setScreenControlTrustMode(boolean screenControlTrustMode) {
         this.screenControlTrustMode = screenControlTrustMode;
+    }
+
+    public Map<String, String> getToolApprovalOverrides() {
+        return toolApprovalOverrides;
+    }
+
+    public void setToolApprovalOverrides(Map<String, String> toolApprovalOverrides) {
+        this.toolApprovalOverrides = toolApprovalOverrides != null
+                ? new HashMap<>(toolApprovalOverrides)
+                : new HashMap<>();
     }
 
     public String getDefaultProviderId() {

--- a/app/src/main/java/io/finett/droidclaw/model/ToolApprovalMode.java
+++ b/app/src/main/java/io/finett/droidclaw/model/ToolApprovalMode.java
@@ -1,0 +1,16 @@
+package io.finett.droidclaw.model;
+
+/**
+ * Per-tool approval override mode.
+ *
+ * <ul>
+ *   <li>{@link #DEFAULT} — follows the global {@code requireApproval} toggle</li>
+ *   <li>{@link #ALWAYS_APPROVE} — auto-approve, no user prompt</li>
+ *   <li>{@link #ALWAYS_REJECT} — auto-reject, no user prompt (tool blocked)</li>
+ * </ul>
+ */
+public enum ToolApprovalMode {
+    DEFAULT,
+    ALWAYS_APPROVE,
+    ALWAYS_REJECT
+}

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -231,6 +231,17 @@ public class SettingsManager {
         config.setScreenControlEnabled(json.optBoolean("screenControlEnabled", false));
         config.setScreenControlTrustMode(json.optBoolean("screenControlTrustMode", false));
 
+        Map<String, String> toolApprovalOverrides = new HashMap<>();
+        if (json.has("toolApprovalOverrides")) {
+            JSONObject obj = json.getJSONObject("toolApprovalOverrides");
+            Iterator<String> keys = obj.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                toolApprovalOverrides.put(key, obj.getString(key));
+            }
+        }
+        config.setToolApprovalOverrides(toolApprovalOverrides);
+
         List<String> customAllowlist = new ArrayList<>();
         if (json.has("customAllowlist")) {
             JSONArray arr = json.getJSONArray("customAllowlist");
@@ -321,6 +332,12 @@ public class SettingsManager {
         json.put("backgroundExecEnabled", config.isBackgroundExecEnabled());
         json.put("screenControlEnabled", config.isScreenControlEnabled());
         json.put("screenControlTrustMode", config.isScreenControlTrustMode());
+
+        JSONObject overridesJson = new JSONObject();
+        for (Map.Entry<String, String> entry : config.getToolApprovalOverrides().entrySet()) {
+            overridesJson.put(entry.getKey(), entry.getValue());
+        }
+        json.put("toolApprovalOverrides", overridesJson);
 
         JSONArray allowlistArr = new JSONArray();
         for (String path : config.getCustomAllowlist()) {

--- a/app/src/main/res/layout/fragment_tool_approval_settings.xml
+++ b/app/src/main/res/layout/fragment_tool_approval_settings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <!-- Header -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/tool_approval_settings_title"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/tool_approval_settings_description"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <!-- Global fallback note -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:background="?attr/colorSurfaceVariant"
+            android:padding="12dp"
+            android:text="@string/tool_approval_global_fallback"
+            android:textAppearance="?attr/textAppearanceCaption" />
+
+        <!-- Divider -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider"
+            android:layout_marginBottom="8dp" />
+
+        <!-- Tool list -->
+        <ListView
+            android:id="@+id/list_tools"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:divider="@null"
+            android:dividerHeight="0dp" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/item_tool_approval_row.xml
+++ b/app/src/main/res/layout/item_tool_approval_row.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="14dp"
+    android:paddingBottom="14dp">
+
+    <!-- Tool name -->
+    <TextView
+        android:id="@+id/text_tool_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+    <!-- Tool description -->
+    <TextView
+        android:id="@+id/text_tool_desc"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textAppearance="?attr/textAppearanceCaption"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <!-- Dropdown -->
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:boxBackgroundMode="outline">
+
+        <AutoCompleteTextView
+            android:id="@+id/dropdown_approval_mode"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/tool_approval_mode"
+            android:inputType="none" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -85,6 +85,13 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+        <action
+            android:id="@+id/action_settingsFragment_to_toolApprovalSettingsFragment"
+            app:destination="@id/toolApprovalSettingsFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
     </fragment>
 
     <fragment
@@ -255,6 +262,11 @@
         android:id="@+id/cronJobListFragment"
         android:name="io.finett.droidclaw.fragment.CronJobListFragment"
         android:label="@string/cron_jobs" />
+
+    <fragment
+        android:id="@+id/toolApprovalSettingsFragment"
+        android:name="io.finett.droidclaw.fragment.ToolApprovalSettingsFragment"
+        android:label="@string/tool_approval_settings_title" />
 
     <fragment
         android:id="@+id/cronJobDetailFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,12 @@
     <string name="settings_agent_subtitle">Configure agent behavior</string>
     <string name="settings_heartbeat">Background Monitoring</string>
     <string name="settings_heartbeat_subtitle">Configure heartbeat health checks</string>
+    <string name="settings_tool_approval">Tool Approval</string>
+    <string name="settings_tool_approval_subtitle">Configure per-tool auto-approve and block rules</string>
+    <string name="tool_approval_settings_title">Tool Approval</string>
+    <string name="tool_approval_settings_description">Set per-tool approval behavior. "Follow global" uses the Require Approval toggle in Agent settings.</string>
+    <string name="tool_approval_global_fallback">⚙ Global "Require Approval" toggle still applies to tools set to "Follow global setting".</string>
+    <string name="tool_approval_mode">Approval mode</string>
     <string name="settings_cron_jobs_subtitle">Manage scheduled automated tasks</string>
     <string name="settings_reset_onboarding">Reset Onboarding</string>
     <string name="settings_reset_onboarding_subtitle">Start fresh setup</string>


### PR DESCRIPTION
## What

Per-tool approval mode: each registered tool can be set to **auto-approve**, **auto-reject (block)**, or **follow global toggle**.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Model | `ToolApprovalMode.java` | New enum: `DEFAULT`, `ALWAYS_APPROVE`, `ALWAYS_REJECT` |
| Config | `AgentConfig.java` | `Map<String,String> toolApprovalOverrides` field + getter/setter |
| Storage | `SettingsManager.java` | JSON serialize/deserialize `toolApprovalOverrides` |
| Logic | `AgentLoop.java` | `getPerToolApprovalMode()` + auto-reject short-circuit before approval flow |
| UI | `ToolApprovalSettingsFragment.java` | New fragment: per-tool row with inline dropdown |
| UI | `ToolApprovalAdapter.java` | ArrayAdapter with AutoCompleteTextView per row |
| Layouts | `fragment_tool_approval_settings.xml`, `item_tool_approval_row.xml` | ScrollView→ListView + row layout |
| Nav | `SettingsFragment.java`, `nav_graph.xml` | New "Tool Approval" menu entry + destination |
| Strings | `strings.xml` | 6 new entries |

## Behavior

 ```
 ALWAYS_REJECT  → block immediately, no user prompt
 ALWAYS_APPROVE → execute immediately, no user prompt
 DEFAULT        → inherits global "Require Approval" toggle
 ```

## Testing

- `./gradlew assembleDebug` — **BUILD SUCCESSFUL**
- `./gradlew testDebugUnitTest` — 82 pre-existing failures (ExecPlannerTest/ShellToolTest), none related to these changes