### PR TITLE
test+docs: regression coverage for cron/service/workspace + agent tools docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Go through the onboarding screen, and you are ready to go! If you want to set up
 
 - **Bundled Python 3.11:** The agent can execute any scripts to help you.
 - **Sandboxed environment:** The agent works in its own filesystem and can't touch your data.
+- **Shell, on-device or remote:** The agent runs shell commands locally in its sandbox, or on a remote host over the SSH backend.
+- **Device control:** The agent can list and open apps and operate the screen — tap, swipe, type, and read the UI tree. See [agent tools](docs/features/agent-tools.md).
 - **Onboarding:** Users can configure the app for its first run with just a couple of questions.
 
 # Docs

--- a/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
@@ -591,8 +591,9 @@ public class AgentExecutionService extends Service {
 
     /**
      * Remove common markdown markers so the notification text is readable.
+     * Package-private for unit testing.
      */
-    private static String stripMarkdown(String text) {
+    static String stripMarkdown(String text) {
         if (text == null) return "";
         return text
                 .replaceAll("(?m)^#{1,6}\\s+", "")     // headings

--- a/app/src/test/java/io/finett/droidclaw/filesystem/WorkspaceManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/filesystem/WorkspaceManagerTest.java
@@ -222,4 +222,87 @@ public class WorkspaceManagerTest {
 
         assertTrue(workspaceManager.getWorkspaceRoot().exists());
     }
+
+    // ==================== temp cleanup: nested trees ====================
+
+    @Test
+    public void testClearTempDirectory_withNestedSubdirectories() throws Exception {
+        workspaceManager.initialize();
+
+        File tempDir = workspaceManager.getTempDirectory();
+        File nested = new File(tempDir, "level1/level2");
+        assertTrue(nested.mkdirs());
+        new File(tempDir, "top.txt").createNewFile();
+        new File(nested, "deep.txt").createNewFile();
+
+        assertTrue(workspaceManager.clearTempDirectory());
+
+        assertTrue(tempDir.exists());
+        assertEquals(0, tempDir.listFiles().length);
+    }
+
+    @Test
+    public void testClearTempDirectory_mixedFilesAndDirs() throws Exception {
+        workspaceManager.initialize();
+
+        File tempDir = workspaceManager.getTempDirectory();
+        new File(tempDir, "a.txt").createNewFile();
+        File subDir = new File(tempDir, "subdir");
+        assertTrue(subDir.mkdir());
+        new File(subDir, "b.txt").createNewFile();
+
+        assertTrue(workspaceManager.clearTempDirectory());
+        assertTrue(tempDir.exists());
+        assertFalse(new File(tempDir, "a.txt").exists());
+        assertFalse(subDir.exists());
+    }
+
+    // ==================== stats: formatting boundaries ====================
+
+    @Test
+    public void testWorkspaceStats_kilobyteRange() throws Exception {
+        workspaceManager.initialize();
+
+        File testFile = new File(workspaceManager.getHomeDirectory(), "kb.bin");
+        java.io.FileWriter writer = new java.io.FileWriter(testFile);
+        char[] chunk = new char[1024];
+        java.util.Arrays.fill(chunk, 'x');
+        writer.write(chunk, 0, 1024);
+        writer.write(chunk, 0, 1024); // 2 KB total
+        writer.close();
+
+        WorkspaceManager.WorkspaceStats stats = workspaceManager.getStats();
+        assertTrue(stats.getTotalSize() >= 2048);
+        assertTrue("expected KB formatting, got: " + stats.getFormattedSize(),
+                stats.getFormattedSize().endsWith("KB"));
+    }
+
+    @Test
+    public void testWorkspaceStats_emptyWorkspace_bytesFormatting() throws Exception {
+        workspaceManager.initialize();
+
+        WorkspaceManager.WorkspaceStats stats = workspaceManager.getStats();
+        assertEquals(0, stats.getTotalSize());
+        assertEquals("0 B", stats.getFormattedSize());
+    }
+
+    // ==================== static path getters ====================
+
+    @Test
+    public void testStaticPathGetters() {
+        assertEquals(".agent/soul.md", WorkspaceManager.getSoulFilePath());
+        assertEquals(".agent/user.md", WorkspaceManager.getUserFilePath());
+        assertEquals(".agent/HEARTBEAT.md", WorkspaceManager.getHeartbeatFilePath());
+    }
+
+    @Test
+    public void testGetHeartbeatFile_underAgentDir() throws Exception {
+        workspaceManager.initialize();
+
+        File heartbeat = workspaceManager.getHeartbeatFile();
+        assertNotNull(heartbeat);
+        assertTrue(heartbeat.getPath().endsWith(".agent/HEARTBEAT.md"));
+        assertTrue(heartbeat.getCanonicalPath().startsWith(
+                workspaceManager.getWorkspaceRoot().getCanonicalPath()));
+    }
 }

--- a/app/src/test/java/io/finett/droidclaw/model/CronJobTest.java
+++ b/app/src/test/java/io/finett/droidclaw/model/CronJobTest.java
@@ -1,0 +1,222 @@
+package io.finett.droidclaw.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for CronJob schedule/retry/statistics logic.
+ *
+ * Covers the regression areas fixed in the cron-reliability work:
+ * next-run gating via shouldRun, retry bookkeeping via
+ * recordSuccess/recordFailure/canRetry, and the derived statistics
+ * used by the cron UI.
+ */
+public class CronJobTest {
+
+    private static final long HOUR = TimeUnit.HOURS.toMillis(1);
+
+    // ==================== shouldRun: gating ====================
+
+    @Test
+    public void shouldRun_disabledJob_returnsFalse() {
+        CronJob job = new CronJob("id", "name", "prompt", String.valueOf(HOUR));
+        job.setEnabled(false);
+        job.setLastRunTimestamp(0);
+
+        assertFalse(job.shouldRun(HOUR * 10));
+    }
+
+    @Test
+    public void shouldRun_pausedJob_returnsFalse() {
+        CronJob job = new CronJob("id", "name", "prompt", String.valueOf(HOUR));
+        job.setEnabled(true);
+        job.setPaused(true);
+        job.setLastRunTimestamp(0);
+
+        assertFalse(job.shouldRun(HOUR * 10));
+    }
+
+    // ==================== shouldRun: numeric interval ====================
+
+    @Test
+    public void shouldRun_intervalElapsed_returnsTrue() {
+        CronJob job = new CronJob("id", "name", "prompt", String.valueOf(HOUR));
+        long now = 5_000_000L;
+        job.setLastRunTimestamp(now - HOUR);
+
+        assertTrue(job.shouldRun(now));
+    }
+
+    @Test
+    public void shouldRun_intervalNotElapsed_returnsFalse() {
+        CronJob job = new CronJob("id", "name", "prompt", String.valueOf(HOUR));
+        long now = 5_000_000L;
+        job.setLastRunTimestamp(now - (HOUR / 2));
+
+        assertFalse(job.shouldRun(now));
+    }
+
+    @Test
+    public void shouldRun_exactlyAtInterval_returnsTrue() {
+        CronJob job = new CronJob("id", "name", "prompt", String.valueOf(HOUR));
+        long now = 5_000_000L;
+        job.setLastRunTimestamp(now - HOUR);
+
+        // Boundary: elapsed == interval must run (>=, not >).
+        assertTrue(job.shouldRun(now));
+    }
+
+    @Test
+    public void shouldRun_neverRun_returnsTrue() {
+        CronJob job = new CronJob("id", "name", "prompt", String.valueOf(HOUR));
+        // lastRunTimestamp defaults to 0, so any sensible "now" is past due.
+        assertTrue(job.shouldRun(System.currentTimeMillis()));
+    }
+
+    // ==================== shouldRun: non-numeric schedule fallback ====================
+
+    @Test
+    public void shouldRun_nonNumericSchedule_fallsBackToOneHour() {
+        CronJob job = new CronJob("id", "name", "prompt", "0 */2 * * *");
+        long now = 10_000_000L;
+
+        // 59 minutes since last run -> not yet due under the 1h fallback.
+        job.setLastRunTimestamp(now - TimeUnit.MINUTES.toMillis(59));
+        assertFalse(job.shouldRun(now));
+
+        // 61 minutes since last run -> due under the 1h fallback.
+        job.setLastRunTimestamp(now - TimeUnit.MINUTES.toMillis(61));
+        assertTrue(job.shouldRun(now));
+    }
+
+    // ==================== retry bookkeeping ====================
+
+    @Test
+    public void recordFailure_incrementsRetryAndStoresError() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+
+        job.recordFailure("boom");
+
+        assertEquals(1, job.getRetryCount());
+        assertEquals(1, job.getFailureCount());
+        assertEquals("boom", job.getLastError());
+    }
+
+    @Test
+    public void recordSuccess_resetsRetryAndClearsError() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        job.recordFailure("boom");
+        job.recordFailure("boom again");
+        assertEquals(2, job.getRetryCount());
+
+        job.recordSuccess(1234L);
+
+        assertEquals(0, job.getRetryCount());
+        assertEquals("", job.getLastError());
+        assertEquals(1, job.getSuccessCount());
+        assertEquals(1234L, job.getTotalExecutionTime());
+        assertTrue(job.getLastSuccessTimestamp() > 0);
+    }
+
+    @Test
+    public void canRetry_belowMax_returnsTrue() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        job.setMaxRetries(3);
+        job.setRetryCount(2);
+
+        assertTrue(job.canRetry());
+    }
+
+    @Test
+    public void canRetry_atMax_returnsFalse() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        job.setMaxRetries(3);
+        job.setRetryCount(3);
+
+        assertFalse(job.canRetry());
+    }
+
+    @Test
+    public void incrementAndResetRetry() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        job.incrementRetry();
+        job.incrementRetry();
+        assertEquals(2, job.getRetryCount());
+
+        job.resetRetry();
+        assertEquals(0, job.getRetryCount());
+    }
+
+    // ==================== statistics ====================
+
+    @Test
+    public void getSuccessRate_neverRun_returns100() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        assertEquals(100, job.getSuccessRate());
+    }
+
+    @Test
+    public void getSuccessRate_mixedRuns_computesPercentage() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        job.setSuccessCount(3);
+        job.setFailureCount(1);
+
+        // 3 / 4 = 75%
+        assertEquals(75, job.getSuccessRate());
+    }
+
+    @Test
+    public void getSuccessRate_allFailures_returnsZero() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        job.setSuccessCount(0);
+        job.setFailureCount(5);
+
+        assertEquals(0, job.getSuccessRate());
+    }
+
+    @Test
+    public void getAverageExecutionTime_noRuns_returnsZero() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        assertEquals(0, job.getAverageExecutionTime());
+    }
+
+    @Test
+    public void getAverageExecutionTime_mixedRuns_computesAverage() {
+        CronJob job = new CronJob("id", "name", "prompt", "hourly");
+        job.setSuccessCount(3);
+        job.setFailureCount(1);
+        job.setTotalExecutionTime(4000L);
+
+        // 4000 / 4 runs = 1000
+        assertEquals(1000L, job.getAverageExecutionTime());
+    }
+
+    // ==================== constructor defaults ====================
+
+    @Test
+    public void parameterizedConstructor_defaults() {
+        CronJob job = new CronJob("id-1", "My Job", "do things", "daily");
+
+        assertEquals("id-1", job.getId());
+        assertEquals("My Job", job.getName());
+        assertEquals("do things", job.getPrompt());
+        assertEquals("daily", job.getSchedule());
+        assertTrue(job.isEnabled());
+        assertFalse(job.isPaused());
+        assertEquals(0, job.getRetryCount());
+        assertEquals(3, job.getMaxRetries());
+        assertTrue(job.getCreatedAt() > 0);
+    }
+
+    @Test
+    public void defaultConstructor_isDisabled() {
+        CronJob job = new CronJob();
+        assertFalse(job.isEnabled());
+        assertFalse(job.isPaused());
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/scheduler/CronJobSchedulerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/scheduler/CronJobSchedulerTest.java
@@ -277,4 +277,126 @@ public class CronJobSchedulerTest {
     public void computeRetryBackoffMinutes_capped() {
         assertEquals(TimeUnit.DAYS.toMinutes(1), CronJobScheduler.computeRetryBackoffMinutes(100));
     }
+
+    // --- computeRetryBackoffMinutes: edge cases ---
+
+    @Test
+    public void computeRetryBackoffMinutes_negative_clampsToOne() {
+        assertEquals(1L, CronJobScheduler.computeRetryBackoffMinutes(-5));
+    }
+
+    @Test
+    public void computeRetryBackoffMinutes_ten() {
+        assertEquals(1024L, CronJobScheduler.computeRetryBackoffMinutes(10));
+    }
+
+    @Test
+    public void computeRetryBackoffMinutes_eleven_cappedAtOneDay() {
+        // 2^11 = 2048 minutes exceeds the 1-day cap (1440 minutes).
+        assertEquals(TimeUnit.DAYS.toMinutes(1), CronJobScheduler.computeRetryBackoffMinutes(11));
+    }
+
+    // --- parseScheduleToInterval: malformed and edge inputs ---
+
+    @Test
+    public void parseScheduleToInterval_whitespaceOnly() {
+        assertEquals(TimeUnit.HOURS.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("   "));
+    }
+
+    @Test
+    public void parseScheduleToInterval_surroundingWhitespace_trimmed() {
+        assertEquals(TimeUnit.DAYS.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("  daily  "));
+    }
+
+    @Test
+    public void parseScheduleToInterval_every_invalid_number() {
+        assertEquals(TimeUnit.HOURS.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("every_abc_minutes"));
+    }
+
+    @Test
+    public void parseScheduleToInterval_every_unknown_unit() {
+        assertEquals(TimeUnit.HOURS.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("every_5_furlongs"));
+    }
+
+    @Test
+    public void parseScheduleToInterval_every_missing_value() {
+        assertEquals(TimeUnit.HOURS.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("every_5"));
+    }
+
+    @Test
+    public void parseScheduleToInterval_every_singular_minute() {
+        assertEquals(TimeUnit.MINUTES.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("every_1_minute"));
+    }
+
+    @Test
+    public void parseScheduleToInterval_every_singular_hour() {
+        assertEquals(TimeUnit.HOURS.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("every_1_hour"));
+    }
+
+    @Test
+    public void parseScheduleToInterval_caseInsensitive() {
+        assertEquals(TimeUnit.DAYS.toMillis(1),
+                CronJobScheduler.parseScheduleToInterval("DAILY"));
+    }
+
+    // --- formatScheduleForDisplay: more variants ---
+
+    @Test
+    public void formatScheduleForDisplay_null() {
+        assertEquals("Unknown", CronJobScheduler.formatScheduleForDisplay(null));
+    }
+
+    @Test
+    public void formatScheduleForDisplay_blank() {
+        assertEquals("Unknown", CronJobScheduler.formatScheduleForDisplay("   "));
+    }
+
+    @Test
+    public void formatScheduleForDisplay_daily() {
+        assertEquals("Daily", CronJobScheduler.formatScheduleForDisplay("daily"));
+    }
+
+    @Test
+    public void formatScheduleForDisplay_weekly() {
+        assertEquals("Weekly", CronJobScheduler.formatScheduleForDisplay("weekly"));
+    }
+
+    @Test
+    public void formatScheduleForDisplay_dailyAt() {
+        assertEquals("Daily at 8:00 AM",
+                CronJobScheduler.formatScheduleForDisplay("daily@08:00"));
+    }
+
+    @Test
+    public void formatScheduleForDisplay_weeklyAt_full() {
+        assertEquals("Monday at 8:00 AM",
+                CronJobScheduler.formatScheduleForDisplay("weekly@monday@08:00"));
+    }
+
+    @Test
+    public void formatScheduleForDisplay_weeklyAt_malformed() {
+        assertEquals("Weekly",
+                CronJobScheduler.formatScheduleForDisplay("weekly@onlyonepart"));
+    }
+
+    // --- formatTime: malformed input ---
+
+    @Test
+    public void formatTime_invalid_returnsInput() {
+        assertEquals("garbage", CronJobScheduler.formatTime("garbage"));
+    }
+
+    // --- getWorkName ---
+
+    @Test
+    public void getWorkName_hasCronPrefix() {
+        assertEquals("cron_job_abc123", CronJobScheduler.getWorkName("abc123"));
+    }
 }

--- a/app/src/test/java/io/finett/droidclaw/service/AgentExecutionServiceTest.java
+++ b/app/src/test/java/io/finett/droidclaw/service/AgentExecutionServiceTest.java
@@ -1,0 +1,244 @@
+package io.finett.droidclaw.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonObject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.finett.droidclaw.agent.AgentLoop;
+import io.finett.droidclaw.model.ChatMessage;
+
+/**
+ * Unit tests for AgentExecutionService session/notification paths.
+ *
+ * Covers the regression areas from the background-lifecycle fixes:
+ * buffered completion/error delivery when the UI reattaches after the
+ * loop finished in the background, session activity tracking, and the
+ * markdown stripping used for completion-notification previews.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AgentExecutionServiceTest {
+
+    private AgentExecutionService service;
+
+    @Before
+    public void setUp() {
+        service = Robolectric.buildService(AgentExecutionService.class).create().get();
+    }
+
+    /** UICallback that records what it was invoked with. */
+    private static class RecordingCallback implements AgentExecutionService.UICallback {
+        int completeCalls = 0;
+        int errorCalls = 0;
+        String completeResponse;
+        List<ChatMessage> completeHistory;
+        String error;
+
+        @Override public void onProgress(String status) {}
+        @Override public void onToolCall(String toolName, String arguments) {}
+        @Override public void onToolResult(String toolName, String result) {}
+
+        @Override
+        public void onComplete(String response, List<ChatMessage> history) {
+            completeCalls++;
+            completeResponse = response;
+            completeHistory = history;
+        }
+
+        @Override
+        public void onError(String err) {
+            errorCalls++;
+            error = err;
+        }
+
+        @Override
+        public void onApprovalRequired(String toolName, String description,
+                                       JsonObject arguments,
+                                       AgentLoop.ApprovalCallback approvalCallback) {}
+    }
+
+    /** Reflective access to the private sessions map (test-only seam). */
+    @SuppressWarnings("unchecked")
+    private static ConcurrentHashMap<String, AgentExecutionService.AgentSession> sessionsOf(
+            AgentExecutionService svc) throws Exception {
+        Field f = AgentExecutionService.class.getDeclaredField("sessions");
+        f.setAccessible(true);
+        return (ConcurrentHashMap<String, AgentExecutionService.AgentSession>) f.get(svc);
+    }
+
+    private static AgentExecutionService.AgentSession seedSession(
+            AgentExecutionService svc, String sessionId,
+            AgentExecutionService.AgentSession.State state) throws Exception {
+        AgentExecutionService.AgentSession session =
+                new AgentExecutionService.AgentSession(sessionId);
+        session.state = state;
+        sessionsOf(svc).put(sessionId, session);
+        return session;
+    }
+
+    // ==================== buffered completion delivery ====================
+
+    @Test
+    public void registerUICallback_completedSession_deliversBufferedResult() throws Exception {
+        AgentExecutionService.AgentSession session = seedSession(
+                service, "s1", AgentExecutionService.AgentSession.State.COMPLETED);
+        session.finalResponse = "All done.";
+        session.finalHistory = new ArrayList<>();
+
+        RecordingCallback cb = new RecordingCallback();
+        service.registerUICallback("s1", cb);
+
+        assertEquals(1, cb.completeCalls);
+        assertEquals("All done.", cb.completeResponse);
+        assertNotNull(cb.completeHistory);
+        assertEquals(0, cb.errorCalls);
+        // Session must be cleaned up after delivery.
+        assertNull(service.getSession("s1"));
+    }
+
+    @Test
+    public void registerUICallback_errorSession_deliversBufferedError() throws Exception {
+        AgentExecutionService.AgentSession session = seedSession(
+                service, "s2", AgentExecutionService.AgentSession.State.ERROR);
+        session.errorMessage = "API unreachable";
+
+        RecordingCallback cb = new RecordingCallback();
+        service.registerUICallback("s2", cb);
+
+        assertEquals(1, cb.errorCalls);
+        assertEquals("API unreachable", cb.error);
+        assertEquals(0, cb.completeCalls);
+        assertNull(service.getSession("s2"));
+    }
+
+    @Test
+    public void registerUICallback_errorSession_nullMessage_deliversUnknownError() throws Exception {
+        seedSession(service, "s3", AgentExecutionService.AgentSession.State.ERROR);
+        // errorMessage left null.
+
+        RecordingCallback cb = new RecordingCallback();
+        service.registerUICallback("s3", cb);
+
+        assertEquals(1, cb.errorCalls);
+        assertEquals("Unknown error", cb.error);
+    }
+
+    @Test
+    public void registerUICallback_unknownSession_registersWithoutDelivery() {
+        RecordingCallback cb = new RecordingCallback();
+        service.registerUICallback("missing", cb);
+
+        assertEquals(0, cb.completeCalls);
+        assertEquals(0, cb.errorCalls);
+    }
+
+    @Test
+    public void registerUICallback_runningSession_doesNotDeliver() throws Exception {
+        seedSession(service, "s4", AgentExecutionService.AgentSession.State.RUNNING);
+
+        RecordingCallback cb = new RecordingCallback();
+        service.registerUICallback("s4", cb);
+
+        assertEquals(0, cb.completeCalls);
+        assertEquals(0, cb.errorCalls);
+        // Running session stays registered.
+        assertNotNull(service.getSession("s4"));
+    }
+
+    // ==================== isSessionActive ====================
+
+    @Test
+    public void isSessionActive_running_returnsTrue() throws Exception {
+        seedSession(service, "a", AgentExecutionService.AgentSession.State.RUNNING);
+        assertTrue(service.isSessionActive("a"));
+    }
+
+    @Test
+    public void isSessionActive_pausedApproval_returnsTrue() throws Exception {
+        seedSession(service, "a", AgentExecutionService.AgentSession.State.PAUSED_APPROVAL);
+        assertTrue(service.isSessionActive("a"));
+    }
+
+    @Test
+    public void isSessionActive_completed_returnsFalse() throws Exception {
+        seedSession(service, "a", AgentExecutionService.AgentSession.State.COMPLETED);
+        assertFalse(service.isSessionActive("a"));
+    }
+
+    @Test
+    public void isSessionActive_error_returnsFalse() throws Exception {
+        seedSession(service, "a", AgentExecutionService.AgentSession.State.ERROR);
+        assertFalse(service.isSessionActive("a"));
+    }
+
+    @Test
+    public void isSessionActive_missing_returnsFalse() {
+        assertFalse(service.isSessionActive("never-seen"));
+    }
+
+    // ==================== stripMarkdown (notification preview) ====================
+
+    @Test
+    public void stripMarkdown_null_returnsEmpty() {
+        assertEquals("", AgentExecutionService.stripMarkdown(null));
+    }
+
+    @Test
+    public void stripMarkdown_plainText_unchanged() {
+        assertEquals("Task finished successfully.",
+                AgentExecutionService.stripMarkdown("Task finished successfully."));
+    }
+
+    @Test
+    public void stripMarkdown_bold_removed() {
+        assertEquals("done", AgentExecutionService.stripMarkdown("**done**"));
+    }
+
+    @Test
+    public void stripMarkdown_headingMarker_removed() {
+        assertEquals("Title", AgentExecutionService.stripMarkdown("# Title"));
+    }
+
+    @Test
+    public void stripMarkdown_link_keepsText() {
+        assertEquals("see docs for more",
+                AgentExecutionService.stripMarkdown("see [docs](https://example.com) for more"));
+    }
+
+    @Test
+    public void stripMarkdown_inlineCode_removed() {
+        String out = AgentExecutionService.stripMarkdown("ran `ls -la` ok");
+        assertFalse(out.contains("`"));
+        assertTrue(out.contains("ran"));
+        assertTrue(out.contains("ok"));
+    }
+
+    @Test
+    public void stripMarkdown_listMarkers_removed() {
+        assertEquals("item one", AgentExecutionService.stripMarkdown("- item one"));
+    }
+
+    @Test
+    public void stripMarkdown_blockquote_removed() {
+        assertEquals("quoted text", AgentExecutionService.stripMarkdown("> quoted text"));
+    }
+
+    @Test
+    public void stripMarkdown_excessiveNewlines_collapsed() {
+        assertEquals("a\n\nb", AgentExecutionService.stripMarkdown("a\n\n\n\nb"));
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ Searching references?
 
 - [User Profile (USER.md)](reference/user.md) — what the agent knows about you
 - [Agent Identity (SOUL.md)](reference/soul.md) — the agent's values, capabilities, and working style
+- [Agent Tools: App & Screen Control](features/agent-tools.md) — how the agent operates your phone and runs shell commands

--- a/docs/features/agent-tools.md
+++ b/docs/features/agent-tools.md
@@ -1,0 +1,53 @@
+# Agent Tools: App & Screen Control
+
+DroidClaw's agent can operate your phone, not just answer questions. This page
+documents the app-control and screen-control tool families and the shell tool
+they are often combined with.
+
+> **Requirement:** the screen tools drive the UI through the Android
+> Accessibility service. Grant the accessibility permission during onboarding
+> (or in Settings) before using them.
+
+## App tools
+
+| Tool | What it does |
+|------|--------------|
+| `list_apps` | Lists installed apps (name, package name, system/user). Pass `show_system=false` to see only user-installed apps. |
+| `open_app` | Launches an app by package name. |
+
+## Screen tools
+
+| Tool | What it does |
+|------|--------------|
+| `screen_get_ui_tree` | Reads the current screen's accessibility tree. Returns each element's text, resource id, bounds, and `centerX`/`centerY` — the starting point for any interaction. |
+| `screen_tap` | Taps an element. Target by `x`+`y` coordinates (use `centerX`/`centerY` from the UI tree), by `resource_id`, or by visible `text`. |
+| `screen_swipe` | Swipes between two points (scrolling, paging, pull-to-refresh). |
+| `screen_type_text` | Types text into the focused input field. |
+| `screen_perform_action` | System navigation: `back`, `home`, `recents`, `notifications`, `quick_settings`, `lock_screen`. |
+
+### Typical flow
+
+1. `screen_get_ui_tree` — see what is on screen.
+2. `screen_tap` / `screen_type_text` — interact using the tree's coordinates or ids.
+3. Repeat until the task is done; use `screen_perform_action` to navigate.
+
+Sensitive or externally visible actions are gated by the same approval flow as
+every other tool — see [Settings](../user/settings.md) for tool approval modes.
+
+## Shell tool
+
+The `execute_shell` tool runs shell commands with two selectable backends:
+
+- **Local** — commands run on the phone itself, inside the app's sandbox.
+- **SSH** — commands run on a remote host you configure (host, user, auth).
+  Useful when the heavy lifting belongs on a server, while the agent still
+  lives on your phone.
+
+Configure the backend in [Settings](../user/settings.md). Commands go through
+the exec planner and allowlist policy before they run, so destructive
+operations require approval.
+
+## Related docs
+
+- [Settings](../user/settings.md)
+- [First steps](../user/first-steps.md)


### PR DESCRIPTION
## Overview

Adds regression test coverage for cron scheduling, the agent execution service, and workspace cleanup — plus documentation for the app/screen agent tools and the SSH shell backend.

## Changes

**Tests**
- New `model/CronJobTest` (19 tests): `shouldRun` next-run gating (disabled/paused, interval boundary, non-numeric schedule fallback), retry bookkeeping (`recordSuccess` / `recordFailure` / `canRetry`), success-rate and average-execution stats
- Extended `scheduler/CronJobSchedulerTest` (+18): retry backoff boundaries (negative input, attempt 10/11 cap), malformed `every_*` inputs, display formats, `getWorkName`
- New `service/AgentExecutionServiceTest` (19 tests, Robolectric): buffered completion/error delivery when the UI reattaches, `isSessionActive` state tracking, `stripMarkdown` notification previews
- Extended `filesystem/WorkspaceManagerTest` (+7): nested temp-directory cleanup, stats KB/B formatting, path getters
- Made `stripMarkdown` package-private for testability (matches the existing `capitalizeFirst` / `getWorkName` convention)

**Docs**
- New `docs/features/agent-tools.md`: app tools (`list_apps`, `open_app`), screen tools (`screen_*`), typical UI-tree interaction flow, `execute_shell` local/SSH backends
- README highlights: added shell local/SSH and device-control bullets
- `docs/README.md`: linked the new page

## Validation

- `./gradlew testDebugUnitTest` — 1338 tests, 0 failures
- `./gradlew lintDebug` — clean
