### PR TITLE
feat(api): stream LLM responses over SSE with live UI rendering

### DIFF
--- a/app/src/androidTest/java/io/finett/droidclaw/fragment/ChatFragmentTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/fragment/ChatFragmentTest.java
@@ -197,8 +197,15 @@ public class ChatFragmentTest {
                 }
 
                 assertNotNull(statusContainer);
-                assertFalse("Send button should be disabled or re-enabled",
-                        sendButton.isEnabled() && statusContainer.getVisibility() == android.view.View.VISIBLE);
+                // The button stays enabled while loading — it morphs into a stop
+                // button so the user can cancel the response.
+                assertTrue("Send button should stay enabled (acts as stop while loading)",
+                        sendButton.isEnabled());
+                if (statusContainer.getVisibility() == android.view.View.VISIBLE) {
+                    assertEquals("While loading the button should be a stop button",
+                            fragment.getString(R.string.stop_response),
+                            String.valueOf(sendButton.getContentDescription()));
+                }
             });
         }
     }

--- a/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
+++ b/app/src/main/java/io/finett/droidclaw/adapter/ChatAdapter.java
@@ -147,6 +147,31 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MessageViewHol
         }
     }
 
+    /**
+     * Update the content of the message at a specific position — used for SSE
+     * streaming live-rendering of the temporary assistant bubble. No-op when the
+     * position is out of range (e.g. the list was replaced concurrently).
+     */
+    public void updateStreamingMessage(int position, String content) {
+        if (position < 0 || position >= messages.size()) {
+            return;
+        }
+        messages.get(position).setContent(content);
+        notifyItemChanged(position);
+    }
+
+    /**
+     * Remove the last message — used to discard a partial streaming bubble when
+     * the agent errors before producing a final response.
+     */
+    public void removeLastMessage() {
+        if (!messages.isEmpty()) {
+            int lastIndex = messages.size() - 1;
+            messages.remove(lastIndex);
+            notifyItemRemoved(lastIndex);
+        }
+    }
+
     public void clearMessages() {
         messages.clear();
         notifyDataSetChanged();

--- a/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
@@ -39,6 +39,7 @@ public class AgentLoop {
     private int iterationCount;
     private int maxIterations;
     private boolean requireApproval;
+    private boolean streamResponses;
     private List<ChatMessage> identityMessages;
     private JsonObject responseSchema;
 
@@ -93,6 +94,13 @@ public class AgentLoop {
          * @param approvalCallback Callback to indicate approval or denial
          */
         void onApprovalRequired(String toolName, String description, JsonObject arguments, ApprovalCallback approvalCallback);
+
+        /**
+         * Called with incremental text deltas while a streaming (SSE) response is
+         * arriving, before {@link #onComplete}. Optional — the default is a no-op
+         * for callbacks that only care about the final result.
+         */
+        default void onStreamDelta(String delta) {}
     }
 
     public interface ApprovalCallback {
@@ -116,10 +124,20 @@ public class AgentLoop {
         if (settingsManager != null) {
             this.maxIterations = settingsManager.getMaxAgentIterations();
             this.requireApproval = settingsManager.isRequireApproval();
+            io.finett.droidclaw.model.AgentConfig cfg = settingsManager.getAgentConfig();
+            this.streamResponses = cfg != null && cfg.isStreamResponses();
         } else {
             this.maxIterations = DEFAULT_MAX_ITERATIONS;
             this.requireApproval = true;
+            // No settings manager (unit tests / programmatic use): keep the
+            // legacy non-streaming path.
+            this.streamResponses = false;
         }
+    }
+
+    /** Whether streaming (SSE) responses are enabled for the standard chat path. */
+    public boolean isStreamingEnabled() {
+        return streamResponses;
     }
 
     public void setIdentityContext(List<ChatMessage> identityMessages) {
@@ -227,18 +245,7 @@ public class AgentLoop {
                 new LlmApiService.StructuredResponseCallback() {
             @Override
             public void onSuccess(LlmApiService.StructuredResponse response) {
-                if (response.getUsage() != null && response.getUsage().isAvailable()) {
-                    currentContextTokens = response.getUsage().getTotalTokens();
-                    currentPromptTokens = response.getUsage().getPromptTokens();
-                    currentCompletionTokens = response.getUsage().getCompletionTokens();
-
-                    totalTokens += response.getUsage().getTotalTokens();
-                    totalPromptTokens += response.getUsage().getPromptTokens();
-                    totalCompletionTokens += response.getUsage().getCompletionTokens();
-
-                    Log.d(TAG, "Token usage - Current context: " + currentContextTokens +
-                          ", Session total: " + totalTokens);
-                }
+                trackTokenUsage(response.getUsage());
 
                 if (response.isRefusal()) {
                     Log.w(TAG, "Model refused to respond: " + response.getRefusal());
@@ -261,22 +268,32 @@ public class AgentLoop {
      */
     private void sendStandardMessage(List<ChatMessage> conversationHistory, JsonArray tools,
                                      List<ChatMessage> contextMessages, AgentCallback callback) {
+        if (streamResponses) {
+            apiService.sendMessageWithToolsStreaming(conversationHistory, tools, contextMessages,
+                    new LlmApiService.StreamingChatCallback() {
+                @Override
+                public void onDelta(String textChunk) {
+                    callback.onStreamDelta(textChunk);
+                }
+
+                @Override
+                public void onSuccess(LlmApiService.LlmResponse response) {
+                    trackTokenUsage(response.getUsage());
+                    handleLlmResponse(response, conversationHistory, callback);
+                }
+
+                @Override
+                public void onError(String error) {
+                    callback.onError(error);
+                }
+            });
+            return;
+        }
+
         apiService.sendMessageWithTools(conversationHistory, tools, contextMessages, new LlmApiService.ChatCallbackWithTools() {
             @Override
             public void onSuccess(LlmApiService.LlmResponse response) {
-                if (response.getUsage() != null && response.getUsage().isAvailable()) {
-                    currentContextTokens = response.getUsage().getTotalTokens();
-                    currentPromptTokens = response.getUsage().getPromptTokens();
-                    currentCompletionTokens = response.getUsage().getCompletionTokens();
-
-                    totalTokens += response.getUsage().getTotalTokens();
-                    totalPromptTokens += response.getUsage().getPromptTokens();
-                    totalCompletionTokens += response.getUsage().getCompletionTokens();
-
-                    Log.d(TAG, "Token usage - Current context: " + currentContextTokens +
-                          ", Session total: " + totalTokens);
-                }
-
+                trackTokenUsage(response.getUsage());
                 handleLlmResponse(response, conversationHistory, callback);
             }
 
@@ -285,6 +302,25 @@ public class AgentLoop {
                 callback.onError(error);
             }
         });
+    }
+
+    /**
+     * Update the "Last Usage" token tracking fields from an API response usage
+     * block (no-op when the provider did not report usage).
+     */
+    private void trackTokenUsage(io.finett.droidclaw.api.TokenUsage usage) {
+        if (usage == null || !usage.isAvailable()) return;
+
+        currentContextTokens = usage.getTotalTokens();
+        currentPromptTokens = usage.getPromptTokens();
+        currentCompletionTokens = usage.getCompletionTokens();
+
+        totalTokens += usage.getTotalTokens();
+        totalPromptTokens += usage.getPromptTokens();
+        totalCompletionTokens += usage.getCompletionTokens();
+
+        Log.d(TAG, "Token usage - Current context: " + currentContextTokens +
+              ", Session total: " + totalTokens);
     }
 
     private void handleLlmResponse(LlmApiService.LlmResponse response, List<ChatMessage> conversationHistory, AgentCallback callback) {

--- a/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/AgentLoop.java
@@ -1,5 +1,7 @@
 package io.finett.droidclaw.agent;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import com.google.gson.JsonArray;
@@ -8,6 +10,7 @@ import com.google.gson.JsonObject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -42,6 +45,23 @@ public class AgentLoop {
     private boolean streamResponses;
     private List<ChatMessage> identityMessages;
     private JsonObject responseSchema;
+
+    // ==================== Cancellation state ====================
+
+    /** Set when the user requests cancellation; stops the loop at the next checkpoint. */
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    /** Guarantees {@link #finalizeCancellation()} dispatches exactly once. */
+    private final AtomicBoolean cancelFinalized = new AtomicBoolean(false);
+
+    /** Text streamed so far in the current response segment (guarded by itself). */
+    private final StringBuilder streamedText = new StringBuilder();
+
+    /** History of the in-flight run, used by cancellation to preserve partial output. */
+    private volatile List<ChatMessage> activeHistory;
+
+    /** Callback of the in-flight run; nulled once the run reaches a terminal state. */
+    private volatile AgentCallback activeCallback;
 
     /**
      * Look up the per-tool approval override for a given tool name.
@@ -101,6 +121,13 @@ public class AgentLoop {
          * for callbacks that only care about the final result.
          */
         default void onStreamDelta(String delta) {}
+
+        /**
+         * Called when the run was cancelled by the user. The history contains any
+         * partially streamed assistant text preserved as a normal assistant message.
+         * Optional — the default is a no-op.
+         */
+        default void onCancelled(List<ChatMessage> conversationHistory) {}
     }
 
     public interface ApprovalCallback {
@@ -152,21 +179,91 @@ public class AgentLoop {
 
     public void start(List<ChatMessage> conversationHistory, AgentCallback callback) {
         iterationCount = 0;
+        cancelled.set(false);
+        cancelFinalized.set(false);
+        synchronized (streamedText) {
+            streamedText.setLength(0);
+        }
 
         // Make a mutable copy of the conversation history
         List<ChatMessage> workingHistory = new ArrayList<>(conversationHistory);
+        this.activeHistory = workingHistory;
+        this.activeCallback = callback;
 
         callback.onProgress("Sending message to LLM...");
         executeIteration(workingHistory, callback);
+    }
+
+    /** Whether cancellation has been requested for the current run. */
+    public boolean isCancelled() {
+        return cancelled.get();
+    }
+
+    /**
+     * Cancel the running agent loop: aborts in-flight HTTP requests and stops the
+     * iteration cycle at the next checkpoint. Any text already streamed in the
+     * current response segment is preserved as a partial assistant message, and the
+     * callback receives {@link AgentCallback#onCancelled(List)}.
+     *
+     * <p>Safe to call from any thread. Finalization is posted to the main thread so
+     * that stream deltas already queued there are accumulated first.</p>
+     */
+    public void cancel() {
+        if (!cancelled.compareAndSet(false, true)) {
+            return;
+        }
+        Log.d(TAG, "Agent loop cancellation requested");
+        if (apiService != null) {
+            apiService.cancelAllRequests();
+        }
+        new Handler(Looper.getMainLooper()).post(this::finalizeCancellation);
+    }
+
+    /**
+     * Finalize a cancellation on the main thread: append any partially streamed
+     * assistant text to the conversation history and notify the callback exactly once.
+     */
+    private void finalizeCancellation() {
+        if (!cancelFinalized.compareAndSet(false, true)) {
+            return;
+        }
+        AgentCallback callback = activeCallback;
+        List<ChatMessage> history = activeHistory;
+        detachActiveRun();
+        if (callback == null || history == null) {
+            Log.d(TAG, "Cancellation finalized after run already ended");
+            return;
+        }
+
+        String partialText;
+        synchronized (streamedText) {
+            partialText = streamedText.toString().trim();
+            streamedText.setLength(0);
+        }
+        if (!partialText.isEmpty()) {
+            history.add(new ChatMessage(partialText, ChatMessage.TYPE_ASSISTANT));
+            Log.d(TAG, "Cancellation preserved partial response (" + partialText.length() + " chars)");
+        }
+        callback.onCancelled(history);
+    }
+
+    /** Clear the in-flight run references so late cancellation becomes a no-op. */
+    private void detachActiveRun() {
+        activeCallback = null;
+        activeHistory = null;
     }
 
     /**
      * Execute one iteration of the agent loop.
      */
     private void executeIteration(List<ChatMessage> conversationHistory, AgentCallback callback) {
+        if (cancelled.get()) {
+            return;
+        }
         iterationCount++;
 
         if (iterationCount > maxIterations) {
+            detachActiveRun();
             callback.onError("Maximum iterations (" + maxIterations + ") reached. The agent may be stuck in a loop.");
             return;
         }
@@ -213,6 +310,9 @@ public class AgentLoop {
      * Continue iteration with conversation (after optional summarization).
      */
     private void continueIteration(List<ChatMessage> conversationHistory, AgentCallback callback) {
+        if (cancelled.get()) {
+            return;
+        }
         List<ChatMessage> contextMessages = new ArrayList<>();
 
         if (identityMessages != null) {
@@ -258,6 +358,7 @@ public class AgentLoop {
 
             @Override
             public void onError(String error) {
+                detachActiveRun();
                 callback.onError(error);
             }
         });
@@ -273,6 +374,11 @@ public class AgentLoop {
                     new LlmApiService.StreamingChatCallback() {
                 @Override
                 public void onDelta(String textChunk) {
+                    if (textChunk != null && !cancelled.get()) {
+                        synchronized (streamedText) {
+                            streamedText.append(textChunk);
+                        }
+                    }
                     callback.onStreamDelta(textChunk);
                 }
 
@@ -284,6 +390,7 @@ public class AgentLoop {
 
                 @Override
                 public void onError(String error) {
+                    detachActiveRun();
                     callback.onError(error);
                 }
             });
@@ -299,6 +406,7 @@ public class AgentLoop {
 
             @Override
             public void onError(String error) {
+                detachActiveRun();
                 callback.onError(error);
             }
         });
@@ -324,6 +432,9 @@ public class AgentLoop {
     }
 
     private void handleLlmResponse(LlmApiService.LlmResponse response, List<ChatMessage> conversationHistory, AgentCallback callback) {
+        if (cancelled.get()) {
+            return;
+        }
         if (response.hasToolCalls()) {
             handleToolCalls(response, conversationHistory, callback);
         } else {
@@ -350,6 +461,9 @@ public class AgentLoop {
      */
     private void processToolCallsWithApproval(List<LlmApiService.ToolCall> toolCalls, int index,
                                                List<ChatMessage> conversationHistory, AgentCallback callback) {
+        if (cancelled.get()) {
+            return;
+        }
         if (index >= toolCalls.size()) {
             // All tool calls processed, continue the loop
             callback.onProgress("Sending tool results to LLM...");
@@ -418,12 +532,18 @@ public class AgentLoop {
             callback.onApprovalRequired(toolName, description, arguments, new ApprovalCallback() {
                 @Override
                 public void onApproved() {
+                    if (cancelled.get()) {
+                        return;
+                    }
                     // Execute the tool and continue
                     executeToolAndContinue(toolCall, toolCalls, index, conversationHistory, callback);
                 }
 
                 @Override
                 public void onDenied() {
+                    if (cancelled.get()) {
+                        return;
+                    }
                     // Add denial result to history and continue
                     String resultContent = "Tool execution denied by user";
                     Log.d(TAG, "Tool " + toolName + " denied by user");
@@ -498,6 +618,9 @@ public class AgentLoop {
 
     private void executeToolAndContinue(LlmApiService.ToolCall toolCall, List<LlmApiService.ToolCall> toolCalls,
                                         int index, List<ChatMessage> conversationHistory, AgentCallback callback) {
+        if (cancelled.get()) {
+            return;
+        }
         String toolName = toolCall.getName();
 
         ToolResult result = toolRegistry.executeTool(toolName, toolCall.getArguments());
@@ -524,6 +647,7 @@ public class AgentLoop {
     }
 
     private void handleFinalResponse(LlmApiService.LlmResponse response, List<ChatMessage> conversationHistory, AgentCallback callback) {
+        detachActiveRun();
         String content = response.getContent();
 
         if (content == null || content.isEmpty()) {
@@ -624,11 +748,15 @@ public class AgentLoop {
     private void handleStructuredLlmResponse(LlmApiService.StructuredResponse response,
                                               List<ChatMessage> conversationHistory,
                                               AgentCallback callback) {
+        if (cancelled.get()) {
+            return;
+        }
         if (response.hasToolCalls()) {
             LlmApiService.LlmResponse llmResponse = new LlmApiService.LlmResponse(
                     response.getContent(), response.getToolCalls(), response.getUsage());
             handleToolCalls(llmResponse, conversationHistory, callback);
         } else {
+            detachActiveRun();
             String content = response.getContent();
 
             if (content == null || content.isEmpty()) {
@@ -649,6 +777,7 @@ public class AgentLoop {
     private void handleRefusal(LlmApiService.StructuredResponse response,
                                List<ChatMessage> conversationHistory,
                                AgentCallback callback) {
+        detachActiveRun();
         String refusalMessage = response.getRefusal() != null ? response.getRefusal() : "Model refused to respond";
 
         Log.w(TAG, "Handling refusal: " + refusalMessage);

--- a/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
+++ b/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
@@ -325,6 +325,10 @@ public class LlmApiService {
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
+                if (call.isCanceled()) {
+                    Log.d(TAG, "Request canceled");
+                    return;
+                }
                 Log.e(TAG, "Network error", e);
                 mainHandler.post(() -> callback.onError("Network error: " + e.getMessage()));
             }
@@ -408,6 +412,10 @@ public class LlmApiService {
         client.newCall(requestBuilder.build()).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
+                if (call.isCanceled()) {
+                    Log.d(TAG, "Request canceled");
+                    return;
+                }
                 Log.e(TAG, "Network error", e);
                 mainHandler.post(() -> callback.onError("Network error: " + e.getMessage()));
             }

--- a/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
+++ b/app/src/main/java/io/finett/droidclaw/api/LlmApiService.java
@@ -29,6 +29,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okio.BufferedSource;
 
 /**
  * Unified LLM API service supporting both OpenAI Chat Completions and Anthropic Messages APIs.
@@ -173,6 +174,20 @@ public class LlmApiService {
 
     public interface StructuredResponseCallback {
         void onSuccess(StructuredResponse response);
+        void onError(String error);
+    }
+
+    /**
+     * Callback for streaming (SSE) responses: incremental text deltas for live
+     * rendering, plus the final assembled response with tool calls and usage.
+     */
+    public interface StreamingChatCallback {
+        /** Incremental text delta (called on the main thread). */
+        void onDelta(String textChunk);
+
+        /** Final assembled response, same shape as the non-streaming path. */
+        void onSuccess(LlmResponse response);
+
         void onError(String error);
     }
 
@@ -423,6 +438,131 @@ public class LlmApiService {
                     Log.e(TAG, "Parse error", e);
                     mainHandler.post(() -> callback.onError("Parse error: " + e.getMessage()));
                 }
+            }
+        });
+    }
+
+    /**
+     * Streaming variant of {@link #sendMessageWithTools(List, JsonArray, List, ChatCallbackWithTools)}.
+     *
+     * <p>Sends the request with {@code stream: true} and parses the Server-Sent-Events
+     * response incrementally: text deltas are delivered to
+     * {@link StreamingChatCallback#onDelta(String)} as they arrive, and the final
+     * assembled response (text + tool calls + token usage) is delivered to
+     * {@link StreamingChatCallback#onSuccess(LlmResponse)} with the same shape as the
+     * non-streaming path.</p>
+     *
+     * <p>For OpenAI-compatible endpoints, {@code stream_options.include_usage} is
+     * requested so token usage arrives in the final chunk; servers that ignore the
+     * field simply produce a response without usage.</p>
+     */
+    public void sendMessageWithToolsStreaming(List<ChatMessage> conversationHistory, JsonArray tools,
+                                              List<ChatMessage> identityMessages,
+                                              StreamingChatCallback callback) {
+        if (!settingsManager.isConfigured()) {
+            Log.w(TAG, "sendMessageWithToolsStreaming: isConfigured() returned false");
+            mainHandler.post(() -> callback.onError("API key not configured. Please set it in Settings."));
+            return;
+        }
+
+        String apiType = settingsManager.getApiType();
+        String apiUrl = settingsManager.getApiUrl();
+        Log.d(TAG, "sendMessageWithToolsStreaming: apiType=" + apiType + ", apiUrl=" + apiUrl
+                + ", model=" + settingsManager.getModelName());
+
+        if (apiUrl == null || apiUrl.isEmpty()) {
+            mainHandler.post(() -> callback.onError("No API URL configured for selected model. Please check Settings."));
+            return;
+        }
+
+        String jsonBody;
+        Request.Builder requestBuilder;
+
+        if (API_ANTHROPIC.equals(apiType)) {
+            JsonObject body = buildAnthropicRequestBody(conversationHistory, tools, identityMessages);
+            body.addProperty("stream", true);
+            jsonBody = gson.toJson(body);
+            requestBuilder = buildAnthropicRequestBuilder(jsonBody);
+        } else {
+            JsonObject body = buildOpenAiRequestBody(conversationHistory, tools, identityMessages);
+            body.addProperty("stream", true);
+            JsonObject streamOptions = new JsonObject();
+            streamOptions.addProperty("include_usage", true);
+            body.add("stream_options", streamOptions);
+            jsonBody = gson.toJson(body);
+            requestBuilder = buildOpenAiRequestBuilder(jsonBody);
+        }
+
+        requestBuilder.addHeader("Accept", "text/event-stream");
+        Request request = requestBuilder.build();
+        Log.d(TAG, "sendMessageWithToolsStreaming: HTTP " + request.method() + " " + request.url());
+
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                if (call.isCanceled()) {
+                    Log.d(TAG, "Streaming request canceled");
+                    return;
+                }
+                Log.e(TAG, "Network error", e);
+                mainHandler.post(() -> callback.onError("Network error: " + e.getMessage()));
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                if (!response.isSuccessful()) {
+                    String responseBody = response.body() != null ? response.body().string() : "";
+                    String errMsg = parseApiError(responseBody, response.code(), apiType);
+                    Log.e(TAG, "API error: " + response.code() + " - " + responseBody);
+                    mainHandler.post(() -> callback.onError(errMsg));
+                    return;
+                }
+                if (response.body() == null) {
+                    mainHandler.post(() -> callback.onError("Empty response body"));
+                    return;
+                }
+
+                final SseStreamAccumulator accumulator = new SseStreamAccumulator(apiType,
+                        new SseStreamAccumulator.Listener() {
+                            @Override
+                            public void onTextDelta(String text) {
+                                mainHandler.post(() -> callback.onDelta(text));
+                            }
+                        });
+
+                try {
+                    BufferedSource source = response.body().source();
+                    String line;
+                    while ((line = source.readUtf8Line()) != null) {
+                        if (call.isCanceled()) {
+                            Log.d(TAG, "Stream canceled mid-read");
+                            return;
+                        }
+                        accumulator.feedLine(line);
+                        if (accumulator.hasError()) break;
+                    }
+                } catch (IOException e) {
+                    if (call.isCanceled()) {
+                        Log.d(TAG, "Stream canceled (read aborted)");
+                        return;
+                    }
+                    Log.e(TAG, "Stream read error", e);
+                    mainHandler.post(() -> callback.onError("Stream read error: " + e.getMessage()));
+                    return;
+                } finally {
+                    response.close();
+                }
+                accumulator.finish();
+
+                if (accumulator.hasError()) {
+                    final String err = accumulator.getError();
+                    Log.e(TAG, "Stream error: " + err);
+                    mainHandler.post(() -> callback.onError(err));
+                    return;
+                }
+
+                final LlmResponse llmResponse = accumulator.buildResponse();
+                mainHandler.post(() -> callback.onSuccess(llmResponse));
             }
         });
     }

--- a/app/src/main/java/io/finett/droidclaw/api/SseStreamAccumulator.java
+++ b/app/src/main/java/io/finett/droidclaw/api/SseStreamAccumulator.java
@@ -1,0 +1,377 @@
+package io.finett.droidclaw.api;
+
+import android.util.Log;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Incremental Server-Sent-Events (SSE) parser for streaming LLM responses.
+ *
+ * <p>Feed raw stream lines via {@link #feedLine(String)}, call {@link #finish()}
+ * when the stream ends, then obtain the assembled result with
+ * {@link #buildResponse()}. Text deltas are surfaced live through the
+ * {@link Listener} so the UI can render tokens as they arrive.</p>
+ *
+ * <p>Supports both API dialects:
+ * <ul>
+ *   <li><b>OpenAI Chat Completions</b> — {@code data: {chunk}} lines with
+ *       {@code choices[0].delta.content} text deltas, {@code delta.tool_calls}
+ *       fragments indexed by position, the {@code [DONE]} sentinel, and an
+ *       optional trailing usage chunk (requires {@code stream_options.include_usage}).</li>
+ *   <li><b>Anthropic Messages</b> — typed events ({@code message_start},
+ *       {@code content_block_start}, {@code content_block_delta},
+ *       {@code message_delta}, {@code error}) with {@code text_delta} and
+ *       {@code input_json_delta} payloads.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>This class is NOT thread-safe: feed lines from a single reader thread.</p>
+ */
+public class SseStreamAccumulator {
+    private static final String TAG = "SseStreamAccumulator";
+
+    /** Receives incremental text deltas for live rendering. */
+    public interface Listener {
+        void onTextDelta(String text);
+    }
+
+    private final String apiType;
+    private final Listener listener;
+
+    // ==================== SSE framing state ====================
+
+    private final StringBuilder dataBuffer = new StringBuilder();
+    private boolean hasData = false;
+
+    // ==================== Accumulated response state ====================
+
+    private final StringBuilder content = new StringBuilder();
+
+    /** OpenAI-style tool calls, ordered by stream index. */
+    private final List<ToolCallAccumulator> openAiToolCalls = new ArrayList<>();
+
+    /** Anthropic tool_use blocks keyed by content-block index. */
+    private final Map<Integer, ToolCallAccumulator> anthropicToolCalls = new HashMap<>();
+
+    private int promptTokens = 0;
+    private int completionTokens = 0;
+    private boolean hasUsage = false;
+
+    private String error = null;
+    private boolean done = false;
+
+    /** Partial tool-call data accumulated across stream fragments. */
+    private static class ToolCallAccumulator {
+        String id = "";
+        String name = "";
+        final StringBuilder arguments = new StringBuilder();
+    }
+
+    public SseStreamAccumulator(String apiType, Listener listener) {
+        this.apiType = apiType;
+        this.listener = listener;
+    }
+
+    /**
+     * Feed one raw line from the SSE stream. Handles SSE framing:
+     * {@code data:} payloads accumulate until a blank line dispatches the event;
+     * comment lines (starting with {@code :}) and {@code event:}/{@code id:}/
+     * {@code retry:} fields are ignored (the JSON payloads carry their own type).
+     */
+    public void feedLine(String line) {
+        if (line == null) return;
+
+        if (line.isEmpty()) {
+            dispatchEvent();
+            return;
+        }
+        if (line.startsWith(":")) {
+            return; // SSE comment (commonly used as keep-alive)
+        }
+        if (line.startsWith("data:")) {
+            String value = line.substring(5);
+            if (value.startsWith(" ")) {
+                value = value.substring(1);
+            }
+            if (hasData) {
+                dataBuffer.append('\n');
+            }
+            dataBuffer.append(value);
+            hasData = true;
+        }
+        // Any other field (event:, id:, retry:) is intentionally ignored.
+    }
+
+    /** Flush a pending event that was not terminated by a blank line (stream end). */
+    public void finish() {
+        dispatchEvent();
+    }
+
+    private void dispatchEvent() {
+        if (!hasData) return;
+        String data = dataBuffer.toString();
+        dataBuffer.setLength(0);
+        hasData = false;
+        if (data.isEmpty()) return;
+
+        if (LlmApiService.API_ANTHROPIC.equals(apiType)) {
+            handleAnthropicEvent(data);
+        } else {
+            handleOpenAiEvent(data);
+        }
+    }
+
+    // ==================== OpenAI dialect ====================
+
+    private void handleOpenAiEvent(String data) {
+        if ("[DONE]".equals(data.trim())) {
+            done = true;
+            return;
+        }
+        try {
+            JsonObject chunk = JsonParser.parseString(data).getAsJsonObject();
+
+            // Usage-only chunk (sent last when stream_options.include_usage=true);
+            // its "choices" array is empty, so parse usage before the choices check.
+            if (chunk.has("usage") && !chunk.get("usage").isJsonNull()
+                    && chunk.get("usage").isJsonObject()) {
+                parseOpenAiUsage(chunk.getAsJsonObject("usage"));
+            }
+
+            if (!chunk.has("choices") || !chunk.get("choices").isJsonArray()) return;
+            JsonArray choices = chunk.getAsJsonArray("choices");
+            if (choices.size() == 0) return;
+
+            JsonObject choice = choices.get(0).getAsJsonObject();
+            if (!choice.has("delta") || choice.get("delta").isJsonNull()) return;
+            JsonObject delta = choice.getAsJsonObject("delta");
+
+            if (delta.has("content") && !delta.get("content").isJsonNull()) {
+                String text = delta.get("content").getAsString();
+                if (!text.isEmpty()) {
+                    content.append(text);
+                    if (listener != null) listener.onTextDelta(text);
+                }
+            }
+
+            if (delta.has("tool_calls") && !delta.get("tool_calls").isJsonNull()
+                    && delta.get("tool_calls").isJsonArray()) {
+                for (JsonElement tcEl : delta.getAsJsonArray("tool_calls")) {
+                    JsonObject tc = tcEl.getAsJsonObject();
+                    int index = tc.has("index") ? tc.get("index").getAsInt() : 0;
+                    while (openAiToolCalls.size() <= index) {
+                        openAiToolCalls.add(new ToolCallAccumulator());
+                    }
+                    ToolCallAccumulator acc = openAiToolCalls.get(index);
+                    if (tc.has("id") && !tc.get("id").isJsonNull()) {
+                        acc.id = tc.get("id").getAsString();
+                    }
+                    if (tc.has("function") && tc.get("function").isJsonObject()) {
+                        JsonObject fn = tc.getAsJsonObject("function");
+                        if (fn.has("name") && !fn.get("name").isJsonNull()) {
+                            acc.name = fn.get("name").getAsString();
+                        }
+                        if (fn.has("arguments") && !fn.get("arguments").isJsonNull()) {
+                            acc.arguments.append(fn.get("arguments").getAsString());
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to parse OpenAI stream chunk: " + truncate(data), e);
+        }
+    }
+
+    private void parseOpenAiUsage(JsonObject usageObj) {
+        if (usageObj.has("prompt_tokens")) {
+            promptTokens = usageObj.get("prompt_tokens").getAsInt();
+            hasUsage = true;
+        }
+        if (usageObj.has("completion_tokens")) {
+            completionTokens = usageObj.get("completion_tokens").getAsInt();
+            hasUsage = true;
+        }
+    }
+
+    // ==================== Anthropic dialect ====================
+
+    private void handleAnthropicEvent(String data) {
+        try {
+            JsonObject event = JsonParser.parseString(data).getAsJsonObject();
+            String type = event.has("type") ? event.get("type").getAsString() : "";
+
+            switch (type) {
+                case "message_start": {
+                    if (event.has("message") && event.get("message").isJsonObject()) {
+                        JsonObject msg = event.getAsJsonObject("message");
+                        if (msg.has("usage") && msg.get("usage").isJsonObject()) {
+                            JsonObject usage = msg.getAsJsonObject("usage");
+                            if (usage.has("input_tokens")) {
+                                promptTokens = usage.get("input_tokens").getAsInt();
+                                hasUsage = true;
+                            }
+                        }
+                    }
+                    break;
+                }
+                case "content_block_start": {
+                    int index = event.has("index") ? event.get("index").getAsInt() : 0;
+                    if (event.has("content_block") && event.get("content_block").isJsonObject()) {
+                        JsonObject block = event.getAsJsonObject("content_block");
+                        String blockType = block.has("type") ? block.get("type").getAsString() : "";
+                        if ("tool_use".equals(blockType)) {
+                            ToolCallAccumulator acc = new ToolCallAccumulator();
+                            if (block.has("id") && !block.get("id").isJsonNull()) {
+                                acc.id = block.get("id").getAsString();
+                            }
+                            if (block.has("name") && !block.get("name").isJsonNull()) {
+                                acc.name = block.get("name").getAsString();
+                            }
+                            anthropicToolCalls.put(index, acc);
+                        }
+                    }
+                    break;
+                }
+                case "content_block_delta": {
+                    int index = event.has("index") ? event.get("index").getAsInt() : 0;
+                    if (!event.has("delta") || !event.get("delta").isJsonObject()) break;
+                    JsonObject delta = event.getAsJsonObject("delta");
+                    String deltaType = delta.has("type") ? delta.get("type").getAsString() : "";
+
+                    if ("text_delta".equals(deltaType)) {
+                        String text = delta.has("text") ? delta.get("text").getAsString() : "";
+                        if (!text.isEmpty()) {
+                            content.append(text);
+                            if (listener != null) listener.onTextDelta(text);
+                        }
+                    } else if ("input_json_delta".equals(deltaType)) {
+                        ToolCallAccumulator acc = anthropicToolCalls.get(index);
+                        if (acc != null && delta.has("partial_json")
+                                && !delta.get("partial_json").isJsonNull()) {
+                            acc.arguments.append(delta.get("partial_json").getAsString());
+                        }
+                    }
+                    break;
+                }
+                case "message_delta": {
+                    if (event.has("usage") && event.get("usage").isJsonObject()) {
+                        JsonObject usage = event.getAsJsonObject("usage");
+                        if (usage.has("output_tokens")) {
+                            completionTokens = usage.get("output_tokens").getAsInt();
+                            hasUsage = true;
+                        }
+                    }
+                    break;
+                }
+                case "error": {
+                    String msg = "unknown stream error";
+                    if (event.has("error") && event.get("error").isJsonObject()) {
+                        JsonObject err = event.getAsJsonObject("error");
+                        if (err.has("message")) {
+                            msg = err.get("message").getAsString();
+                        }
+                    }
+                    error = "Anthropic stream error: " + msg;
+                    break;
+                }
+                default:
+                    // ping, content_block_stop, message_stop, etc. — nothing to accumulate.
+                    break;
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to parse Anthropic stream event: " + truncate(data), e);
+        }
+    }
+
+    // ==================== Result assembly ====================
+
+    /**
+     * Assemble the final {@link LlmApiService.LlmResponse} from accumulated state.
+     * Shape matches the non-streaming parse path: text content (null when empty
+     * and tool calls exist), tool calls, and token usage when reported.
+     */
+    public LlmApiService.LlmResponse buildResponse() {
+        List<LlmApiService.ToolCall> toolCalls = new ArrayList<>();
+
+        for (ToolCallAccumulator acc : openAiToolCalls) {
+            LlmApiService.ToolCall tc = toToolCall(acc);
+            if (tc != null) toolCalls.add(tc);
+        }
+
+        if (!anthropicToolCalls.isEmpty()) {
+            List<Integer> indices = new ArrayList<>(anthropicToolCalls.keySet());
+            Collections.sort(indices);
+            for (Integer idx : indices) {
+                LlmApiService.ToolCall tc = toToolCall(anthropicToolCalls.get(idx));
+                if (tc != null) toolCalls.add(tc);
+            }
+        }
+
+        String text = content.length() > 0 ? content.toString() : null;
+        TokenUsage usage = hasUsage
+                ? new TokenUsage(promptTokens + completionTokens, promptTokens, completionTokens)
+                : null;
+
+        if (text == null && toolCalls.isEmpty()) {
+            text = "No response received";
+        }
+
+        return new LlmApiService.LlmResponse(text, toolCalls.isEmpty() ? null : toolCalls, usage);
+    }
+
+    private LlmApiService.ToolCall toToolCall(ToolCallAccumulator acc) {
+        if (acc.name == null || acc.name.isEmpty()) {
+            Log.w(TAG, "Skipping streamed tool call without a name");
+            return null;
+        }
+        JsonObject args;
+        String argsStr = acc.arguments.toString().trim();
+        if (argsStr.isEmpty()) {
+            args = new JsonObject();
+        } else {
+            try {
+                args = JsonParser.parseString(argsStr).getAsJsonObject();
+            } catch (Exception e) {
+                Log.w(TAG, "Streamed tool call arguments were not valid JSON: "
+                        + truncate(argsStr));
+                args = new JsonObject();
+            }
+        }
+        return new LlmApiService.ToolCall(acc.id, acc.name, args);
+    }
+
+    // ==================== Accessors ====================
+
+    /** True when a fatal stream error was reported (e.g. Anthropic error event). */
+    public boolean hasError() {
+        return error != null;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    /** True when the OpenAI [DONE] sentinel was received. */
+    public boolean isDone() {
+        return done;
+    }
+
+    /** The text accumulated so far (live view of the response). */
+    public String getContent() {
+        return content.toString();
+    }
+
+    private static String truncate(String s) {
+        if (s == null) return "";
+        return s.length() > 200 ? s.substring(0, 200) + "..." : s;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
@@ -38,6 +38,7 @@ public class AgentSettingsFragment extends Fragment {
     private AutoCompleteTextView dropdownSandboxMode;
     private TextInputEditText inputMaxIterations;
     private SwitchMaterial switchRequireApproval;
+    private SwitchMaterial switchStreamResponses;
     private TextInputEditText inputShellTimeout;
     private SwitchMaterial switchBackgroundShellAccess;
     private SwitchMaterial switchBackgroundExec;
@@ -109,6 +110,7 @@ public class AgentSettingsFragment extends Fragment {
         dropdownSandboxMode = view.findViewById(R.id.dropdown_sandbox_mode);
         inputMaxIterations = view.findViewById(R.id.input_max_iterations);
         switchRequireApproval = view.findViewById(R.id.switch_require_approval);
+        switchStreamResponses = view.findViewById(R.id.switch_stream_responses);
         inputShellTimeout = view.findViewById(R.id.input_shell_timeout);
         switchBackgroundShellAccess = view.findViewById(R.id.switch_background_shell_access);
         switchBackgroundExec = view.findViewById(R.id.switch_background_exec);
@@ -220,6 +222,7 @@ public class AgentSettingsFragment extends Fragment {
 
             inputMaxIterations.setText(String.valueOf(agentConfig.getMaxIterations()));
             switchRequireApproval.setChecked(agentConfig.isRequireApproval());
+            switchStreamResponses.setChecked(agentConfig.isStreamResponses());
             inputShellTimeout.setText(String.valueOf(agentConfig.getShellTimeout()));
             switchBackgroundShellAccess.setChecked(agentConfig.isBackgroundShellEnabled());
             switchBackgroundExec.setChecked(agentConfig.isBackgroundExecEnabled());
@@ -581,6 +584,7 @@ public class AgentSettingsFragment extends Fragment {
         agentConfig.setSandboxMode(sandboxMode);
         agentConfig.setMaxIterations(maxIterations);
         agentConfig.setRequireApproval(switchRequireApproval.isChecked());
+        agentConfig.setStreamResponses(switchStreamResponses.isChecked());
         agentConfig.setShellTimeout(shellTimeout);
         agentConfig.setBackgroundShellEnabled(switchBackgroundShellAccess.isChecked());
         agentConfig.setBackgroundExecEnabled(switchBackgroundExec.isChecked());

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -72,6 +72,10 @@ public class ChatFragment extends Fragment {
     private RecyclerView recyclerView;
     private EditText messageInput;
     private ImageButton sendButton;
+    /** True while an agent request is in flight; the send button doubles as stop. */
+    private boolean loading = false;
+    /** Currently visible tool-approval dialog, if any. */
+    private AlertDialog approvalDialog;
     private ImageButton attachButton;
     private View statusContainer;
     private HorizontalScrollView attachmentBarContainer;
@@ -210,8 +214,25 @@ public class ChatFragment extends Fragment {
             if (hadPartialBubble) {
                 chatAdapter.removeLastMessage();
             }
+            dismissApprovalDialog();
             setLoading(false);
             Toast.makeText(requireContext(), error, Toast.LENGTH_LONG).show();
+        }
+
+        @Override
+        public void onCancelled(List<ChatMessage> history) {
+            if (!isAdded() || getContext() == null) {
+                return;
+            }
+            // The service already persisted `history` (including any partial streamed
+            // text); just re-render it in place of the temporary streaming bubble.
+            resetStreamingState();
+            dismissApprovalDialog();
+            setLoading(false);
+            chatAdapter.setMessages(history);
+            scrollToBottom();
+            updateToolbarTitle();
+            Toast.makeText(requireContext(), R.string.response_stopped, Toast.LENGTH_SHORT).show();
         }
 
         @Override
@@ -907,7 +928,13 @@ public class ChatFragment extends Fragment {
 
 
     private void setupClickListeners() {
-        sendButton.setOnClickListener(v -> sendMessage());
+        sendButton.setOnClickListener(v -> {
+            if (loading) {
+                stopResponse();
+            } else {
+                sendMessage();
+            }
+        });
         attachButton.setOnClickListener(v -> launchFilePicker());
         messageInput.setOnEditorActionListener((v, actionId, event) -> {
             sendMessage();
@@ -1030,6 +1057,9 @@ public class ChatFragment extends Fragment {
 
 
     private void sendMessage() {
+        if (loading) {
+            return;
+        }
         String messageText = messageInput.getText().toString().trim();
         if (messageText.isEmpty()) {
             return;
@@ -1071,27 +1101,70 @@ public class ChatFragment extends Fragment {
      */
     private void showApprovalDialog(String toolName, String description,
                                     AgentLoop.ApprovalCallback approvalCallback) {
-        new AlertDialog.Builder(requireContext())
+        approvalDialog = new AlertDialog.Builder(requireContext())
             .setTitle("Approve Tool Execution?")
             .setMessage("Tool: " + formatToolName(toolName) + "\n\n" + description)
             .setPositiveButton("Approve", (dialog, which) -> {
                 Log.d(TAG, "User approved tool: " + toolName);
+                approvalDialog = null;
                 approvalCallback.onApproved();
             })
             .setNegativeButton("Deny", (dialog, which) -> {
                 Log.d(TAG, "User denied tool: " + toolName);
+                approvalDialog = null;
                 approvalCallback.onDenied();
             })
             .setCancelable(false)
             .show();
     }
 
+    /** Dismiss the tool-approval dialog if it is still showing (e.g. on stop). */
+    private void dismissApprovalDialog() {
+        if (approvalDialog != null && approvalDialog.isShowing()) {
+            approvalDialog.dismiss();
+        }
+        approvalDialog = null;
+    }
+
     private void setLoading(boolean loading) {
+        this.loading = loading;
         if (statusContainer != null) {
             statusContainer.setVisibility(loading ? View.VISIBLE : View.GONE);
         }
-        sendButton.setEnabled(!loading);
+        updateSendButton();
         messageInput.setEnabled(!loading);
+    }
+
+    /**
+     * While idle the button sends; while a request is in flight it morphs into a
+     * stop button so the user can abort the response. It stays enabled in both
+     * states.
+     */
+    private void updateSendButton() {
+        if (sendButton == null) {
+            return;
+        }
+        sendButton.setImageResource(loading ? R.drawable.ic_stop : R.drawable.ic_send);
+        sendButton.setContentDescription(
+                getString(loading ? R.string.stop_response : R.string.send));
+        sendButton.setEnabled(true);
+    }
+
+    /**
+     * Stop the in-flight response: cancels the agent loop and aborts any HTTP
+     * requests. The final UI reset happens in {@code agentUiCallback.onCancelled()};
+     * the partial streamed text is preserved by the agent loop.
+     */
+    private void stopResponse() {
+        Log.d(TAG, "stopResponse: user requested cancellation");
+        if (serviceBound && agentExecutionService != null && currentSessionId != null
+                && agentExecutionService.isSessionActive(currentSessionId)) {
+            agentExecutionService.cancelAgentLoop(currentSessionId);
+        } else {
+            // No active service/session — reset the UI directly.
+            resetStreamingState();
+            setLoading(false);
+        }
     }
 
     private void updateStatus(String status, String subStatus) {

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -455,6 +455,10 @@ public class ChatFragment extends Fragment {
         int contextWindow = pendingServiceContextWindow;
         pendingServiceConversationHistory = null;
 
+        // The service drops the UI callback when a run reaches a terminal state,
+        // so re-register before every dispatch — otherwise responses for the
+        // second and later messages in the same screen session never reach the UI.
+        agentExecutionService.registerUICallback(currentSessionId, agentUiCallback);
         agentExecutionService.startAgentLoop(currentSessionId, history, contextWindow);
     }
 

--- a/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/ChatFragment.java
@@ -104,6 +104,24 @@ public class ChatFragment extends Fragment {
     private List<ChatMessage> pendingServiceConversationHistory;
     private int pendingServiceContextWindow;
 
+    // ==================== SSE streaming live-render state ====================
+
+    /** Interval between streaming UI refreshes; deltas accumulate in between. */
+    private static final long STREAM_FLUSH_INTERVAL_MS = 80;
+
+    /** Accumulated text of the currently streaming assistant bubble. */
+    private final StringBuilder streamingBuffer = new StringBuilder();
+
+    /** True while a temporary streaming bubble is present in the adapter. */
+    private boolean streamingBubbleActive = false;
+
+    /** Adapter position of the temporary streaming bubble. */
+    private int streamingBubblePosition = -1;
+
+    /** Throttled flush runnable (posted to the RecyclerView). */
+    private final Runnable streamFlushRunnable = this::flushStreamingBubble;
+    private boolean streamFlushScheduled = false;
+
     private final AgentExecutionService.UICallback agentUiCallback = new AgentExecutionService.UICallback() {
         @Override
         public void onProgress(String status) {
@@ -114,10 +132,32 @@ public class ChatFragment extends Fragment {
         }
 
         @Override
+        public void onStreamDelta(String delta) {
+            if (!isAdded() || delta == null || delta.isEmpty()) {
+                return;
+            }
+            if (!streamingBubbleActive) {
+                // New streamed assistant segment — add a temporary bubble that is
+                // replaced by the canonical history in onComplete().
+                ChatMessage streamingMessage = new ChatMessage("", ChatMessage.TYPE_ASSISTANT);
+                chatAdapter.addMessage(streamingMessage);
+                streamingBubblePosition = chatAdapter.getItemCount() - 1;
+                streamingBuffer.setLength(0);
+                streamingBubbleActive = true;
+                scrollToBottom();
+            }
+            streamingBuffer.append(delta);
+            scheduleStreamFlush();
+        }
+
+        @Override
         public void onToolCall(String toolName, String arguments) {
             if (!isAdded()) {
                 return;
             }
+            // The current streamed text segment is finished; the next text delta
+            // belongs to a new assistant message and starts a fresh bubble.
+            streamingBubbleActive = false;
             Log.d(TAG, "Tool call: " + toolName + " with args: " + arguments);
 
             boolean isBackground = arguments.contains("\"background\":true")
@@ -144,6 +184,7 @@ public class ChatFragment extends Fragment {
                 return;
             }
 
+            resetStreamingState();
             setLoading(false);
             chatAdapter.setMessages(updatedHistory);
             scrollToBottom();
@@ -162,6 +203,12 @@ public class ChatFragment extends Fragment {
             if (!isAdded() || getContext() == null) {
                 Log.w(TAG, "onError: Fragment not attached, ignoring error: " + error);
                 return;
+            }
+            // Drop the partial streaming bubble — its text never made it into history.
+            boolean hadPartialBubble = streamingBubbleActive;
+            resetStreamingState();
+            if (hadPartialBubble) {
+                chatAdapter.removeLastMessage();
             }
             setLoading(false);
             Toast.makeText(requireContext(), error, Toast.LENGTH_LONG).show();
@@ -1068,6 +1115,44 @@ public class ChatFragment extends Fragment {
         if (chatAdapter.getItemCount() > 0) {
             recyclerView.scrollToPosition(chatAdapter.getItemCount() - 1);
         }
+    }
+
+    // ==================== SSE streaming live-render helpers ====================
+
+    /**
+     * Throttled flush of accumulated stream deltas into the temporary bubble.
+     * Re-rendering markdown on every token is wasteful, so deltas are batched
+     * and applied at most once per {@link #STREAM_FLUSH_INTERVAL_MS}.
+     */
+    private void scheduleStreamFlush() {
+        if (streamFlushScheduled || recyclerView == null) {
+            return;
+        }
+        streamFlushScheduled = true;
+        recyclerView.postDelayed(streamFlushRunnable, STREAM_FLUSH_INTERVAL_MS);
+    }
+
+    private void flushStreamingBubble() {
+        streamFlushScheduled = false;
+        if (!streamingBubbleActive || !isAdded()) {
+            return;
+        }
+        chatAdapter.updateStreamingMessage(streamingBubblePosition, streamingBuffer.toString());
+        scrollToBottom();
+    }
+
+    /**
+     * Clear all streaming state and cancel any pending flush. Called when the
+     * agent completes or errors; the final history render replaces the bubble.
+     */
+    private void resetStreamingState() {
+        streamingBubbleActive = false;
+        streamingBubblePosition = -1;
+        streamingBuffer.setLength(0);
+        if (recyclerView != null) {
+            recyclerView.removeCallbacks(streamFlushRunnable);
+        }
+        streamFlushScheduled = false;
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
+++ b/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
@@ -17,6 +17,7 @@ public class AgentConfig {
     private List<String> customAllowlist; // extra executable paths for relaxed mode
     private boolean screenControlEnabled;  // allow agent to read UI and control screen via accessibility
     private boolean screenControlTrustMode; // skip per-action approval for screen control tools
+    private boolean streamResponses;        // stream LLM text via SSE as it is generated
     private int llmConnectTimeout;   // seconds
     private int llmReadTimeout;      // seconds
     private int llmWriteTimeout;     // seconds
@@ -32,6 +33,7 @@ public class AgentConfig {
 
     public AgentConfig() {
         this.customAllowlist = new ArrayList<>();
+        this.streamResponses = true;
         this.llmConnectTimeout = 30;
         this.llmReadTimeout = 120;
         this.llmWriteTimeout = 30;
@@ -54,6 +56,7 @@ public class AgentConfig {
         this.shellTimeout = shellTimeout;
         this.backgroundShellEnabled = backgroundShellEnabled;
         this.backgroundExecEnabled = false;
+        this.streamResponses = true;
         this.customAllowlist = customAllowlist != null ? new ArrayList<>(customAllowlist) : new ArrayList<>();
         this.llmConnectTimeout = 30;
         this.llmReadTimeout = 120;
@@ -187,6 +190,14 @@ public class AgentConfig {
 
     public void setScreenControlTrustMode(boolean screenControlTrustMode) {
         this.screenControlTrustMode = screenControlTrustMode;
+    }
+
+    public boolean isStreamResponses() {
+        return streamResponses;
+    }
+
+    public void setStreamResponses(boolean streamResponses) {
+        this.streamResponses = streamResponses;
     }
 
     public Map<String, String> getToolApprovalOverrides() {

--- a/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
@@ -109,6 +109,12 @@ public class AgentExecutionService extends Service {
         void onError(String error);
         void onApprovalRequired(String toolName, String description, JsonObject arguments,
                                 AgentLoop.ApprovalCallback approvalCallback);
+
+        /**
+         * Incremental text delta while a streaming (SSE) response is arriving.
+         * Optional — no-op by default for UIs that only render the final result.
+         */
+        default void onStreamDelta(String delta) {}
     }
 
     // ==================== Binder ====================
@@ -305,6 +311,14 @@ public class AgentExecutionService extends Service {
                     mainHandler.post(() -> {
                         UICallback cb = uiCallbacks.get(session.sessionId);
                         if (cb != null) cb.onProgress(status);
+                    });
+                }
+
+                @Override
+                public void onStreamDelta(String delta) {
+                    mainHandler.post(() -> {
+                        UICallback cb = uiCallbacks.get(session.sessionId);
+                        if (cb != null) cb.onStreamDelta(delta);
                     });
                 }
 

--- a/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
@@ -69,6 +69,12 @@ public class AgentExecutionService extends Service {
         /** Queued approval request waiting for the user to return. */
         volatile PendingApproval pendingApproval;
 
+        /** The running loop; set just before {@link AgentLoop#start} so it can be cancelled. */
+        volatile AgentLoop agentLoop;
+
+        /** Set when cancellation is requested before the loop has started. */
+        volatile boolean cancelRequested;
+
         /** Worker thread parks here when approval is needed and UI is detached. */
         final SynchronousQueue<Boolean> approvalQueue = new SynchronousQueue<>();
 
@@ -115,6 +121,13 @@ public class AgentExecutionService extends Service {
          * Optional — no-op by default for UIs that only render the final result.
          */
         default void onStreamDelta(String delta) {}
+
+        /**
+         * The run was cancelled by the user. {@code history} is the final
+         * conversation including any partially streamed response text.
+         * Optional — no-op by default.
+         */
+        default void onCancelled(List<ChatMessage> history) {}
     }
 
     // ==================== Binder ====================
@@ -276,6 +289,60 @@ public class AgentExecutionService extends Service {
                 && session.state != AgentSession.State.ERROR;
     }
 
+    /**
+     * Cancel the agent loop for the given session. In-flight HTTP requests are
+     * aborted, any partially streamed response text is persisted, and the UI
+     * callback (if attached) receives {@link UICallback#onCancelled(List)}.
+     */
+    public void cancelAgentLoop(String sessionId) {
+        AgentSession session = sessions.get(sessionId);
+        if (session == null) {
+            Log.d(TAG, "cancelAgentLoop: no active session for " + sessionId);
+            return;
+        }
+        Log.i(TAG, "Cancelling agent loop for session: " + sessionId);
+        session.cancelRequested = true;
+
+        // Wake a thread parked waiting for approval so the loop can observe
+        // the cancellation instead of blocking on the dialog outcome.
+        if (session.state == AgentSession.State.PAUSED_APPROVAL) {
+            session.pendingApproval = null;
+            session.approvalQueue.offer(false);
+        }
+
+        AgentLoop loop = session.agentLoop;
+        if (loop != null) {
+            loop.cancel();
+        }
+    }
+
+    /**
+     * Persist the (possibly partial) conversation and notify the UI that the run
+     * was cancelled. Idempotent: ignored if the session already reached a
+     * terminal state.
+     */
+    private void deliverCancelled(AgentSession session, List<ChatMessage> history) {
+        if (session.state == AgentSession.State.COMPLETED
+                || session.state == AgentSession.State.ERROR) {
+            return;
+        }
+        session.state = AgentSession.State.COMPLETED;
+        session.finalHistory = history;
+
+        // Persist messages regardless of UI state.
+        ChatRepository chatRepository = new ChatRepository(getApplicationContext());
+        chatRepository.saveMessages(session.sessionId, history);
+
+        mainHandler.post(() -> {
+            UICallback cb = uiCallbacks.remove(session.sessionId);
+            if (cb != null) {
+                cb.onCancelled(history);
+            }
+            sessions.remove(session.sessionId);
+            checkIdleAndStop();
+        });
+    }
+
     // ==================== Worker thread ====================
 
     private void runAgentLoop(AgentSession session, List<ChatMessage> conversationHistory,
@@ -297,6 +364,19 @@ public class AgentExecutionService extends Service {
 
             AgentLoop agentLoop = new AgentLoop(
                     apiService, toolRegistry, settingsManager, summarizer, memoryContext);
+            session.agentLoop = agentLoop;
+
+            // Cancellation was requested before the loop even started (user tapped
+            // stop within milliseconds of sending). Deliver it without running.
+            if (session.cancelRequested) {
+                Log.d(TAG, "Session cancelled before loop start: " + session.sessionId);
+                deliverCancelled(session, conversationHistory);
+                try {
+                    toolRegistry.shutdown();
+                } catch (Exception ignored) {
+                }
+                return;
+            }
 
             try {
                 List<ChatMessage> identityMessages = identityManager.getIdentityMessages();
@@ -414,6 +494,11 @@ public class AgentExecutionService extends Service {
                             approvalCallback.onDenied();
                         }
                     }
+                }
+
+                @Override
+                public void onCancelled(List<ChatMessage> history) {
+                    deliverCancelled(session, history);
                 }
             });
 

--- a/app/src/main/java/io/finett/droidclaw/service/BackgroundProcessService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/BackgroundProcessService.java
@@ -8,7 +8,9 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.PowerManager;
 import android.util.Log;
 
@@ -35,8 +37,20 @@ public class BackgroundProcessService extends Service {
     static final String ACTION_STOP = "io.finett.droidclaw.BG_STOP";
     static final String EXTRA_RUNNING_COUNT = "running_count";
 
+    /**
+     * Grace period before an idle service actually tears itself down. Prevents a
+     * stop/start race: if new work is submitted right after the last process
+     * finished, the delayed stop is cancelled and the same service record keeps
+     * serving — avoiding a {@code startForegroundService()} that lands on a
+     * dying record, which Android 15 punishes with
+     * {@code ForegroundServiceDidNotStartInTimeException} (process death).
+     */
+    private static final long STOP_GRACE_MS = 3_000;
+
     private PowerManager.WakeLock wakeLock;
     private NotificationManager notificationManager;
+    private final Handler stopHandler = new Handler(Looper.getMainLooper());
+    private Runnable pendingStop;
 
     // ==================== Lifecycle ====================
 
@@ -57,20 +71,35 @@ public class BackgroundProcessService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        BackgroundProcessManager manager = BackgroundProcessManager.getInstance(this);
+
         if (intent != null && ACTION_STOP.equals(intent.getAction())) {
-            Log.d(TAG, "Stop action received — killing all processes and stopping service");
-            BackgroundProcessManager.getInstance(this).killAll();
-            stopForeground(true);
-            stopSelf();
+            int running = manager.runningCount();
+            if (running > 0) {
+                // Stale stop intent: new work was submitted after this intent was
+                // queued (stopIfIdle sends it when the count hits 0, but submit()
+                // can race ahead). Killing here would destroy the new process.
+                Log.d(TAG, "Stale stop intent ignored — " + running + " process(es) running");
+                return START_STICKY;
+            }
+            Log.d(TAG, "Stop action received — scheduling idle shutdown");
+            scheduleStop();
             return START_NOT_STICKY;
         }
+
+        // New work or a refresh arrived — cancel any pending idle shutdown.
+        cancelPendingStop();
 
         int runningCount = (intent != null)
                 ? intent.getIntExtra(EXTRA_RUNNING_COUNT, 0)
                 : 0;
 
-        // Update the notification with the actual running count now that we have it.
-        notificationManager.notify(NOTIFICATION_ID, buildNotification(runningCount));
+        // Re-assert foreground state: every startForegroundService() call
+        // (ensureRunning / updateNotification) must be paired with a
+        // startForeground() call, even when the service is already running —
+        // otherwise Android 12+ may kill the process with
+        // ForegroundServiceDidNotStartInTimeException.
+        startForeground(NOTIFICATION_ID, buildNotification(runningCount));
 
         if (intent != null && ACTION_UPDATE_NOTIFICATION.equals(intent.getAction())) {
             // Just a notification refresh — no new work to start
@@ -81,9 +110,39 @@ public class BackgroundProcessService extends Service {
         return START_STICKY;
     }
 
+    /**
+     * Schedule the actual teardown after {@link #STOP_GRACE_MS}. The runnable
+     * re-checks the running count, so work submitted during the grace window
+     * keeps the service alive even if no new intent cancels the stop.
+     */
+    private void scheduleStop() {
+        if (pendingStop != null) {
+            return; // already scheduled
+        }
+        pendingStop = () -> {
+            pendingStop = null;
+            if (BackgroundProcessManager.getInstance(this).runningCount() > 0) {
+                Log.d(TAG, "Pending stop expired but work is running — staying alive");
+                return;
+            }
+            Log.d(TAG, "Grace period elapsed — stopping service");
+            stopForeground(true);
+            stopSelf();
+        };
+        stopHandler.postDelayed(pendingStop, STOP_GRACE_MS);
+    }
+
+    private void cancelPendingStop() {
+        if (pendingStop != null) {
+            stopHandler.removeCallbacks(pendingStop);
+            pendingStop = null;
+        }
+    }
+
     @Override
     public void onDestroy() {
         super.onDestroy();
+        cancelPendingStop();
         // Safety net: kill any remaining processes if the OS tears down the service
         BackgroundProcessManager.getInstance(this).killAll();
         releaseWakeLock();

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -230,6 +230,7 @@ public class SettingsManager {
         config.setBackgroundExecEnabled(json.optBoolean("backgroundExecEnabled", false));
         config.setScreenControlEnabled(json.optBoolean("screenControlEnabled", false));
         config.setScreenControlTrustMode(json.optBoolean("screenControlTrustMode", false));
+        config.setStreamResponses(json.optBoolean("streamResponses", true));
         config.setShellBackend(json.optString("shellBackend", "local"));
         config.setSshHost(json.optString("sshHost", ""));
         config.setSshPort(json.optInt("sshPort", 22));
@@ -340,6 +341,7 @@ public class SettingsManager {
         json.put("backgroundExecEnabled", config.isBackgroundExecEnabled());
         json.put("screenControlEnabled", config.isScreenControlEnabled());
         json.put("screenControlTrustMode", config.isScreenControlTrustMode());
+        json.put("streamResponses", config.isStreamResponses());
         json.put("shellBackend", config.getShellBackend());
         json.put("sshHost", config.getSshHost());
         json.put("sshPort", config.getSshPort());

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnPrimary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,6h12v12H6z" />
+</vector>

--- a/app/src/main/res/layout/fragment_agent_settings.xml
+++ b/app/src/main/res/layout/fragment_agent_settings.xml
@@ -241,6 +241,42 @@
 
         </LinearLayout>
 
+        <!-- Stream Responses Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/stream_responses"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/stream_responses_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_stream_responses"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
         <!-- Shell Timeout -->
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
     <string name="app_name">DroidClaw</string>
     <string name="type_message">Type a message…</string>
     <string name="send">Send</string>
+    <string name="stop_response">Stop response</string>
+    <string name="response_stopped">Response stopped</string>
     <string name="attach_file">Attach file</string>
     <string name="menu">Menu</string>
     <string name="new_chat">New Chat</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="max_iterations_description">Maximum tool execution cycles</string>
     <string name="require_approval">Require Approval</string>
     <string name="require_approval_description">Confirm before executing tools</string>
+    <string name="stream_responses">Stream Responses</string>
+    <string name="stream_responses_description">Show text live as it is generated (SSE)</string>
     <string name="shell_timeout">Shell Timeout (seconds)</string>
     <string name="shell_timeout_description">Command execution limit</string>
     <string name="background_shell_access">Shell in Background Tasks</string>

--- a/app/src/test/java/io/finett/droidclaw/agent/AgentLoopCancellationTest.java
+++ b/app/src/test/java/io/finett/droidclaw/agent/AgentLoopCancellationTest.java
@@ -1,0 +1,219 @@
+package io.finett.droidclaw.agent;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import android.os.Looper;
+
+import com.google.gson.JsonArray;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.model.AgentConfig;
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.tool.ToolRegistry;
+import io.finett.droidclaw.util.SettingsManager;
+
+/**
+ * Tests cancellation of {@link AgentLoop}: aborting in-flight requests,
+ * preserving partially streamed text, and single-delivery guarantees.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AgentLoopCancellationTest {
+
+    @Mock
+    private LlmApiService mockApiService;
+
+    @Mock
+    private ToolRegistry mockToolRegistry;
+
+    @Mock
+    private SettingsManager mockSettingsManager;
+
+    @Mock
+    private AgentLoop.AgentCallback mockCallback;
+
+    private AgentConfig agentConfig;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        agentConfig = new AgentConfig();
+        agentConfig.setStreamResponses(true);
+        when(mockSettingsManager.getMaxAgentIterations()).thenReturn(20);
+        when(mockSettingsManager.isRequireApproval()).thenReturn(false);
+        when(mockSettingsManager.getAgentConfig()).thenReturn(agentConfig);
+        when(mockToolRegistry.getToolDefinitions()).thenReturn(new JsonArray());
+    }
+
+    private AgentLoop createLoop() {
+        return new AgentLoop(mockApiService, mockToolRegistry, mockSettingsManager);
+    }
+
+    private List<ChatMessage> simpleConversation() {
+        List<ChatMessage> conversation = new ArrayList<>();
+        conversation.add(new ChatMessage("Hello", ChatMessage.TYPE_USER));
+        return conversation;
+    }
+
+    /** Stub the streaming API to emit deltas but never complete (in-flight stream). */
+    private void stubStreamingDeltasOnly(String... deltas) {
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                LlmApiService.StreamingChatCallback callback =
+                        invocation.getArgument(3, LlmApiService.StreamingChatCallback.class);
+                for (String delta : deltas) {
+                    callback.onDelta(delta);
+                }
+                return null;
+            }
+        }).when(mockApiService).sendMessageWithToolsStreaming(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.StreamingChatCallback.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ChatMessage> captureCancelledHistory() {
+        ArgumentCaptor<List<ChatMessage>> captor = ArgumentCaptor.forClass(List.class);
+        verify(mockCallback).onCancelled(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void cancel_duringStreaming_preservesPartialText() {
+        stubStreamingDeltasOnly("Hello ", "world");
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+
+        assertTrue(loop.isCancelled() == false);
+        loop.cancel();
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+        assertTrue(loop.isCancelled());
+        verify(mockApiService).cancelAllRequests();
+
+        List<ChatMessage> history = captureCancelledHistory();
+        ChatMessage last = history.get(history.size() - 1);
+        assertEquals("Partial text should be preserved as an assistant message",
+                ChatMessage.TYPE_ASSISTANT, last.getType());
+        assertEquals("Hello world", last.getContent());
+
+        verify(mockCallback, never()).onComplete(anyString(), anyList());
+        verify(mockCallback, never()).onError(anyString());
+    }
+
+    @Test
+    public void cancel_beforeAnyResponse_dispatchesOnCancelledWithOriginalHistory() {
+        stubStreamingDeltasOnly(); // request in flight, no deltas yet
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+        loop.cancel();
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+        verify(mockApiService).cancelAllRequests();
+
+        List<ChatMessage> history = captureCancelledHistory();
+        assertEquals(1, history.size());
+        assertEquals(ChatMessage.TYPE_USER, history.get(0).getType());
+
+        verify(mockCallback, never()).onComplete(anyString(), anyList());
+        verify(mockCallback, never()).onError(anyString());
+    }
+
+    @Test
+    public void cancel_twice_dispatchesOnCancelledOnlyOnce() {
+        stubStreamingDeltasOnly("partial");
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+        loop.cancel();
+        loop.cancel();
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+        verify(mockApiService, times(1)).cancelAllRequests();
+        verify(mockCallback, times(1)).onCancelled(anyList());
+    }
+
+    @Test
+    public void cancel_afterCompletion_doesNotDispatchOnCancelled() {
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                LlmApiService.StreamingChatCallback callback =
+                        invocation.getArgument(3, LlmApiService.StreamingChatCallback.class);
+                callback.onDelta("Done");
+                callback.onSuccess(new LlmApiService.LlmResponse("Done", null));
+                return null;
+            }
+        }).when(mockApiService).sendMessageWithToolsStreaming(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.StreamingChatCallback.class));
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+        verify(mockCallback).onComplete(eq("Done"), anyList());
+
+        // User taps stop a moment after the response finished.
+        loop.cancel();
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+        verify(mockCallback, never()).onCancelled(anyList());
+    }
+
+    @Test
+    public void cancel_stopsFurtherIterations_afterToolCalls() {
+        // First response requests a tool; after the tool result the loop would
+        // normally send a follow-up request — cancellation must prevent it.
+        List<LlmApiService.ToolCall> toolCalls = new ArrayList<>();
+        toolCalls.add(new LlmApiService.ToolCall(
+                "call-1", "list_files", new com.google.gson.JsonObject()));
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                LlmApiService.StreamingChatCallback callback =
+                        invocation.getArgument(3, LlmApiService.StreamingChatCallback.class);
+                callback.onSuccess(new LlmApiService.LlmResponse("", toolCalls));
+                return null;
+            }
+        }).doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                // Second request "hangs" in flight — cancellation aborts it.
+                return null;
+            }
+        }).when(mockApiService).sendMessageWithToolsStreaming(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.StreamingChatCallback.class));
+
+        when(mockToolRegistry.getTool(anyString())).thenReturn(null);
+        when(mockToolRegistry.executeTool(anyString(), any()))
+                .thenReturn(io.finett.droidclaw.tool.ToolResult.success("ok"));
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+
+        // The tool executed synchronously; cancel before the next request goes out.
+        loop.cancel();
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+        verify(mockApiService, times(1)).cancelAllRequests();
+        verify(mockCallback).onCancelled(anyList());
+        verify(mockCallback, never()).onComplete(anyString(), anyList());
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/agent/AgentLoopStreamingTest.java
+++ b/app/src/test/java/io/finett/droidclaw/agent/AgentLoopStreamingTest.java
@@ -1,0 +1,161 @@
+package io.finett.droidclaw.agent;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.google.gson.JsonArray;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.model.AgentConfig;
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.tool.ToolRegistry;
+import io.finett.droidclaw.util.SettingsManager;
+
+/**
+ * Tests the streaming (SSE) path of {@link AgentLoop}: selection between the
+ * streaming and legacy API calls, live delta forwarding, and final completion.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AgentLoopStreamingTest {
+
+    @Mock
+    private LlmApiService mockApiService;
+
+    @Mock
+    private ToolRegistry mockToolRegistry;
+
+    @Mock
+    private SettingsManager mockSettingsManager;
+
+    @Mock
+    private AgentLoop.AgentCallback mockCallback;
+
+    private AgentConfig agentConfig;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        agentConfig = new AgentConfig();
+        when(mockSettingsManager.getMaxAgentIterations()).thenReturn(20);
+        when(mockSettingsManager.isRequireApproval()).thenReturn(false);
+        when(mockSettingsManager.getAgentConfig()).thenReturn(agentConfig);
+        when(mockToolRegistry.getToolDefinitions()).thenReturn(new JsonArray());
+    }
+
+    private AgentLoop createLoop() {
+        return new AgentLoop(mockApiService, mockToolRegistry, mockSettingsManager);
+    }
+
+    private List<ChatMessage> simpleConversation() {
+        List<ChatMessage> conversation = new ArrayList<>();
+        conversation.add(new ChatMessage("Hello", ChatMessage.TYPE_USER));
+        return conversation;
+    }
+
+    @Test
+    public void streamingEnabledByDefault_fromAgentConfig() {
+        AgentLoop loop = createLoop();
+        assertTrue("Streaming should be enabled by default", loop.isStreamingEnabled());
+    }
+
+    @Test
+    public void streamingDisabled_whenConfiguredOff() {
+        agentConfig.setStreamResponses(false);
+        AgentLoop loop = createLoop();
+        assertFalse(loop.isStreamingEnabled());
+    }
+
+    @Test
+    public void noSettingsManager_fallsBackToLegacyPath() {
+        AgentLoop loop = new AgentLoop(mockApiService, mockToolRegistry, null);
+        assertFalse("Null settings manager must keep the legacy path",
+                loop.isStreamingEnabled());
+    }
+
+    @Test
+    public void streamingPath_forwardsDeltasAndCompletes() {
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                LlmApiService.StreamingChatCallback callback =
+                        invocation.getArgument(3, LlmApiService.StreamingChatCallback.class);
+                callback.onDelta("Hello ");
+                callback.onDelta("world");
+                callback.onSuccess(new LlmApiService.LlmResponse("Hello world", null));
+                return null;
+            }
+        }).when(mockApiService).sendMessageWithToolsStreaming(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.StreamingChatCallback.class));
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+
+        verify(mockCallback).onStreamDelta("Hello ");
+        verify(mockCallback).onStreamDelta("world");
+        verify(mockCallback).onComplete(eq("Hello world"), anyList());
+        verify(mockCallback, never()).onError(anyString());
+        verify(mockApiService, never()).sendMessageWithTools(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.ChatCallbackWithTools.class));
+    }
+
+    @Test
+    public void streamingPath_errorPropagates() {
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                LlmApiService.StreamingChatCallback callback =
+                        invocation.getArgument(3, LlmApiService.StreamingChatCallback.class);
+                callback.onDelta("par");
+                callback.onError("Stream read error: timeout");
+                return null;
+            }
+        }).when(mockApiService).sendMessageWithToolsStreaming(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.StreamingChatCallback.class));
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+
+        verify(mockCallback).onStreamDelta("par");
+        verify(mockCallback).onError(contains("timeout"));
+        verify(mockCallback, never()).onComplete(anyString(), anyList());
+    }
+
+    @Test
+    public void legacyPath_usedWhenStreamingDisabled() {
+        agentConfig.setStreamResponses(false);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                LlmApiService.ChatCallbackWithTools callback =
+                        invocation.getArgument(3, LlmApiService.ChatCallbackWithTools.class);
+                callback.onSuccess(new LlmApiService.LlmResponse("Legacy response", null));
+                return null;
+            }
+        }).when(mockApiService).sendMessageWithTools(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.ChatCallbackWithTools.class));
+
+        AgentLoop loop = createLoop();
+        loop.start(simpleConversation(), mockCallback);
+
+        verify(mockApiService).sendMessageWithTools(anyList(), any(JsonArray.class),
+                any(), any(LlmApiService.ChatCallbackWithTools.class));
+        verify(mockApiService, never()).sendMessageWithToolsStreaming(anyList(),
+                any(JsonArray.class), any(), any(LlmApiService.StreamingChatCallback.class));
+        verify(mockCallback).onComplete(eq("Legacy response"), anyList());
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/api/SseStreamAccumulatorTest.java
+++ b/app/src/test/java/io/finett/droidclaw/api/SseStreamAccumulatorTest.java
@@ -1,0 +1,351 @@
+package io.finett.droidclaw.api;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.finett.droidclaw.api.LlmApiService.LlmResponse;
+import io.finett.droidclaw.api.LlmApiService.ToolCall;
+
+/**
+ * Unit tests for {@link SseStreamAccumulator} — SSE framing plus both the
+ * OpenAI and Anthropic streaming dialects.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class SseStreamAccumulatorTest {
+
+    private List<String> feedAll(SseStreamAccumulator acc, String rawStream) {
+        List<String> deltas = new ArrayList<>();
+        for (String line : rawStream.split("\n", -1)) {
+            acc.feedLine(line);
+        }
+        acc.finish();
+        return deltas;
+    }
+
+    private SseStreamAccumulator openAiAccumulator(List<String> deltas) {
+        return new SseStreamAccumulator(LlmApiService.API_OPENAI, deltas::add);
+    }
+
+    private SseStreamAccumulator anthropicAccumulator(List<String> deltas) {
+        return new SseStreamAccumulator(LlmApiService.API_ANTHROPIC, deltas::add);
+    }
+
+    // ==================== OpenAI dialect ====================
+
+    @Test
+    public void openAi_textDeltas_accumulateAndNotify() {
+        List<String> deltas = new ArrayList<>();
+        String stream =
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n" +
+                "\n" +
+                "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n" +
+                "\n" +
+                "data: [DONE]\n" +
+                "\n";
+        feedAll(openAiAccumulator(deltas), stream);
+
+        assertEquals(List.of("Hello", " world"), deltas);
+    }
+
+    @Test
+    public void openAi_finalResponse_assemblesContentAndDoneFlag() {
+        List<String> deltas = new ArrayList<>();
+        SseStreamAccumulator acc = openAiAccumulator(deltas);
+        feedAll(acc,
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n" +
+                "\n" +
+                "data: {\"choices\":[{\"delta\":{}}]}\n" +
+                "\n" +
+                "data: [DONE]\n" +
+                "\n");
+
+        assertTrue("DONE sentinel should be recorded", acc.isDone());
+        LlmResponse response = acc.buildResponse();
+        assertEquals("Hi", response.getContent());
+        assertFalse("No tool calls expected", response.hasToolCalls());
+    }
+
+    @Test
+    public void openAi_toolCalls_accumulatedAcrossFragments() {
+        List<String> deltas = new ArrayList<>();
+        String stream =
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\"," +
+                "\"function\":{\"name\":\"file_read\",\"arguments\":\"{\\\"pa\"}}]}}]}\n" +
+                "\n" +
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0," +
+                "\"function\":{\"arguments\":\"th\\\":\\\"a.txt\\\"}\"}}]}}]}\n" +
+                "\n" +
+                "data: [DONE]\n" +
+                "\n";
+        feedAll(openAiAccumulator(deltas), stream);
+
+        // Rebuild to inspect tool calls
+        SseStreamAccumulator acc = openAiAccumulator(new ArrayList<>());
+        feedAll(acc, stream);
+        LlmResponse response = acc.buildResponse();
+
+        assertTrue(response.hasToolCalls());
+        assertEquals(1, response.getToolCalls().size());
+        ToolCall tc = response.getToolCalls().get(0);
+        assertEquals("call_1", tc.getId());
+        assertEquals("file_read", tc.getName());
+        assertEquals("a.txt", tc.getArguments().get("path").getAsString());
+    }
+
+    @Test
+    public void openAi_multipleToolCalls_orderedByIndex() {
+        SseStreamAccumulator acc = openAiAccumulator(new ArrayList<>());
+        // Deliver index 1 before index 0 to verify index-based ordering.
+        feedAll(acc,
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_b\"," +
+                "\"function\":{\"name\":\"second\",\"arguments\":\"{}\"}}]}}]}\n" +
+                "\n" +
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\"," +
+                "\"function\":{\"name\":\"first\",\"arguments\":\"{}\"}}]}}]}\n" +
+                "\n" +
+                "data: [DONE]\n" +
+                "\n");
+
+        LlmResponse response = acc.buildResponse();
+        assertEquals(2, response.getToolCalls().size());
+        assertEquals("first", response.getToolCalls().get(0).getName());
+        assertEquals("second", response.getToolCalls().get(1).getName());
+    }
+
+    @Test
+    public void openAi_usageChunk_capturedFromTrailingUsageEvent() {
+        SseStreamAccumulator acc = openAiAccumulator(new ArrayList<>());
+        feedAll(acc,
+                "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n" +
+                "\n" +
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5," +
+                "\"total_tokens\":15}}\n" +
+                "\n" +
+                "data: [DONE]\n" +
+                "\n");
+
+        LlmResponse response = acc.buildResponse();
+        assertNotNull("Usage should be present", response.getUsage());
+        assertEquals(10, response.getUsage().getPromptTokens());
+        assertEquals(5, response.getUsage().getCompletionTokens());
+        assertEquals(15, response.getUsage().getTotalTokens());
+    }
+
+    @Test
+    public void openAi_noUsage_usageIsNull() {
+        SseStreamAccumulator acc = openAiAccumulator(new ArrayList<>());
+        feedAll(acc,
+                "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n" +
+                "\n" +
+                "data: [DONE]\n\n");
+
+        assertNull(acc.buildResponse().getUsage());
+    }
+
+    @Test
+    public void openAi_malformedChunk_skippedWithoutCrash() {
+        SseStreamAccumulator acc = openAiAccumulator(new ArrayList<>());
+        feedAll(acc,
+                "data: {not valid json\n" +
+                "\n" +
+                "data: {\"choices\":[{\"delta\":{\"content\":\"still alive\"}}]}\n" +
+                "\n" +
+                "data: [DONE]\n\n");
+
+        assertEquals("still alive", acc.buildResponse().getContent());
+    }
+
+    // ==================== Anthropic dialect ====================
+
+    @Test
+    public void anthropic_textDeltas_accumulateAndNotify() {
+        List<String> deltas = new ArrayList<>();
+        String stream =
+                "event: message_start\n" +
+                "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":7}}}\n" +
+                "\n" +
+                "event: content_block_start\n" +
+                "data: {\"type\":\"content_block_start\",\"index\":0," +
+                "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+                "\n" +
+                "event: content_block_delta\n" +
+                "data: {\"type\":\"content_block_delta\",\"index\":0," +
+                "\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n" +
+                "\n" +
+                "event: content_block_delta\n" +
+                "data: {\"type\":\"content_block_delta\",\"index\":0," +
+                "\"delta\":{\"type\":\"text_delta\",\"text\":\" there\"}}\n" +
+                "\n" +
+                "event: message_delta\n" +
+                "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":3}," +
+                "\"stop_reason\":\"end_turn\"}\n" +
+                "\n" +
+                "event: message_stop\n" +
+                "data: {\"type\":\"message_stop\"}\n" +
+                "\n";
+        feedAll(anthropicAccumulator(deltas), stream);
+
+        assertEquals(List.of("Hello", " there"), deltas);
+    }
+
+    @Test
+    public void anthropic_usage_combinedFromMessageStartAndDelta() {
+        SseStreamAccumulator acc = anthropicAccumulator(new ArrayList<>());
+        feedAll(acc,
+                "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":12}}}\n" +
+                "\n" +
+                "data: {\"type\":\"content_block_delta\",\"index\":0," +
+                "\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}\n" +
+                "\n" +
+                "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":4}}\n" +
+                "\n");
+
+        LlmResponse response = acc.buildResponse();
+        assertNotNull(response.getUsage());
+        assertEquals(12, response.getUsage().getPromptTokens());
+        assertEquals(4, response.getUsage().getCompletionTokens());
+        assertEquals(16, response.getUsage().getTotalTokens());
+    }
+
+    @Test
+    public void anthropic_toolUse_partialJsonAccumulated() {
+        SseStreamAccumulator acc = anthropicAccumulator(new ArrayList<>());
+        feedAll(acc,
+                "data: {\"type\":\"content_block_start\",\"index\":0," +
+                "\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"execute_shell\"," +
+                "\"input\":{}}}\n" +
+                "\n" +
+                "data: {\"type\":\"content_block_delta\",\"index\":0," +
+                "\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"comm\"}}\n" +
+                "\n" +
+                "data: {\"type\":\"content_block_delta\",\"index\":0," +
+                "\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"and\\\":\\\"ls\\\"}\"}}\n" +
+                "\n" +
+                "data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+                "\n");
+
+        LlmResponse response = acc.buildResponse();
+        assertTrue(response.hasToolCalls());
+        ToolCall tc = response.getToolCalls().get(0);
+        assertEquals("toolu_1", tc.getId());
+        assertEquals("execute_shell", tc.getName());
+        assertEquals("ls", tc.getArguments().get("command").getAsString());
+    }
+
+    @Test
+    public void anthropic_mixedTextAndToolUse_textStreamedToolAccumulated() {
+        List<String> deltas = new ArrayList<>();
+        SseStreamAccumulator acc = anthropicAccumulator(deltas);
+        feedAll(acc,
+                "data: {\"type\":\"content_block_start\",\"index\":0," +
+                "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+                "\n" +
+                "data: {\"type\":\"content_block_delta\",\"index\":0," +
+                "\"delta\":{\"type\":\"text_delta\",\"text\":\"Let me check.\"}}\n" +
+                "\n" +
+                "data: {\"type\":\"content_block_start\",\"index\":1," +
+                "\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_2\",\"name\":\"file_read\"," +
+                "\"input\":{}}}\n" +
+                "\n" +
+                "data: {\"type\":\"content_block_delta\",\"index\":1," +
+                "\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"f.txt\\\"}\"}}\n" +
+                "\n");
+
+        assertEquals(List.of("Let me check."), deltas);
+        LlmResponse response = acc.buildResponse();
+        assertEquals("Let me check.", response.getContent());
+        assertEquals(1, response.getToolCalls().size());
+        assertEquals("file_read", response.getToolCalls().get(0).getName());
+    }
+
+    @Test
+    public void anthropic_errorEvent_setsError() {
+        SseStreamAccumulator acc = anthropicAccumulator(new ArrayList<>());
+        feedAll(acc,
+                "data: {\"type\":\"content_block_delta\",\"index\":0," +
+                "\"delta\":{\"type\":\"text_delta\",\"text\":\"partial\"}}\n" +
+                "\n" +
+                "data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\"," +
+                "\"message\":\"Overloaded\"}}\n" +
+                "\n");
+
+        assertTrue(acc.hasError());
+        assertTrue(acc.getError().contains("Overloaded"));
+        // Partial text still accumulated for inspection
+        assertEquals("partial", acc.getContent());
+    }
+
+    // ==================== SSE framing ====================
+
+    @Test
+    public void sseFraming_commentsAndKeepAlivesIgnored() {
+        List<String> deltas = new ArrayList<>();
+        SseStreamAccumulator acc = openAiAccumulator(deltas);
+        feedAll(acc,
+                ": keep-alive ping\n" +
+                "\n" +
+                "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n" +
+                "\n" +
+                ": another comment\n" +
+                "data: [DONE]\n" +
+                "\n");
+
+        assertEquals(List.of("a"), deltas);
+    }
+
+    @Test
+    public void sseFraming_trailingEventWithoutBlankLine_flushedByFinish() {
+        List<String> deltas = new ArrayList<>();
+        SseStreamAccumulator acc = openAiAccumulator(deltas);
+        // No trailing blank line — common when the connection closes right after.
+        acc.feedLine("data: {\"choices\":[{\"delta\":{\"content\":\"tail\"}}]}");
+        acc.finish();
+
+        assertEquals(List.of("tail"), deltas);
+    }
+
+    @Test
+    public void sseFraming_dataWithoutSpaceAfterColon() {
+        List<String> deltas = new ArrayList<>();
+        SseStreamAccumulator acc = openAiAccumulator(deltas);
+        // SSE allows "data:" with no space before the payload.
+        feedAll(acc,
+                "data:{\"choices\":[{\"delta\":{\"content\":\"nospace\"}}]}\n" +
+                "\n" +
+                "data: [DONE]\n\n");
+
+        assertEquals(List.of("nospace"), deltas);
+    }
+
+    @Test
+    public void emptyStream_fallbackContent() {
+        SseStreamAccumulator acc = openAiAccumulator(new ArrayList<>());
+        acc.finish();
+
+        LlmResponse response = acc.buildResponse();
+        assertEquals("No response received", response.getContent());
+        assertFalse(response.hasToolCalls());
+        assertNull(response.getUsage());
+    }
+
+    @Test
+    public void openAi_toolCallWithMalformedArguments_emptyArgsFallback() {
+        SseStreamAccumulator acc = openAiAccumulator(new ArrayList<>());
+        feedAll(acc,
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_x\"," +
+                "\"function\":{\"name\":\"some_tool\",\"arguments\":\"{broken\"}}]}}]}\n" +
+                "\n" +
+                "data: [DONE]\n\n");
+
+        LlmResponse response = acc.buildResponse();
+        assertTrue(response.hasToolCalls());
+        assertEquals("some_tool", response.getToolCalls().get(0).getName());
+        assertNotNull(response.getToolCalls().get(0).getArguments());
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
@@ -138,6 +138,21 @@ public class SettingsManagerTest {
     }
 
     @Test
+    public void streamResponses_defaultIsTrue() {
+        assertTrue(settingsManager.getAgentConfig().isStreamResponses());
+    }
+
+    @Test
+    public void streamResponses_persistsAcrossInstances() {
+        AgentConfig config = settingsManager.getAgentConfig();
+        config.setStreamResponses(false);
+        settingsManager.setAgentConfig(config);
+
+        SettingsManager newInstance = new SettingsManager(context);
+        assertFalse(newInstance.getAgentConfig().isStreamResponses());
+    }
+
+    @Test
     public void setDefaultModel_storesValue() {
         Provider provider = createTestProvider("test-provider", "Test Provider",
                 "https://api.test.com", "test-api-key");

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -25,6 +25,8 @@ Adjust how the agent interacts and processes tasks:
 
 - **Max Iterations**: Limits how many steps the agent can take in a single loop to prevent infinite loops or excessive API usage.
 - **Context Window**: Configure how much conversation history is sent to the model.
+- **Require Approval**: Ask for confirmation before executing tools that change state.
+- **Stream Responses**: When enabled (default), LLM text is streamed live over SSE as it is generated, instead of waiting for the full answer. Disable it if a provider does not support streaming.
 - **System Prompt**: Customize the "Soul" of your agent. This defines its personality and core instructions.
 
 ## Filesystem & Workspace


### PR DESCRIPTION
## What

Adds Server-Sent-Events (SSE) streaming for LLM chat responses, so text renders live as it is generated instead of waiting for the full completion. Also fixes an Android 15 crash discovered while validating on a real device.

## Changes

### SSE streaming (`6b45b4a`)
- **`SseStreamAccumulator`** (new) — reusable SSE parser handling both OpenAI (`data:` chunks, `[DONE]`, fragmented tool-call arguments, trailing `usage`) and Anthropic (`content_block_delta`, `input_json_delta`, `message_delta` usage, `error` events) streaming dialects.
- **`LlmApiService`** — new `sendMessageWithToolsStreaming()`: sends `stream: true` (requests `stream_options.include_usage` on OpenAI), reads the event stream via okio, emits deltas on the main thread, and delivers the final assembled `LlmResponse` (text + tool calls + usage) exactly like the non-streaming path.
- **`AgentLoop`** — new `AgentCallback.onStreamDelta` (default no-op); streams when enabled; null `SettingsManager` keeps the legacy path. Extracted `trackTokenUsage()`.
- **`AgentExecutionService`** — forwards deltas to `UICallback.onStreamDelta` (default no-op).
- **`ChatFragment`** — renders a temporary streaming bubble with 80 ms throttled markdown re-renders, replaced by canonical history on completion; partial bubble discarded on error; a new bubble starts per text segment across tool-call iterations.
- **Settings** — new `streamResponses` agent setting (default **on**), persisted in `AgentConfig`/`SettingsManager`, with a "Stream Responses" toggle in Agent Settings.
- **Docs** — `docs/user/settings.md` updated.

### Android 15 foreground-service crash fix (`0d290db`)
Found by instrumented tests on a physical Android 15 device: `BackgroundProcessService` stopped itself immediately on `ACTION_STOP`. If new work was submitted right after, `startForegroundService()` landed on the dying service record and the OS killed the process with `ForegroundServiceDidNotStartInTimeException`.
- `ACTION_STOP` now ignores stale stop intents when work is running and otherwise schedules teardown after a 3 s grace period, re-checking the running count before stopping.
- New work cancels the pending stop; `onStartCommand` re-asserts `startForeground()` for every start intent (pairing each `startForegroundService()` as the contract requires).

## Testing

- **Unit tests**: 1,411 pass, including 25 new (`SseStreamAccumulatorTest` ×17, `AgentLoopStreamingTest` ×6, streaming settings round-trip ×2).
- **Lint**: clean.
- **Instrumented tests on a physical device** (Infinix X6851B, Android 15): **767/767 pass** after the FGS fix (initially the suite crashed the process on `killTool_runningProcess_killsIt`, which is what exposed the race).

## Compatibility notes

- Streaming is on by default but toggleable per-agent in Settings for providers without SSE support.
- Non-streaming code path is unchanged and used when streaming is disabled or no `SettingsManager` is present.
- `AgentCallback.onStreamDelta` / `UICallback.onStreamDelta` are `default` interface methods — existing implementations compile unchanged.

> Note for local device testing: if a differently-signed `io.finett.droidclaw` exists in a secondary profile (e.g. Second Space), Gradle's `installDebug` fails with `INSTALL_FAILED_UPDATE_INCOMPATIBLE`; install for user 0 with `adb shell pm install --user 0 -r -t <apk>` or remove the conflicting copy.