### PR TITLE
feat: add list_apps and open_app tools

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -46,6 +46,8 @@ import io.finett.droidclaw.tool.impl.ScreenTypeTextTool;
 import io.finett.droidclaw.tool.impl.SetupHeartbeatTool;
 import io.finett.droidclaw.tool.impl.SubmitNotificationTool;
 import io.finett.droidclaw.tool.impl.SearxngSearchTool;
+import io.finett.droidclaw.tool.impl.ListAppsTool;
+import io.finett.droidclaw.tool.impl.OpenAppTool;
 import io.finett.droidclaw.util.SettingsManager;
 
 public class ToolRegistry {
@@ -147,6 +149,10 @@ public class ToolRegistry {
         if (settingsManager != null) {
             registerTool(new SearxngSearchTool(settingsManager));
         }
+
+        // Android app management — always available
+        registerTool(new ListAppsTool(context));
+        registerTool(new OpenAppTool(context));
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/ListAppsTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/ListAppsTool.java
@@ -1,0 +1,116 @@
+package io.finett.droidclaw.tool.impl;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Tool that lists all installed Android apps.
+ *
+ * <p>Uses {@link PackageManager#getInstalledApplications(int)} to enumerate
+ * installed applications. Returns name, package name, and a flag indicating
+ * whether the app is a system app.
+ *
+ * <p>Optional filter: {@code show_system} — if false, excludes system apps
+ * (default: true, includes all apps).
+ */
+public class ListAppsTool implements Tool {
+
+    private static final String TOOL_NAME = "list_apps";
+
+    private final Context context;
+
+    public ListAppsTool(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return false;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addBoolean("show_system",
+                        "Include system apps in the results. Default: true (show all apps). "
+                        + "Set to false to show only user-installed apps.",
+                        false)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "List all installed Android apps on the device. Returns each app's "
+                + "name, package name, and whether it is a system app. Optionally "
+                + "filter out system apps with show_system=false.",
+                parameters
+        );
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        PackageManager pm = context.getPackageManager();
+        boolean showSystem = true;
+
+        if (arguments != null && arguments.has("show_system")
+                && !arguments.get("show_system").isJsonNull()) {
+            showSystem = arguments.get("show_system").getAsBoolean();
+        }
+
+        List<ApplicationInfo> installedApps = pm.getInstalledApplications(0);
+
+        JsonArray array = new JsonArray();
+        int userApps = 0;
+        int systemApps = 0;
+
+        for (ApplicationInfo app : installedApps) {
+            // Skip if it's a system app and we're not showing system apps
+            if (!showSystem && (app.flags & ApplicationInfo.FLAG_SYSTEM) != 0) {
+                systemApps++;
+                continue;
+            }
+
+            JsonObject obj = new JsonObject();
+            try {
+                CharSequence name = app.loadLabel(pm);
+                obj.addProperty("name", name != null ? name.toString() : app.packageName);
+            } catch (Exception e) {
+                // Fall back to package name if label loading fails
+                obj.addProperty("name", app.packageName);
+            }
+            obj.addProperty("package_name", app.packageName);
+            obj.addProperty("is_system_app", (app.flags & ApplicationInfo.FLAG_SYSTEM) != 0);
+
+            array.add(obj);
+
+            if ((app.flags & ApplicationInfo.FLAG_SYSTEM) != 0) {
+                systemApps++;
+            } else {
+                userApps++;
+            }
+        }
+
+        JsonObject result = new JsonObject();
+        result.addProperty("total", array.size());
+        result.addProperty("user_apps", userApps);
+        result.addProperty("system_apps", systemApps);
+        result.addProperty("show_system", showSystem);
+        result.add("apps", array);
+
+        return ToolResult.success(result);
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/OpenAppTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/OpenAppTool.java
@@ -1,0 +1,106 @@
+package io.finett.droidclaw.tool.impl;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Tool that opens an installed Android app by its package name.
+ *
+ * <p>Uses {@link PackageManager#getLaunchIntentForPackage(String)} to construct
+ * and launch the app's launcher intent. Returns an error if the app is not
+ * installed or has no launcher activity.
+ */
+public class OpenAppTool implements Tool {
+
+    private static final String TOOL_NAME = "open_app";
+
+    private final Context context;
+
+    public OpenAppTool(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return true;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addString("package_name",
+                        "The package name of the app to open (e.g., 'com.android.chrome'). "
+                        + "Use list_apps to find available apps.",
+                        true)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "Open an installed Android app by its package name. "
+                + "Launches the app's main/launcher activity. Use list_apps to find "
+                + "the package name of installed apps. Requires user approval before execution.",
+                parameters
+        );
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        String packageName = arguments != null && arguments.has("package_name")
+                ? arguments.get("package_name").getAsString()
+                : "";
+        return "Open app: " + packageName;
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        if (!arguments.has("package_name")
+                || arguments.get("package_name").isJsonNull()) {
+            return ToolResult.error("Missing required parameter: package_name");
+        }
+
+        String packageName = arguments.get("package_name").getAsString().trim();
+        if (packageName.isEmpty()) {
+            return ToolResult.error("package_name must not be empty");
+        }
+
+        PackageManager pm = context.getPackageManager();
+        Intent launchIntent = pm.getLaunchIntentForPackage(packageName);
+
+        if (launchIntent == null) {
+            return ToolResult.error(
+                    "Cannot open app: package '" + packageName + "' is not installed "
+                    + "or has no launcher activity. Use list_apps to find available apps."
+            );
+        }
+
+        // Add FLAG_ACTIVITY_NEW_TASK because startActivity() requires it when not
+        // called from an Activity context (e.g., from a background service).
+        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        try {
+            context.startActivity(launchIntent);
+        } catch (Exception e) {
+            return ToolResult.error(
+                    "Failed to open app: " + (e.getMessage() != null
+                            ? e.getMessage()
+                            : e.getClass().getSimpleName())
+            );
+        }
+
+        return ToolResult.success(
+                "App '" + packageName + "' opened successfully"
+        );
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/tool/ToolRegistryTest.java
+++ b/app/src/test/java/io/finett/droidclaw/tool/ToolRegistryTest.java
@@ -46,15 +46,15 @@ public class ToolRegistryTest {
         // Without SettingsManager: sandboxMode="strict", shellEnabled=true but strict blocks
         // shell/python and also mutating file tools (write/edit/delete).
         // Read-only file tools (4) + automation/notification tools (10)
-        // + background process tools (2) = 16.
-        assertEquals("Should have exactly 16 tools in strict mode without settings", 16, toolCount);
+        // + background process tools (2) + app tools (2) = 18.
+        assertEquals("Should have exactly 18 tools in strict mode without settings", 18, toolCount);
     }
 
     @Test
     public void testGetAllTools() {
         List<Tool> tools = toolRegistry.getAllTools();
         assertNotNull("Tools list should not be null", tools);
-        assertEquals("Should return all registered tools", 16, tools.size());
+        assertEquals("Should return all registered tools", 18, tools.size());
     }
 
     @Test
@@ -136,6 +136,10 @@ public class ToolRegistryTest {
 
     @Test
     public void testHasToolWithName_NonExisting() {
+        // New app tools should always be available
+        assertTrue("Should find list_apps tool", toolRegistry.hasToolWithName("list_apps"));
+        assertTrue("Should find open_app tool", toolRegistry.hasToolWithName("open_app"));
+
         assertFalse("Should not find non-existent tool", toolRegistry.hasToolWithName("non_existent"));
     }
 
@@ -143,7 +147,7 @@ public class ToolRegistryTest {
     public void testGetToolDefinitions() {
         JsonArray definitions = toolRegistry.getToolDefinitions();
         assertNotNull("Tool definitions should not be null", definitions);
-        assertEquals("Should have definitions for all tools in strict mode", 16, definitions.size());
+        assertEquals("Should have definitions for all tools in strict mode", 18, definitions.size());
         
         JsonObject firstDef = definitions.get(0).getAsJsonObject();
         assertTrue("Should have 'type' field", firstDef.has("type"));
@@ -265,6 +269,6 @@ public class ToolRegistryTest {
         t1.join();
         t2.join();
 
-        assertEquals("Tool count should remain consistent", 16, toolRegistry.getToolCount());
+        assertEquals("Tool count should remain consistent", 18, toolRegistry.getToolCount());
     }
 }


### PR DESCRIPTION
Add two new Android app management tools:

- list_apps: Enumerate installed apps via PackageManager. Returns name,
  package name, and is_system_app flag. Optional show_system=false filter
  to exclude system apps. No approval required.

- open_app: Launch an installed app by package name via
  PackageManager.getLaunchIntentForPackage(). Requires user approval.
  Adds FLAG_ACTIVITY_NEW_TASK for background service compatibility.