### PR TITLE
feat(calendar): add CalendarContract-backed agent tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ The agent uses an iterative tool-calling loop (`AgentLoop.java`):
 - `read_file`, `write_file`, `edit_file`, `list_files`, `delete_file`, `search_files`, `file_info` - Virtual filesystem
 - `execute_shell` - Shell commands (requires shell access)
 - `execute_python` / `pip_install` - Python execution (requires shell access)
+- `calendar_list_calendars`, `calendar_list_events`, `calendar_create_event`, `calendar_update_event`, `calendar_delete_event` - Device calendar via `CalendarContract` (requires `calendarEnabled` + READ/WRITE_CALENDAR permissions; write tools require approval)
 
 ### Skills System
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,6 +158,7 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-contrib:3.6.1")
     androidTestImplementation(libs.test.core)
     androidTestImplementation(libs.test.runner)
+    androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation(libs.navigation.testing)
     debugImplementation(libs.fragment.testing)
     androidTestImplementation(libs.fragment.testing)

--- a/app/src/androidTest/java/io/finett/droidclaw/calendar/CalendarRepositoryInstrumentedTest.java
+++ b/app/src/androidTest/java/io/finett/droidclaw/calendar/CalendarRepositoryInstrumentedTest.java
@@ -1,0 +1,326 @@
+package io.finett.droidclaw.calendar;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.Manifest;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.CalendarContract;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SdkSuppress;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Instrumented tests for {@link CalendarRepository} against the real device
+ * CalendarProvider.
+ *
+ * <p>Each run creates a dedicated throwaway calendar (inserted as a sync
+ * adapter under a private test account), performs CRUD through the
+ * repository, and removes the calendar in {@link #tearDown()} — deleting a
+ * calendar also deletes its events. If the device's provider rejects
+ * third-party calendar creation (some OEM builds do), the tests are skipped.
+ *
+ * <p>Requires API 28+ because runtime permissions are granted via
+ * UiAutomation ({@code GrantPermissionRule}).
+ */
+@RunWith(AndroidJUnit4.class)
+@SdkSuppress(minSdkVersion = 28)
+public class CalendarRepositoryInstrumentedTest {
+
+    private static final String TEST_ACCOUNT_NAME = "droidclaw.instrumented.test";
+    private static final String TEST_ACCOUNT_TYPE = "io.finett.droidclaw.test";
+    private static final String TEST_CALENDAR_NAME = "DroidClaw Instrumented Test Calendar";
+
+    private static final long HOUR_MS = 3600 * 1000L;
+    private static final long DAY_MS = 24 * HOUR_MS;
+
+    @Rule
+    public androidx.test.rule.GrantPermissionRule permissionRule =
+            androidx.test.rule.GrantPermissionRule.grant(
+                    Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR);
+
+    private CalendarRepository repository;
+    private long testCalendarId = -1;
+    private long baseMillis;
+
+    @Before
+    public void setUp() {
+        repository = new CalendarRepository(getApplicationContext());
+        // Anchor event times in the near future; some providers behave oddly
+        // with events far in the past.
+        baseMillis = (System.currentTimeMillis() / HOUR_MS) * HOUR_MS + DAY_MS;
+
+        testCalendarId = createTestCalendar();
+        Assume.assumeTrue(
+                "Device CalendarProvider rejected test calendar creation — skipping",
+                testCalendarId != -1);
+    }
+
+    @After
+    public void tearDown() {
+        if (testCalendarId != -1) {
+            deleteCalendar(testCalendarId);
+        }
+    }
+
+    // ==================== Calendars ====================
+
+    @Test
+    public void getCalendars_containsTestCalendar_andItIsWritable() {
+        List<CalendarInfo> calendars = repository.getCalendars();
+
+        CalendarInfo found = null;
+        for (CalendarInfo calendar : calendars) {
+            if (calendar.getId() == testCalendarId) {
+                found = calendar;
+                break;
+            }
+        }
+
+        assertNotNull("Test calendar should be listed", found);
+        assertEquals(TEST_CALENDAR_NAME, found.getDisplayName());
+        assertEquals(TEST_ACCOUNT_NAME, found.getAccountName());
+        assertTrue("Test calendar should be writable", found.isWritable());
+        assertTrue(repository.hasWritableCalendar());
+    }
+
+    // ==================== Create / read round-trip ====================
+
+    @Test
+    public void createEvent_thenGetEvent_roundTripsAllFields() {
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(testCalendarId);
+        spec.setTitle("Instrumented Meeting");
+        spec.setLocation("Conference Room 3");
+        spec.setDescription("Created by CalendarRepositoryInstrumentedTest");
+        spec.setDtStart(baseMillis);
+        spec.setDtEnd(baseMillis + HOUR_MS);
+        spec.setTimezone(TimeZone.getDefault().getID());
+
+        long eventId = repository.createEvent(spec);
+        assertTrue(eventId > 0);
+
+        CalendarEvent event = repository.getEvent(eventId);
+        assertNotNull(event);
+        assertEquals("Instrumented Meeting", event.getTitle());
+        assertEquals("Conference Room 3", event.getLocation());
+        assertEquals("Created by CalendarRepositoryInstrumentedTest", event.getDescription());
+        assertEquals(baseMillis, event.getStartMillis());
+        assertEquals(baseMillis + HOUR_MS, event.getEndMillis());
+        assertEquals(testCalendarId, event.getCalendarId());
+        assertEquals(TEST_CALENDAR_NAME, event.getCalendarName());
+        assertFalse(event.isAllDay());
+        assertFalse(event.isRecurring());
+    }
+
+    @Test
+    public void createEvent_allDay_setsFlag() {
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(testCalendarId);
+        spec.setTitle("Instrumented Holiday");
+        spec.setAllDay(true);
+        spec.setDtStart(baseMillis);
+
+        long eventId = repository.createEvent(spec);
+
+        CalendarEvent event = repository.getEvent(eventId);
+        assertNotNull(event);
+        assertTrue(event.isAllDay());
+    }
+
+    @Test
+    public void createEvent_withReminders_insertsReminderRows() {
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(testCalendarId);
+        spec.setTitle("Instrumented Reminder Test");
+        spec.setDtStart(baseMillis);
+        spec.setDtEnd(baseMillis + HOUR_MS);
+        spec.setReminders(Arrays.asList(30, 1440));
+
+        long eventId = repository.createEvent(spec);
+
+        assertEquals(2, countReminders(eventId));
+    }
+
+    // ==================== Query ====================
+
+    @Test
+    public void queryEvents_returnsCreatedEventInWindow() {
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(testCalendarId);
+        spec.setTitle("Window Probe");
+        spec.setDtStart(baseMillis);
+        spec.setDtEnd(baseMillis + HOUR_MS);
+        repository.createEvent(spec);
+
+        List<CalendarEvent> events = repository.queryEvents(
+                baseMillis - DAY_MS, baseMillis + DAY_MS, testCalendarId, null, 100);
+
+        assertEquals(1, events.size());
+        assertEquals("Window Probe", events.get(0).getTitle());
+        assertEquals(TEST_CALENDAR_NAME, events.get(0).getCalendarName());
+    }
+
+    @Test
+    public void queryEvents_textQuery_matchesTitle() {
+        EventSpec match = new EventSpec();
+        match.setCalendarId(testCalendarId);
+        match.setTitle("Unique Dentist Probe");
+        match.setDtStart(baseMillis);
+        match.setDtEnd(baseMillis + HOUR_MS);
+        repository.createEvent(match);
+
+        EventSpec other = new EventSpec();
+        other.setCalendarId(testCalendarId);
+        other.setTitle("Something else");
+        other.setDtStart(baseMillis + 2 * HOUR_MS);
+        other.setDtEnd(baseMillis + 3 * HOUR_MS);
+        repository.createEvent(other);
+
+        List<CalendarEvent> events = repository.queryEvents(
+                baseMillis - DAY_MS, baseMillis + DAY_MS, testCalendarId, "dentist", 100);
+
+        assertEquals(1, events.size());
+        assertEquals("Unique Dentist Probe", events.get(0).getTitle());
+    }
+
+    @Test
+    public void queryEvents_windowExcludesDistantEvent() {
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(testCalendarId);
+        spec.setTitle("Far Future Event");
+        spec.setDtStart(baseMillis + 30 * DAY_MS);
+        spec.setDtEnd(baseMillis + 30 * DAY_MS + HOUR_MS);
+        repository.createEvent(spec);
+
+        List<CalendarEvent> events = repository.queryEvents(
+                baseMillis, baseMillis + DAY_MS, testCalendarId, null, 100);
+
+        assertEquals(0, events.size());
+    }
+
+    // ==================== Update / delete ====================
+
+    @Test
+    public void updateEvent_changesTitleAndMovesTime() {
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(testCalendarId);
+        spec.setTitle("Before Move");
+        spec.setDtStart(baseMillis);
+        spec.setDtEnd(baseMillis + HOUR_MS);
+        long eventId = repository.createEvent(spec);
+
+        EventSpec update = new EventSpec();
+        update.setTitle("After Move");
+        update.setDtStart(baseMillis + 2 * DAY_MS);
+        update.setDtEnd(baseMillis + 2 * DAY_MS + HOUR_MS);
+
+        assertTrue(repository.updateEvent(eventId, update));
+
+        CalendarEvent event = repository.getEvent(eventId);
+        assertNotNull(event);
+        assertEquals("After Move", event.getTitle());
+        assertEquals(baseMillis + 2 * DAY_MS, event.getStartMillis());
+        assertEquals(baseMillis + 2 * DAY_MS + HOUR_MS, event.getEndMillis());
+    }
+
+    @Test
+    public void deleteEvent_removesEvent() {
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(testCalendarId);
+        spec.setTitle("Doomed Event");
+        spec.setDtStart(baseMillis);
+        spec.setDtEnd(baseMillis + HOUR_MS);
+        long eventId = repository.createEvent(spec);
+
+        assertTrue(repository.deleteEvent(eventId));
+        assertNull(repository.getEvent(eventId));
+    }
+
+    @Test
+    public void deleteEvent_unknownId_returnsFalse() {
+        assertFalse(repository.deleteEvent(999_999_999L));
+    }
+
+    // ==================== Test calendar lifecycle ====================
+
+    /**
+     * Creates the throwaway calendar as a sync adapter. Returns the calendar
+     * id, or -1 if the provider rejected the insert (test is skipped then).
+     */
+    private long createTestCalendar() {
+        ContentValues values = new ContentValues();
+        values.put(CalendarContract.Calendars.ACCOUNT_NAME, TEST_ACCOUNT_NAME);
+        values.put(CalendarContract.Calendars.ACCOUNT_TYPE, TEST_ACCOUNT_TYPE);
+        values.put(CalendarContract.Calendars.NAME, TEST_CALENDAR_NAME);
+        values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, TEST_CALENDAR_NAME);
+        values.put(CalendarContract.Calendars.OWNER_ACCOUNT, TEST_ACCOUNT_NAME);
+        values.put(CalendarContract.Calendars.CALENDAR_COLOR, 0xFF33B5E5);
+        values.put(CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
+                CalendarContract.Calendars.CAL_ACCESS_OWNER);
+        values.put(CalendarContract.Calendars.CALENDAR_TIME_ZONE,
+                TimeZone.getDefault().getID());
+        values.put(CalendarContract.Calendars.VISIBLE, 1);
+        values.put(CalendarContract.Calendars.SYNC_EVENTS, 1);
+
+        Uri uri = getApplicationContext().getContentResolver()
+                .insert(syncAdapterCalendarsUri(), values);
+        if (uri == null) {
+            return -1;
+        }
+        return ContentUris.parseId(uri);
+    }
+
+    private void deleteCalendar(long calendarId) {
+        ContentResolver resolver = getApplicationContext().getContentResolver();
+        // Deleting via the item URI; fall back to a selection-based delete
+        // scoped to the test account for providers that ignore item deletes.
+        int deleted = resolver.delete(
+                ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId),
+                null, null);
+        if (deleted == 0) {
+            resolver.delete(syncAdapterCalendarsUri(),
+                    CalendarContract.Calendars._ID + " = ?",
+                    new String[]{String.valueOf(calendarId)});
+        }
+    }
+
+    private static Uri syncAdapterCalendarsUri() {
+        return CalendarContract.Calendars.CONTENT_URI.buildUpon()
+                .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+                .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, TEST_ACCOUNT_NAME)
+                .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, TEST_ACCOUNT_TYPE)
+                .build();
+    }
+
+    private static int countReminders(long eventId) {
+        ContentResolver resolver = getApplicationContext().getContentResolver();
+        try (Cursor cursor = resolver.query(
+                CalendarContract.Reminders.CONTENT_URI,
+                new String[]{CalendarContract.Reminders._ID},
+                CalendarContract.Reminders.EVENT_ID + " = ?",
+                new String[]{String.valueOf(eventId)},
+                null)) {
+            return cursor == null ? 0 : cursor.getCount();
+        }
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
 
     <application
         android:name=".DroidClawApplication"

--- a/app/src/main/java/io/finett/droidclaw/calendar/CalendarDataSource.java
+++ b/app/src/main/java/io/finett/droidclaw/calendar/CalendarDataSource.java
@@ -1,0 +1,57 @@
+package io.finett.droidclaw.calendar;
+
+import java.util.List;
+
+/**
+ * Abstraction over the device calendar store, implemented by
+ * {@link CalendarRepository} (Android CalendarContract). Tools depend on this
+ * interface so they can be unit-tested with fakes.
+ */
+public interface CalendarDataSource {
+
+    /** All calendars known to the device, sorted by display name. */
+    List<CalendarInfo> getCalendars();
+
+    /**
+     * Look up a single event by its id, or {@code null} when not found.
+     * For recurring events this returns the series definition row.
+     */
+    CalendarEvent getEvent(long eventId);
+
+    /**
+     * Event occurrences within {@code [beginMillis, endMillis)} (recurring
+     * events are expanded). Optionally filtered by calendar and by a text
+     * match on title/location/description.
+     *
+     * @param calendarId nullable; restrict to one calendar
+     * @param textQuery  nullable; case-insensitive substring match
+     * @param limit      maximum number of occurrences to return
+     */
+    List<CalendarEvent> queryEvents(long beginMillis, long endMillis,
+                                    Long calendarId, String textQuery, int limit);
+
+    /**
+     * Insert a new event. Returns the new event id.
+     *
+     * @throws CalendarException on validation or provider failure
+     */
+    long createEvent(EventSpec spec);
+
+    /**
+     * Update fields of an existing event (non-null spec fields only).
+     *
+     * @return true if the event was found and updated
+     * @throws CalendarException on validation or provider failure
+     */
+    boolean updateEvent(long eventId, EventSpec spec);
+
+    /**
+     * Delete an event (whole series for recurring events).
+     *
+     * @return true if the event was found and deleted
+     */
+    boolean deleteEvent(long eventId);
+
+    /** Whether the device has at least one writable calendar. */
+    boolean hasWritableCalendar();
+}

--- a/app/src/main/java/io/finett/droidclaw/calendar/CalendarEvent.java
+++ b/app/src/main/java/io/finett/droidclaw/calendar/CalendarEvent.java
@@ -1,0 +1,119 @@
+package io.finett.droidclaw.calendar;
+
+import com.google.gson.JsonObject;
+
+/**
+ * One calendar event occurrence (from {@code CalendarContract.Instances}).
+ * Recurring events appear once per occurrence within the queried window.
+ */
+public class CalendarEvent {
+    /** Cap applied to long text fields so tool output stays bounded. */
+    private static final int MAX_FIELD_LENGTH = 500;
+
+    private final long eventId;
+    private final long calendarId;
+    private final String calendarName;
+    private final String title;
+    private final long startMillis;
+    private final long endMillis;
+    private final boolean allDay;
+    private final String location;
+    private final String description;
+    private final String timezone;
+    private final boolean recurring;
+
+    public CalendarEvent(long eventId, long calendarId, String calendarName, String title,
+                         long startMillis, long endMillis, boolean allDay,
+                         String location, String description, String timezone,
+                         boolean recurring) {
+        this.eventId = eventId;
+        this.calendarId = calendarId;
+        this.calendarName = calendarName != null ? calendarName : "";
+        this.title = title != null ? title : "";
+        this.startMillis = startMillis;
+        this.endMillis = endMillis;
+        this.allDay = allDay;
+        this.location = location != null ? location : "";
+        this.description = description != null ? description : "";
+        this.timezone = timezone != null ? timezone : "";
+        this.recurring = recurring;
+    }
+
+    public long getEventId() {
+        return eventId;
+    }
+
+    public long getCalendarId() {
+        return calendarId;
+    }
+
+    public String getCalendarName() {
+        return calendarName;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public long getStartMillis() {
+        return startMillis;
+    }
+
+    public long getEndMillis() {
+        return endMillis;
+    }
+
+    public boolean isAllDay() {
+        return allDay;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public boolean isRecurring() {
+        return recurring;
+    }
+
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        json.addProperty("event_id", eventId);
+        json.addProperty("calendar_id", calendarId);
+        if (!calendarName.isEmpty()) {
+            json.addProperty("calendar", calendarName);
+        }
+        json.addProperty("title", truncate(title));
+        if (allDay) {
+            json.addProperty("all_day", true);
+            json.addProperty("date", CalendarTimeUtil.format(startMillis));
+        } else {
+            json.addProperty("start", CalendarTimeUtil.format(startMillis));
+            json.addProperty("end", CalendarTimeUtil.format(endMillis));
+        }
+        if (!location.isEmpty()) {
+            json.addProperty("location", truncate(location));
+        }
+        if (!description.isEmpty()) {
+            json.addProperty("description", truncate(description));
+        }
+        if (recurring) {
+            json.addProperty("recurring", true);
+        }
+        return json;
+    }
+
+    private static String truncate(String s) {
+        if (s.length() <= MAX_FIELD_LENGTH) {
+            return s;
+        }
+        return s.substring(0, MAX_FIELD_LENGTH) + "...";
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/calendar/CalendarException.java
+++ b/app/src/main/java/io/finett/droidclaw/calendar/CalendarException.java
@@ -1,0 +1,16 @@
+package io.finett.droidclaw.calendar;
+
+/**
+ * Raised by {@link CalendarDataSource} implementations for any calendar
+ * operation failure. The message is user/LLM-readable and is surfaced
+ * verbatim as the tool error.
+ */
+public class CalendarException extends RuntimeException {
+    public CalendarException(String message) {
+        super(message);
+    }
+
+    public CalendarException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/calendar/CalendarInfo.java
+++ b/app/src/main/java/io/finett/droidclaw/calendar/CalendarInfo.java
@@ -1,0 +1,78 @@
+package io.finett.droidclaw.calendar;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Metadata about one device calendar (from {@code CalendarContract.Calendars}),
+ * e.g. a Google account calendar or a locally synced calendar.
+ */
+public class CalendarInfo {
+    private final long id;
+    private final String displayName;
+    private final String accountName;
+    private final String accountType;
+    private final int accessLevel;
+    private final boolean visible;
+    private final String timeZone;
+
+    public CalendarInfo(long id, String displayName, String accountName, String accountType,
+                        int accessLevel, boolean visible, String timeZone) {
+        this.id = id;
+        this.displayName = displayName != null ? displayName : "";
+        this.accountName = accountName != null ? accountName : "";
+        this.accountType = accountType != null ? accountType : "";
+        this.accessLevel = accessLevel;
+        this.visible = visible;
+        this.timeZone = timeZone != null ? timeZone : "";
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public String getAccountType() {
+        return accountType;
+    }
+
+    public int getAccessLevel() {
+        return accessLevel;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public String getTimeZone() {
+        return timeZone;
+    }
+
+    /**
+     * Whether the agent may create/update/delete events in this calendar.
+     * Requires at least contributor access (CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR = 500).
+     */
+    public boolean isWritable() {
+        return accessLevel >= 500;
+    }
+
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        json.addProperty("calendar_id", id);
+        json.addProperty("name", displayName);
+        json.addProperty("account_name", accountName);
+        json.addProperty("account_type", accountType);
+        json.addProperty("writable", isWritable());
+        json.addProperty("visible", visible);
+        if (!timeZone.isEmpty()) {
+            json.addProperty("timezone", timeZone);
+        }
+        return json;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/calendar/CalendarRepository.java
+++ b/app/src/main/java/io/finett/droidclaw/calendar/CalendarRepository.java
@@ -1,0 +1,487 @@
+package io.finett.droidclaw.calendar;
+
+import android.Manifest;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.CalendarContract;
+
+import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * {@link CalendarDataSource} backed by the Android CalendarProvider
+ * ({@link CalendarContract}). Covers every calendar the device syncs
+ * (Google, DAVx5/CalDAV, local, ...).
+ *
+ * <p>Requires {@link Manifest.permission#READ_CALENDAR} and
+ * {@link Manifest.permission#WRITE_CALENDAR}. Every operation checks the
+ * permissions and throws {@link CalendarException} with an instructive
+ * message when they are missing.
+ */
+public class CalendarRepository implements CalendarDataSource {
+
+    private static final String PERMISSION_ERROR =
+            "Calendar permission not granted. Ask the user to enable "
+            + "'Calendar access' in Settings -> Agent settings.";
+
+    private static final String[] CALENDAR_PROJECTION = {
+            CalendarContract.Calendars._ID,
+            CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+            CalendarContract.Calendars.ACCOUNT_NAME,
+            CalendarContract.Calendars.ACCOUNT_TYPE,
+            CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
+            CalendarContract.Calendars.VISIBLE,
+            CalendarContract.Calendars.CALENDAR_TIME_ZONE,
+    };
+
+    private static final String[] INSTANCE_PROJECTION = {
+            CalendarContract.Instances.EVENT_ID,
+            CalendarContract.Instances.CALENDAR_ID,
+            CalendarContract.Instances.BEGIN,
+            CalendarContract.Instances.END,
+            CalendarContract.Instances.TITLE,
+            CalendarContract.Instances.EVENT_LOCATION,
+            CalendarContract.Instances.DESCRIPTION,
+            CalendarContract.Instances.ALL_DAY,
+            CalendarContract.Instances.EVENT_TIMEZONE,
+            CalendarContract.Instances.RRULE,
+    };
+
+    private static final String[] EVENT_PROJECTION = {
+            CalendarContract.Events._ID,
+            CalendarContract.Events.RRULE,
+            CalendarContract.Events.DTSTART,
+            CalendarContract.Events.DTEND,
+    };
+
+    private static final String[] EVENT_DETAIL_PROJECTION = {
+            CalendarContract.Events._ID,
+            CalendarContract.Events.CALENDAR_ID,
+            CalendarContract.Events.TITLE,
+            CalendarContract.Events.DTSTART,
+            CalendarContract.Events.DTEND,
+            CalendarContract.Events.ALL_DAY,
+            CalendarContract.Events.EVENT_LOCATION,
+            CalendarContract.Events.DESCRIPTION,
+            CalendarContract.Events.EVENT_TIMEZONE,
+            CalendarContract.Events.RRULE,
+    };
+
+    private final Context context;
+
+    public CalendarRepository(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    // ==================== Queries ====================
+
+    @Override
+    public List<CalendarInfo> getCalendars() {
+        requireReadPermission();
+        List<CalendarInfo> result = new ArrayList<>();
+        ContentResolver resolver = context.getContentResolver();
+        try (Cursor cursor = resolver.query(
+                CalendarContract.Calendars.CONTENT_URI,
+                CALENDAR_PROJECTION, null, null,
+                CalendarContract.Calendars.CALENDAR_DISPLAY_NAME + " ASC")) {
+            if (cursor == null) {
+                throw new CalendarException("Calendar provider is not available on this device.");
+            }
+            while (cursor.moveToNext()) {
+                result.add(new CalendarInfo(
+                        cursor.getLong(0),
+                        cursor.getString(1),
+                        cursor.getString(2),
+                        cursor.getString(3),
+                        cursor.getInt(4),
+                        cursor.getInt(5) != 0,
+                        cursor.getString(6)));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public List<CalendarEvent> queryEvents(long beginMillis, long endMillis,
+                                           Long calendarId, String textQuery, int limit) {
+        requireReadPermission();
+        if (endMillis <= beginMillis) {
+            throw new CalendarException("End time must be after start time.");
+        }
+
+        Map<Long, String> calendarNames = new HashMap<>();
+        for (CalendarInfo info : getCalendars()) {
+            calendarNames.put(info.getId(), info.getDisplayName());
+        }
+
+        Uri.Builder builder = CalendarContract.Instances.CONTENT_URI.buildUpon();
+        ContentUris.appendId(builder, beginMillis);
+        ContentUris.appendId(builder, endMillis);
+
+        StringBuilder selection = new StringBuilder();
+        List<String> selectionArgs = new ArrayList<>();
+        if (calendarId != null) {
+            selection.append(CalendarContract.Instances.CALENDAR_ID).append(" = ?");
+            selectionArgs.add(String.valueOf(calendarId));
+        }
+        if (textQuery != null && !textQuery.trim().isEmpty()) {
+            String like = "%" + textQuery.trim().toLowerCase(Locale.ROOT) + "%";
+            if (selection.length() > 0) {
+                selection.append(" AND ");
+            }
+            selection.append("(")
+                    .append("LOWER(").append(CalendarContract.Instances.TITLE).append(") LIKE ? OR ")
+                    .append("LOWER(").append(CalendarContract.Instances.EVENT_LOCATION).append(") LIKE ? OR ")
+                    .append("LOWER(").append(CalendarContract.Instances.DESCRIPTION).append(") LIKE ?")
+                    .append(")");
+            selectionArgs.add(like);
+            selectionArgs.add(like);
+            selectionArgs.add(like);
+        }
+
+        List<CalendarEvent> result = new ArrayList<>();
+        ContentResolver resolver = context.getContentResolver();
+        try (Cursor cursor = resolver.query(
+                builder.build(), INSTANCE_PROJECTION,
+                selection.length() > 0 ? selection.toString() : null,
+                selectionArgs.isEmpty() ? null : selectionArgs.toArray(new String[0]),
+                CalendarContract.Instances.BEGIN + " ASC")) {
+            if (cursor == null) {
+                throw new CalendarException("Calendar provider is not available on this device.");
+            }
+            while (cursor.moveToNext() && result.size() < limit) {
+                long eventId = cursor.getLong(0);
+                long calId = cursor.getLong(1);
+                result.add(new CalendarEvent(
+                        eventId,
+                        calId,
+                        calendarNames.containsKey(calId) ? calendarNames.get(calId) : "",
+                        cursor.getString(4),
+                        cursor.getLong(2),
+                        cursor.getLong(3),
+                        cursor.getInt(7) != 0,
+                        cursor.getString(5),
+                        cursor.getString(6),
+                        cursor.getString(8),
+                        cursor.getString(9) != null && !cursor.getString(9).isEmpty()));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public CalendarEvent getEvent(long eventId) {
+        requireReadPermission();
+        ContentResolver resolver = context.getContentResolver();
+        try (Cursor cursor = resolver.query(
+                ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId),
+                EVENT_DETAIL_PROJECTION, null, null, null)) {
+            if (cursor == null || !cursor.moveToFirst()) {
+                return null;
+            }
+            long calId = cursor.getLong(1);
+            long dtStart = cursor.getLong(3);
+            long dtEnd = cursor.isNull(4) ? dtStart : cursor.getLong(4);
+            String rrule = cursor.getString(9);
+
+            String calendarName = "";
+            try {
+                for (CalendarInfo info : getCalendars()) {
+                    if (info.getId() == calId) {
+                        calendarName = info.getDisplayName();
+                        break;
+                    }
+                }
+            } catch (CalendarException e) {
+                // Name is cosmetic — continue without it
+            }
+
+            return new CalendarEvent(
+                    cursor.getLong(0),
+                    calId,
+                    calendarName,
+                    cursor.getString(2),
+                    dtStart,
+                    dtEnd,
+                    cursor.getInt(5) != 0,
+                    cursor.getString(6),
+                    cursor.getString(7),
+                    cursor.getString(8),
+                    rrule != null && !rrule.isEmpty());
+        }
+    }
+
+    // ==================== Mutations ====================
+
+    @Override
+    public long createEvent(EventSpec spec) {
+        requireWritePermission();
+        if (spec == null) {
+            throw new CalendarException("Event spec must not be null.");
+        }
+        if (spec.getTitle() == null || spec.getTitle().trim().isEmpty()) {
+            throw new CalendarException("Event title must not be empty.");
+        }
+        if (spec.getDtStart() == null) {
+            throw new CalendarException("Event start time is required.");
+        }
+
+        long calendarId = resolveCalendarId(spec.getCalendarId());
+
+        ContentValues values = new ContentValues();
+        values.put(CalendarContract.Events.CALENDAR_ID, calendarId);
+        values.put(CalendarContract.Events.TITLE, spec.getTitle().trim());
+        values.put(CalendarContract.Events.DTSTART, spec.getDtStart());
+        values.put(CalendarContract.Events.EVENT_TIMEZONE,
+                resolveTimezone(spec.getTimezone()));
+
+        boolean allDay = spec.getAllDay() != null && spec.getAllDay();
+        if (allDay) {
+            values.put(CalendarContract.Events.ALL_DAY, 1);
+        }
+
+        if (spec.getDtEnd() != null) {
+            if (spec.getDtEnd() <= spec.getDtStart()) {
+                throw new CalendarException("Event end time must be after the start time.");
+            }
+            values.put(CalendarContract.Events.DTEND, spec.getDtEnd());
+        } else {
+            // Default duration: 1 hour for timed events, 1 day for all-day events
+            long defaultDurationMs = allDay ? 24 * 3600 * 1000L : 3600 * 1000L;
+            values.put(CalendarContract.Events.DTEND, spec.getDtStart() + defaultDurationMs);
+        }
+
+        if (spec.getLocation() != null && !spec.getLocation().trim().isEmpty()) {
+            values.put(CalendarContract.Events.EVENT_LOCATION, spec.getLocation().trim());
+        }
+        if (spec.getDescription() != null && !spec.getDescription().trim().isEmpty()) {
+            values.put(CalendarContract.Events.DESCRIPTION, spec.getDescription().trim());
+        }
+
+        Uri uri;
+        try {
+            uri = context.getContentResolver().insert(
+                    CalendarContract.Events.CONTENT_URI, values);
+        } catch (SecurityException e) {
+            throw new CalendarException(PERMISSION_ERROR, e);
+        }
+        if (uri == null) {
+            throw new CalendarException(
+                    "Failed to create event: the calendar provider rejected the insert.");
+        }
+
+        long eventId;
+        try {
+            eventId = Long.parseLong(uri.getLastPathSegment());
+        } catch (NumberFormatException e) {
+            throw new CalendarException("Failed to parse the new event id.", e);
+        }
+
+        insertReminders(eventId, spec.getReminders());
+        return eventId;
+    }
+
+    @Override
+    public boolean updateEvent(long eventId, EventSpec spec) {
+        requireWritePermission();
+        if (spec == null) {
+            throw new CalendarException("Event spec must not be null.");
+        }
+
+        // Load the existing event to detect recurring series and validate the id.
+        String rrule = null;
+        boolean exists = false;
+        ContentResolver resolver = context.getContentResolver();
+        try (Cursor cursor = resolver.query(
+                ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId),
+                EVENT_PROJECTION, null, null, null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                exists = true;
+                rrule = cursor.getString(1);
+            }
+        }
+        if (!exists) {
+            return false;
+        }
+
+        boolean recurring = rrule != null && !rrule.isEmpty();
+        boolean changesTime = spec.getDtStart() != null || spec.getDtEnd() != null;
+        if (recurring && changesTime) {
+            throw new CalendarException(
+                    "Event " + eventId + " is a recurring series. Moving individual "
+                    + "occurrences or the series time is not supported. You can update "
+                    + "non-time fields (title, location, description) of the whole series, "
+                    + "or delete the series with calendar_delete_event and recreate it.");
+        }
+
+        ContentValues values = new ContentValues();
+        if (spec.getTitle() != null) {
+            if (spec.getTitle().trim().isEmpty()) {
+                throw new CalendarException("Event title must not be empty.");
+            }
+            values.put(CalendarContract.Events.TITLE, spec.getTitle().trim());
+        }
+        if (spec.getDtStart() != null) {
+            values.put(CalendarContract.Events.DTSTART, spec.getDtStart());
+        }
+        if (spec.getDtEnd() != null) {
+            values.put(CalendarContract.Events.DTEND, spec.getDtEnd());
+        }
+        if (spec.getDtStart() != null && spec.getDtEnd() != null
+                && spec.getDtEnd() <= spec.getDtStart()) {
+            throw new CalendarException("Event end time must be after the start time.");
+        }
+        if (spec.getAllDay() != null) {
+            values.put(CalendarContract.Events.ALL_DAY, spec.getAllDay() ? 1 : 0);
+        }
+        if (spec.getLocation() != null) {
+            values.put(CalendarContract.Events.EVENT_LOCATION, spec.getLocation().trim());
+        }
+        if (spec.getDescription() != null) {
+            values.put(CalendarContract.Events.DESCRIPTION, spec.getDescription().trim());
+        }
+        if (values.size() == 0) {
+            throw new CalendarException("No fields to update.");
+        }
+
+        try {
+            int rows = resolver.update(
+                    ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId),
+                    values, null, null);
+            if (rows > 0 && spec.getReminders() != null) {
+                insertReminders(eventId, spec.getReminders());
+            }
+            return rows > 0;
+        } catch (SecurityException e) {
+            throw new CalendarException(PERMISSION_ERROR, e);
+        }
+    }
+
+    @Override
+    public boolean deleteEvent(long eventId) {
+        requireWritePermission();
+        try {
+            int rows = context.getContentResolver().delete(
+                    ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId),
+                    null, null);
+            return rows > 0;
+        } catch (SecurityException e) {
+            throw new CalendarException(PERMISSION_ERROR, e);
+        }
+    }
+
+    @Override
+    public boolean hasWritableCalendar() {
+        for (CalendarInfo info : getCalendars()) {
+            if (info.isWritable()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ==================== Internals ====================
+
+    /**
+     * Resolve the target calendar: use the requested id when writable,
+     * otherwise fall back to the single writable calendar (if exactly one),
+     * otherwise fail with guidance.
+     */
+    private long resolveCalendarId(Long requestedId) {
+        List<CalendarInfo> calendars = getCalendars();
+        if (requestedId != null) {
+            for (CalendarInfo info : calendars) {
+                if (info.getId() == requestedId) {
+                    if (!info.isWritable()) {
+                        throw new CalendarException(
+                                "Calendar " + requestedId + " ('" + info.getDisplayName()
+                                + "') is read-only. Use calendar_list_calendars to find "
+                                + "a writable calendar.");
+                    }
+                    return requestedId;
+                }
+            }
+            throw new CalendarException(
+                    "Calendar " + requestedId + " not found. Use calendar_list_calendars "
+                    + "to list available calendars.");
+        }
+
+        List<CalendarInfo> writable = new ArrayList<>();
+        for (CalendarInfo info : calendars) {
+            if (info.isWritable()) {
+                writable.add(info);
+            }
+        }
+        if (writable.isEmpty()) {
+            throw new CalendarException(
+                    "No writable calendar found on this device. The user needs to add a "
+                    + "calendar account (e.g. Google account) first.");
+        }
+        if (writable.size() == 1) {
+            return writable.get(0).getId();
+        }
+        throw new CalendarException(
+                "Multiple writable calendars exist. Call calendar_list_calendars and pass "
+                + "an explicit calendar_id.");
+    }
+
+    private void insertReminders(long eventId, List<Integer> reminderMinutes) {
+        if (reminderMinutes == null || reminderMinutes.isEmpty()) {
+            return;
+        }
+        ContentResolver resolver = context.getContentResolver();
+        for (Integer minutes : reminderMinutes) {
+            if (minutes == null || minutes < 0) {
+                continue;
+            }
+            ContentValues values = new ContentValues();
+            values.put(CalendarContract.Reminders.EVENT_ID, eventId);
+            values.put(CalendarContract.Reminders.MINUTES, minutes);
+            values.put(CalendarContract.Reminders.METHOD,
+                    CalendarContract.Reminders.METHOD_ALERT);
+            try {
+                resolver.insert(CalendarContract.Reminders.CONTENT_URI, values);
+            } catch (Exception e) {
+                // Reminder insertion is best-effort — the event itself was created.
+            }
+        }
+    }
+
+    private static String resolveTimezone(String requested) {
+        if (requested != null && !requested.trim().isEmpty()) {
+            try {
+                return TimeZone.getTimeZone(requested.trim()).getID();
+            } catch (Exception e) {
+                throw new CalendarException("Unknown timezone: '" + requested + "'");
+            }
+        }
+        return TimeZone.getDefault().getID();
+    }
+
+    private void requireReadPermission() {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+                != PackageManager.PERMISSION_GRANTED) {
+            throw new CalendarException(PERMISSION_ERROR);
+        }
+    }
+
+    private void requireWritePermission() {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
+                != PackageManager.PERMISSION_GRANTED
+                || ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+                != PackageManager.PERMISSION_GRANTED) {
+            throw new CalendarException(PERMISSION_ERROR);
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/calendar/CalendarTimeUtil.java
+++ b/app/src/main/java/io/finett/droidclaw/calendar/CalendarTimeUtil.java
@@ -1,0 +1,174 @@
+package io.finett.droidclaw.calendar;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+
+/**
+ * Parses and formats the ISO-8601-ish timestamps the LLM uses for calendar
+ * event boundaries.
+ *
+ * <p>Accepted input forms:
+ * <ul>
+ *   <li>{@code 2026-06-01T15:00} or {@code 2026-06-01 15:00} — local time in the
+ *       device timezone (seconds optional)</li>
+ *   <li>{@code 2026-06-01T15:00:00+02:00} / {@code ...Z} — explicit UTC offset</li>
+ *   <li>{@code 2026-06-01} — date only; interpreted as the start of that day.
+ *       Callers use {@link ParsedTime#isDateOnly()} to map this to all-day events.</li>
+ * </ul>
+ */
+public final class CalendarTimeUtil {
+
+    private static final DateTimeFormatter LOCAL_TIME_FORMAT = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .appendLiteral(' ')
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalEnd()
+            .toFormatter();
+
+    private static final DateTimeFormatter OUTPUT_FORMAT =
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    private CalendarTimeUtil() {
+    }
+
+    /** Result of parsing an LLM-supplied timestamp. */
+    public static class ParsedTime {
+        private final long epochMillis;
+        private final boolean dateOnly;
+
+        ParsedTime(long epochMillis, boolean dateOnly) {
+            this.epochMillis = epochMillis;
+            this.dateOnly = dateOnly;
+        }
+
+        /** Epoch milliseconds (UTC). */
+        public long getEpochMillis() {
+            return epochMillis;
+        }
+
+        /** True when the input was a bare date ({@code yyyy-MM-dd}). */
+        public boolean isDateOnly() {
+            return dateOnly;
+        }
+    }
+
+    /**
+     * Parse a timestamp string into epoch millis.
+     *
+     * @throws IllegalArgumentException if the string is null, blank, or not a
+     *         recognised date/time format.
+     */
+    public static ParsedTime parse(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            throw new IllegalArgumentException("Date/time must not be empty");
+        }
+        String s = input.trim();
+
+        // Explicit UTC offset (e.g. "2026-06-01T15:00:00+02:00" or "...Z")
+        try {
+            OffsetDateTime odt = OffsetDateTime.parse(s);
+            return new ParsedTime(odt.toInstant().toEpochMilli(), false);
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+
+        // Local date-time with 'T' separator, seconds optional
+        try {
+            LocalDateTime ldt = LocalDateTime.parse(s, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            return new ParsedTime(toDeviceMillis(ldt), false);
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+
+        // Local date-time with space separator ("2026-06-01 15:00")
+        try {
+            LocalDateTime ldt = LocalDateTime.parse(s, LOCAL_TIME_FORMAT);
+            return new ParsedTime(toDeviceMillis(ldt), false);
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+
+        // Bare date -> date only (all-day semantics)
+        try {
+            LocalDate date = LocalDate.parse(s, DateTimeFormatter.ISO_LOCAL_DATE);
+            return new ParsedTime(toDeviceMillis(date.atStartOfDay()), true);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                    "Unrecognised date/time: '" + input + "'. Expected ISO-8601 such as "
+                    + "'2026-06-01T15:00', '2026-06-01T15:00:00+02:00' or '2026-06-01'.");
+        }
+    }
+
+    private static long toDeviceMillis(LocalDateTime ldt) {
+        return ldt.atZone(deviceZone()).toInstant().toEpochMilli();
+    }
+
+    /** Format epoch millis as ISO-8601 with the device timezone offset. */
+    public static String format(long epochMillis) {
+        return format(epochMillis, deviceZone());
+    }
+
+    /** Format epoch millis as ISO-8601 in the given timezone id. */
+    public static String format(long epochMillis, String timeZoneId) {
+        ZoneId zone;
+        try {
+            zone = ZoneId.of(timeZoneId);
+        } catch (Exception e) {
+            zone = deviceZone();
+        }
+        return format(epochMillis, zone);
+    }
+
+    private static String format(long epochMillis, ZoneId zone) {
+        ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), zone);
+        return zdt.format(OUTPUT_FORMAT);
+    }
+
+    /** Start of the next day (device timezone) after the given epoch millis. */
+    public static long plusOneDay(long epochMillis) {
+        return Instant.ofEpochMilli(epochMillis)
+                .atZone(deviceZone())
+                .plusDays(1)
+                .toInstant()
+                .toEpochMilli();
+    }
+
+    /**
+     * UTC midnight of the (device-local) calendar day containing the given
+     * instant. All-day events in {@code CalendarContract} store UTC midnight
+     * boundaries, so use this when building ALL_DAY rows.
+     */
+    public static long toUtcMidnight(long epochMillis) {
+        LocalDate date = Instant.ofEpochMilli(epochMillis).atZone(deviceZone()).toLocalDate();
+        return date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+    }
+
+    /** Epoch millis of the start of today in the device timezone. */
+    public static long startOfToday() {
+        return LocalDate.now(deviceZone()).atStartOfDay(deviceZone()).toInstant().toEpochMilli();
+    }
+
+    /** Epoch millis {@code days} days after the start of today (device timezone). */
+    public static long startOfTodayPlusDays(int days) {
+        return LocalDate.now(deviceZone()).plusDays(days)
+                .atStartOfDay(deviceZone()).toInstant().toEpochMilli();
+    }
+
+    private static ZoneId deviceZone() {
+        return ZoneId.systemDefault();
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/calendar/EventSpec.java
+++ b/app/src/main/java/io/finett/droidclaw/calendar/EventSpec.java
@@ -1,0 +1,93 @@
+package io.finett.droidclaw.calendar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Specification for creating or updating a calendar event. All fields except
+ * {@code title}/{@code dtStart} on creation are nullable, meaning "leave
+ * unchanged" for updates.
+ */
+public class EventSpec {
+    private Long calendarId;
+    private String title;
+    private Long dtStart;
+    private Long dtEnd;
+    private Boolean allDay;
+    private String location;
+    private String description;
+    private List<Integer> reminders;
+    private String timezone;
+
+    public Long getCalendarId() {
+        return calendarId;
+    }
+
+    public void setCalendarId(Long calendarId) {
+        this.calendarId = calendarId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Long getDtStart() {
+        return dtStart;
+    }
+
+    public void setDtStart(Long dtStart) {
+        this.dtStart = dtStart;
+    }
+
+    public Long getDtEnd() {
+        return dtEnd;
+    }
+
+    public void setDtEnd(Long dtEnd) {
+        this.dtEnd = dtEnd;
+    }
+
+    public Boolean getAllDay() {
+        return allDay;
+    }
+
+    public void setAllDay(Boolean allDay) {
+        this.allDay = allDay;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<Integer> getReminders() {
+        return reminders;
+    }
+
+    public void setReminders(List<Integer> reminders) {
+        this.reminders = reminders != null ? new ArrayList<>(reminders) : null;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
@@ -29,6 +29,7 @@ import io.finett.droidclaw.accessibility.AccessibilityBridge;
 import io.finett.droidclaw.model.AgentConfig;
 import io.finett.droidclaw.shell.SshConfig;
 import io.finett.droidclaw.shell.SshShellBackend;
+import io.finett.droidclaw.util.CalendarPermissionHelper;
 import io.finett.droidclaw.util.SettingsManager;
 
 public class AgentSettingsFragment extends Fragment {
@@ -63,6 +64,10 @@ public class AgentSettingsFragment extends Fragment {
     private SwitchMaterial switchScreenControlTrustMode;
     private TextView textAccessibilityStatus;
     private MaterialButton buttonOpenAccessibilitySettings;
+
+    // Calendar access views
+    private SwitchMaterial switchCalendarAccess;
+    private CalendarPermissionHelper calendarPermissionHelper;
 
     private Button buttonSave;
 
@@ -103,6 +108,26 @@ public class AgentSettingsFragment extends Fragment {
         updateAccessibilityStatus();
     }
 
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        calendarPermissionHelper.handlePermissionResult(requestCode, permissions, grantResults,
+                new CalendarPermissionHelper.PermissionCallback() {
+                    @Override
+                    public void onPermissionGranted() {
+                        // Switch stays on; tools become available on the next agent run.
+                    }
+
+                    @Override
+                    public void onPermissionDenied() {
+                        switchCalendarAccess.setChecked(false);
+                        Toast.makeText(requireContext(), R.string.calendar_permission_denied,
+                                Toast.LENGTH_LONG).show();
+                    }
+                });
+    }
+
     private void initViews(View view) {
         dropdownDefaultModel = view.findViewById(R.id.dropdown_default_model);
         switchShellAccess = view.findViewById(R.id.switch_shell_access);
@@ -133,6 +158,9 @@ public class AgentSettingsFragment extends Fragment {
         switchScreenControlTrustMode = view.findViewById(R.id.switch_screen_control_trust_mode);
         textAccessibilityStatus = view.findViewById(R.id.text_accessibility_status);
         buttonOpenAccessibilitySettings = view.findViewById(R.id.button_open_accessibility_settings);
+
+        switchCalendarAccess = view.findViewById(R.id.switch_calendar_access);
+        calendarPermissionHelper = new CalendarPermissionHelper(requireContext());
 
         buttonSave = view.findViewById(R.id.button_save);
     }
@@ -239,6 +267,9 @@ public class AgentSettingsFragment extends Fragment {
             switchScreenControl.setChecked(agentConfig.isScreenControlEnabled());
             switchScreenControlTrustMode.setChecked(agentConfig.isScreenControlTrustMode());
 
+            // Calendar access
+            switchCalendarAccess.setChecked(agentConfig.isCalendarEnabled());
+
             // Terminal backend
             String backend = agentConfig.getShellBackend();
             if ("ssh".equals(backend)) {
@@ -299,6 +330,15 @@ public class AgentSettingsFragment extends Fragment {
         });
 
         buttonOpenAccessibilitySettings.setOnClickListener(v -> openAccessibilitySettings());
+
+        // When the user enables calendar access, request the runtime permissions.
+        // isPressed() guards against programmatic setChecked() during loadSettings().
+        switchCalendarAccess.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked && buttonView.isPressed()
+                    && !CalendarPermissionHelper.hasCalendarPermission(requireContext())) {
+                calendarPermissionHelper.requestCalendarPermissions(requireActivity());
+            }
+        });
 
         // Terminal backend change listener
         dropdownTerminalBackend.setOnItemClickListener((parent, view, position, id) -> {
@@ -590,6 +630,7 @@ public class AgentSettingsFragment extends Fragment {
         agentConfig.setLlmWriteTimeout(llmWriteTimeout);
         agentConfig.setScreenControlEnabled(switchScreenControl.isChecked());
         agentConfig.setScreenControlTrustMode(switchScreenControlTrustMode.isChecked());
+        agentConfig.setCalendarEnabled(switchCalendarAccess.isChecked());
 
         // Terminal backend
         String backendText = dropdownTerminalBackend.getText().toString();

--- a/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
+++ b/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
@@ -17,6 +17,7 @@ public class AgentConfig {
     private List<String> customAllowlist; // extra executable paths for relaxed mode
     private boolean screenControlEnabled;  // allow agent to read UI and control screen via accessibility
     private boolean screenControlTrustMode; // skip per-action approval for screen control tools
+    private boolean calendarEnabled; // allow agent to read and manage device calendar events
     private int llmConnectTimeout;   // seconds
     private int llmReadTimeout;      // seconds
     private int llmWriteTimeout;     // seconds
@@ -37,6 +38,7 @@ public class AgentConfig {
         this.llmWriteTimeout = 30;
         this.screenControlEnabled = false;
         this.screenControlTrustMode = false;
+        this.calendarEnabled = false;
         this.toolApprovalOverrides = new HashMap<>();
         this.shellBackend = "local";
         this.sshPort = 22;
@@ -60,6 +62,7 @@ public class AgentConfig {
         this.llmWriteTimeout = 30;
         this.screenControlEnabled = false;
         this.screenControlTrustMode = false;
+        this.calendarEnabled = false;
         this.sshPort = 22;
         this.sshVerifyHostKey = true;
     }
@@ -187,6 +190,14 @@ public class AgentConfig {
 
     public void setScreenControlTrustMode(boolean screenControlTrustMode) {
         this.screenControlTrustMode = screenControlTrustMode;
+    }
+
+    public boolean isCalendarEnabled() {
+        return calendarEnabled;
+    }
+
+    public void setCalendarEnabled(boolean calendarEnabled) {
+        this.calendarEnabled = calendarEnabled;
     }
 
     public Map<String, String> getToolApprovalOverrides() {

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolDefinition.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolDefinition.java
@@ -102,6 +102,21 @@ public class ToolDefinition {
             return this;
         }
 
+        public ParametersBuilder addIntegerArray(String name, String description, boolean required) {
+            JsonObject prop = new JsonObject();
+            prop.addProperty("type", "array");
+            JsonObject items = new JsonObject();
+            items.addProperty("type", "integer");
+            prop.add("items", items);
+            prop.addProperty("description", description);
+            properties.add(name, prop);
+
+            if (required) {
+                addRequired(name);
+            }
+            return this;
+        }
+
         private void addRequired(String name) {
             if (!schema.has("required")) {
                 schema.add("required", new com.google.gson.JsonArray());

--- a/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/ToolRegistry.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.finett.droidclaw.calendar.CalendarRepository;
 import io.finett.droidclaw.filesystem.VirtualFileSystem;
 import io.finett.droidclaw.filesystem.WorkspaceManager;
 import io.finett.droidclaw.python.PythonConfig;
@@ -48,6 +49,12 @@ import io.finett.droidclaw.tool.impl.SubmitNotificationTool;
 import io.finett.droidclaw.tool.impl.SearxngSearchTool;
 import io.finett.droidclaw.tool.impl.ListAppsTool;
 import io.finett.droidclaw.tool.impl.OpenAppTool;
+import io.finett.droidclaw.tool.impl.CalendarListCalendarsTool;
+import io.finett.droidclaw.tool.impl.CalendarListEventsTool;
+import io.finett.droidclaw.tool.impl.CalendarCreateEventTool;
+import io.finett.droidclaw.tool.impl.CalendarUpdateEventTool;
+import io.finett.droidclaw.tool.impl.CalendarDeleteEventTool;
+import io.finett.droidclaw.util.CalendarPermissionHelper;
 import io.finett.droidclaw.util.SettingsManager;
 
 public class ToolRegistry {
@@ -153,6 +160,18 @@ public class ToolRegistry {
         // Android app management — always available
         registerTool(new ListAppsTool(context));
         registerTool(new OpenAppTool(context));
+
+        // Calendar tools — only when enabled in settings AND calendar permissions granted
+        if (settingsManager != null
+                && settingsManager.getAgentConfig().isCalendarEnabled()
+                && CalendarPermissionHelper.hasCalendarPermission(context)) {
+            CalendarRepository calendarRepository = new CalendarRepository(context);
+            registerTool(new CalendarListCalendarsTool(calendarRepository));
+            registerTool(new CalendarListEventsTool(calendarRepository));
+            registerTool(new CalendarCreateEventTool(calendarRepository));
+            registerTool(new CalendarUpdateEventTool(calendarRepository));
+            registerTool(new CalendarDeleteEventTool(calendarRepository));
+        }
     }
 
     /**

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarArgs.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarArgs.java
@@ -1,0 +1,94 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Small lenient argument-extraction helpers shared by the calendar tools.
+ * LLMs occasionally send numbers as strings, so numeric getters accept both.
+ */
+final class CalendarArgs {
+
+    private CalendarArgs() {
+    }
+
+    /** Optional string; returns null when absent, null, or blank. */
+    static String optString(JsonObject args, String key) {
+        if (args == null || !args.has(key) || args.get(key).isJsonNull()) {
+            return null;
+        }
+        String value = args.get(key).getAsString().trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    /** Required string; throws IllegalArgumentException with a tool-friendly message. */
+    static String reqString(JsonObject args, String key) {
+        String value = optString(args, key);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing required parameter: " + key);
+        }
+        return value;
+    }
+
+    /** Optional boolean; null when absent. */
+    static Boolean optBoolean(JsonObject args, String key) {
+        if (args == null || !args.has(key) || args.get(key).isJsonNull()) {
+            return null;
+        }
+        JsonElement el = args.get(key);
+        if (el.isJsonPrimitive() && el.getAsJsonPrimitive().isBoolean()) {
+            return el.getAsBoolean();
+        }
+        return Boolean.parseBoolean(el.getAsString().trim());
+    }
+
+    /** Optional long (accepts JSON numbers or numeric strings); null when absent. */
+    static Long optLong(JsonObject args, String key) {
+        String value = optString(args, key);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Parameter " + key + " must be an integer, got: " + value);
+        }
+    }
+
+    /** Optional array of integers (also accepts a comma-separated string); null when absent. */
+    static List<Integer> optIntegerArray(JsonObject args, String key) {
+        if (args == null || !args.has(key) || args.get(key).isJsonNull()) {
+            return null;
+        }
+        JsonElement el = args.get(key);
+        List<Integer> result = new ArrayList<>();
+        if (el.isJsonArray()) {
+            JsonArray arr = el.getAsJsonArray();
+            for (JsonElement item : arr) {
+                if (item.isJsonNull()) continue;
+                try {
+                    result.add(Integer.parseInt(item.getAsString().trim()));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(
+                            "Parameter " + key + " must contain only integers, got: " + item);
+                }
+            }
+        } else {
+            for (String part : el.getAsString().split(",")) {
+                String trimmed = part.trim();
+                if (trimmed.isEmpty()) continue;
+                try {
+                    result.add(Integer.parseInt(trimmed));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(
+                            "Parameter " + key + " must contain only integers, got: " + trimmed);
+                }
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarCreateEventTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarCreateEventTool.java
@@ -1,0 +1,182 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+import io.finett.droidclaw.calendar.CalendarDataSource;
+import io.finett.droidclaw.calendar.CalendarException;
+import io.finett.droidclaw.calendar.CalendarTimeUtil;
+import io.finett.droidclaw.calendar.EventSpec;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Creates a calendar event on the device calendar. Destructive in the sense
+ * that it mutates user data visible to other apps, so it always requires
+ * approval.
+ */
+public class CalendarCreateEventTool implements Tool {
+
+    private static final String TOOL_NAME = "calendar_create_event";
+    private static final long HOUR_MS = 3600 * 1000L;
+    private static final long DAY_MS = 24 * HOUR_MS;
+
+    private final CalendarDataSource dataSource;
+
+    public CalendarCreateEventTool(CalendarDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return true;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addString("title", "Event title.", true)
+                .addString("start",
+                        "Start time, ISO-8601 (e.g. '2026-06-01T15:00' or with explicit "
+                        + "offset '2026-06-01T15:00:00+02:00'). Times without an offset "
+                        + "are interpreted in the device timezone. A bare date "
+                        + "('2026-06-01') creates an all-day event.", true)
+                .addString("end",
+                        "End time, ISO-8601. Optional: defaults to start + 1 hour for "
+                        + "timed events, or the same day for all-day events. For all-day "
+                        + "events the end DATE is inclusive (the last day of the event).",
+                        false)
+                .addBoolean("all_day", "Create an all-day event (default: false).", false)
+                .addInteger("calendar_id",
+                        "Target calendar id (see calendar_list_calendars). Optional when "
+                        + "exactly one writable calendar exists.", false)
+                .addString("location", "Event location.", false)
+                .addString("description", "Event description/notes.", false)
+                .addIntegerArray("reminders",
+                        "Reminder lead times in minutes before the event "
+                        + "(e.g. [30] or [1440, 60]). Optional; when omitted the "
+                        + "calendar's own default applies.", false)
+                .addString("timezone",
+                        "IANA timezone id for the event (e.g. 'Europe/Berlin'). "
+                        + "Defaults to the device timezone.", false)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "Create a new event in the device calendar. Requires user approval. "
+                + "When several writable calendars exist you must pass calendar_id — "
+                + "call calendar_list_calendars first.",
+                parameters
+        );
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        try {
+            Resolved resolved = resolve(arguments);
+            StringBuilder sb = new StringBuilder("Create calendar event: \"")
+                    .append(resolved.title).append("\" from ")
+                    .append(CalendarTimeUtil.format(resolved.dtStart));
+            if (!resolved.allDay) {
+                sb.append(" to ").append(CalendarTimeUtil.format(resolved.dtEnd));
+            } else {
+                sb.append(" (all-day)");
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            return "Create calendar event";
+        }
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        Resolved resolved;
+        try {
+            resolved = resolve(arguments);
+        } catch (IllegalArgumentException e) {
+            return ToolResult.error(e.getMessage());
+        }
+
+        EventSpec spec = new EventSpec();
+        spec.setCalendarId(CalendarArgs.optLong(arguments, "calendar_id"));
+        spec.setTitle(resolved.title);
+        spec.setDtStart(resolved.dtStart);
+        spec.setDtEnd(resolved.dtEnd);
+        spec.setAllDay(resolved.allDay);
+        spec.setLocation(CalendarArgs.optString(arguments, "location"));
+        spec.setDescription(CalendarArgs.optString(arguments, "description"));
+        spec.setTimezone(CalendarArgs.optString(arguments, "timezone"));
+        List<Integer> reminders = CalendarArgs.optIntegerArray(arguments, "reminders");
+        spec.setReminders(reminders);
+
+        try {
+            long eventId = dataSource.createEvent(spec);
+            JsonObject out = new JsonObject();
+            out.addProperty("event_id", eventId);
+            out.addProperty("title", resolved.title);
+            out.addProperty("start", CalendarTimeUtil.format(resolved.dtStart));
+            out.addProperty("end", CalendarTimeUtil.format(resolved.dtEnd));
+            if (resolved.allDay) {
+                out.addProperty("all_day", true);
+            }
+            if (reminders != null && !reminders.isEmpty()) {
+                out.addProperty("reminders_minutes", reminders.toString());
+            }
+            return ToolResult.success(out);
+        } catch (CalendarException e) {
+            return ToolResult.error(e.getMessage());
+        }
+    }
+
+    /** Resolved event times, shared by execute() and the approval description. */
+    private static class Resolved {
+        String title;
+        long dtStart;
+        long dtEnd;
+        boolean allDay;
+    }
+
+    private static Resolved resolve(JsonObject arguments) {
+        Resolved resolved = new Resolved();
+        resolved.title = CalendarArgs.reqString(arguments, "title");
+        String startStr = CalendarArgs.reqString(arguments, "start");
+        String endStr = CalendarArgs.optString(arguments, "end");
+        Boolean allDayArg = CalendarArgs.optBoolean(arguments, "all_day");
+
+        CalendarTimeUtil.ParsedTime startParsed = CalendarTimeUtil.parse(startStr);
+        resolved.allDay = (allDayArg != null && allDayArg) || startParsed.isDateOnly();
+
+        if (resolved.allDay) {
+            resolved.dtStart = CalendarTimeUtil.toUtcMidnight(startParsed.getEpochMillis());
+            if (endStr == null) {
+                resolved.dtEnd = resolved.dtStart + DAY_MS;
+            } else {
+                CalendarTimeUtil.ParsedTime endParsed = CalendarTimeUtil.parse(endStr);
+                long endMidnight = CalendarTimeUtil.toUtcMidnight(endParsed.getEpochMillis());
+                if (endMidnight < resolved.dtStart) {
+                    throw new IllegalArgumentException("'end' date is before 'start' date");
+                }
+                // End date is inclusive for all-day events -> exclusive DTEND is next midnight
+                resolved.dtEnd = endMidnight + DAY_MS;
+            }
+        } else {
+            resolved.dtStart = startParsed.getEpochMillis();
+            if (endStr == null) {
+                resolved.dtEnd = resolved.dtStart + HOUR_MS;
+            } else {
+                resolved.dtEnd = CalendarTimeUtil.parse(endStr).getEpochMillis();
+                if (resolved.dtEnd <= resolved.dtStart) {
+                    throw new IllegalArgumentException("'end' must be after 'start'");
+                }
+            }
+        }
+        return resolved;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarDeleteEventTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarDeleteEventTool.java
@@ -1,0 +1,111 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.calendar.CalendarDataSource;
+import io.finett.droidclaw.calendar.CalendarEvent;
+import io.finett.droidclaw.calendar.CalendarException;
+import io.finett.droidclaw.calendar.CalendarTimeUtil;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Deletes a calendar event. For recurring events the whole series is removed.
+ * Requires approval.
+ */
+public class CalendarDeleteEventTool implements Tool {
+
+    private static final String TOOL_NAME = "calendar_delete_event";
+
+    private final CalendarDataSource dataSource;
+
+    public CalendarDeleteEventTool(CalendarDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return true;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addInteger("event_id",
+                        "The id of the event to delete (from calendar_list_events).", true)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "Delete a calendar event. For recurring events the entire series is "
+                + "deleted. Requires user approval.",
+                parameters
+        );
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        try {
+            Long eventId = CalendarArgs.optLong(arguments, "event_id");
+            if (eventId == null) {
+                return "Delete calendar event";
+            }
+            try {
+                CalendarEvent existing = dataSource.getEvent(eventId);
+                if (existing != null) {
+                    StringBuilder sb = new StringBuilder("Delete calendar event: '")
+                            .append(existing.getTitle()).append("' at ")
+                            .append(CalendarTimeUtil.format(existing.getStartMillis()));
+                    if (existing.isRecurring()) {
+                        sb.append(" (ENTIRE recurring series)");
+                    }
+                    return sb.toString();
+                }
+            } catch (Exception e) {
+                // Fall through to the generic description
+            }
+            return "Delete calendar event " + eventId;
+        } catch (Exception e) {
+            return "Delete calendar event";
+        }
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        Long eventId;
+        try {
+            eventId = CalendarArgs.optLong(arguments, "event_id");
+        } catch (IllegalArgumentException e) {
+            return ToolResult.error(e.getMessage());
+        }
+        if (eventId == null) {
+            return ToolResult.error("Missing required parameter: event_id");
+        }
+
+        try {
+            CalendarEvent existing = dataSource.getEvent(eventId);
+            if (existing == null) {
+                return ToolResult.error(
+                        "Event " + eventId + " not found. Use calendar_list_events to find "
+                        + "current event ids.");
+            }
+            boolean deleted = dataSource.deleteEvent(eventId);
+            if (!deleted) {
+                return ToolResult.error("Failed to delete event " + eventId);
+            }
+            JsonObject out = new JsonObject();
+            out.addProperty("event_id", eventId);
+            out.addProperty("deleted", true);
+            out.addProperty("title", existing.getTitle());
+            return ToolResult.success(out);
+        } catch (CalendarException e) {
+            return ToolResult.error(e.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarListCalendarsTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarListCalendarsTool.java
@@ -1,0 +1,64 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+import io.finett.droidclaw.calendar.CalendarDataSource;
+import io.finett.droidclaw.calendar.CalendarException;
+import io.finett.droidclaw.calendar.CalendarInfo;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Lists the calendars available on the device (all synced accounts).
+ * Read-only. The output tells the agent which calendars are writable,
+ * which is required before creating events when several exist.
+ */
+public class CalendarListCalendarsTool implements Tool {
+
+    private static final String TOOL_NAME = "calendar_list_calendars";
+
+    private final CalendarDataSource dataSource;
+
+    public CalendarListCalendarsTool(CalendarDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder().build();
+        return new ToolDefinition(
+                TOOL_NAME,
+                "List all calendars on the device (from all synced accounts, e.g. Google). "
+                + "Returns each calendar's calendar_id, name, account, and whether it is "
+                + "writable. Call this before creating events when you need to choose a "
+                + "calendar.",
+                parameters
+        );
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        try {
+            List<CalendarInfo> calendars = dataSource.getCalendars();
+            JsonArray arr = new JsonArray();
+            for (CalendarInfo calendar : calendars) {
+                arr.add(calendar.toJson());
+            }
+            JsonObject out = new JsonObject();
+            out.addProperty("count", calendars.size());
+            out.add("calendars", arr);
+            return ToolResult.success(out);
+        } catch (CalendarException e) {
+            return ToolResult.error(e.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarListEventsTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarListEventsTool.java
@@ -1,0 +1,104 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+import io.finett.droidclaw.calendar.CalendarDataSource;
+import io.finett.droidclaw.calendar.CalendarEvent;
+import io.finett.droidclaw.calendar.CalendarException;
+import io.finett.droidclaw.calendar.CalendarTimeUtil;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Queries calendar events in a time window via the CalendarContract
+ * Instances table, so recurring events are expanded to occurrences.
+ * Read-only.
+ */
+public class CalendarListEventsTool implements Tool {
+
+    private static final String TOOL_NAME = "calendar_list_events";
+    private static final int DEFAULT_WINDOW_DAYS = 7;
+    private static final int MAX_EVENTS = 200;
+
+    private final CalendarDataSource dataSource;
+
+    public CalendarListEventsTool(CalendarDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addString("start",
+                        "Start of the time window, ISO-8601 (e.g. '2026-06-01T09:00'). "
+                        + "Defaults to the start of today.", false)
+                .addString("end",
+                        "End of the time window, ISO-8601. Defaults to " + DEFAULT_WINDOW_DAYS
+                        + " days after the start.", false)
+                .addString("query",
+                        "Optional text to filter events by title, location or description "
+                        + "(case-insensitive substring match).", false)
+                .addInteger("calendar_id",
+                        "Optional calendar id to restrict the search to one calendar "
+                        + "(see calendar_list_calendars).", false)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "List calendar events from the device calendar within a time window. "
+                + "Recurring events are expanded to individual occurrences. Returns each "
+                + "event's event_id, title, start/end times (ISO-8601 with timezone offset), "
+                + "location, description and calendar. Use 'start'/'end' to bound the window "
+                + "(default: today through the next " + DEFAULT_WINDOW_DAYS + " days).",
+                parameters
+        );
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        try {
+            String startStr = CalendarArgs.optString(arguments, "start");
+            String endStr = CalendarArgs.optString(arguments, "end");
+            String query = CalendarArgs.optString(arguments, "query");
+            Long calendarId = CalendarArgs.optLong(arguments, "calendar_id");
+
+            long startMillis = startStr != null
+                    ? CalendarTimeUtil.parse(startStr).getEpochMillis()
+                    : CalendarTimeUtil.startOfToday();
+            long endMillis = endStr != null
+                    ? CalendarTimeUtil.parse(endStr).getEpochMillis()
+                    : startMillis + (long) DEFAULT_WINDOW_DAYS * 24 * 3600 * 1000;
+
+            if (endMillis <= startMillis) {
+                return ToolResult.error("'end' must be after 'start'");
+            }
+
+            List<CalendarEvent> events = dataSource.queryEvents(
+                    startMillis, endMillis, calendarId, query, MAX_EVENTS);
+
+            JsonArray arr = new JsonArray();
+            for (CalendarEvent event : events) {
+                arr.add(event.toJson());
+            }
+            JsonObject out = new JsonObject();
+            out.addProperty("count", events.size());
+            out.addProperty("window_start", CalendarTimeUtil.format(startMillis));
+            out.addProperty("window_end", CalendarTimeUtil.format(endMillis));
+            out.add("events", arr);
+            return ToolResult.success(out);
+        } catch (IllegalArgumentException e) {
+            return ToolResult.error(e.getMessage());
+        } catch (CalendarException e) {
+            return ToolResult.error(e.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarUpdateEventTool.java
+++ b/app/src/main/java/io/finett/droidclaw/tool/impl/CalendarUpdateEventTool.java
@@ -1,0 +1,161 @@
+package io.finett.droidclaw.tool.impl;
+
+import com.google.gson.JsonObject;
+
+import io.finett.droidclaw.calendar.CalendarDataSource;
+import io.finett.droidclaw.calendar.CalendarEvent;
+import io.finett.droidclaw.calendar.CalendarException;
+import io.finett.droidclaw.calendar.CalendarTimeUtil;
+import io.finett.droidclaw.calendar.EventSpec;
+import io.finett.droidclaw.tool.Tool;
+import io.finett.droidclaw.tool.ToolDefinition;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Updates an existing calendar event. Only the fields passed by the LLM are
+ * changed. Requires approval.
+ *
+ * <p>Phase-1 limitation: recurring series can have non-time fields updated;
+ * moving a recurring event (changing start/end) is rejected with guidance.
+ */
+public class CalendarUpdateEventTool implements Tool {
+
+    private static final String TOOL_NAME = "calendar_update_event";
+    private static final long DAY_MS = 24 * 3600 * 1000L;
+
+    private final CalendarDataSource dataSource;
+
+    public CalendarUpdateEventTool(CalendarDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String getName() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public boolean requiresApproval() {
+        return true;
+    }
+
+    @Override
+    public ToolDefinition getDefinition() {
+        JsonObject parameters = new ToolDefinition.ParametersBuilder()
+                .addInteger("event_id",
+                        "The id of the event to update (from calendar_list_events).", true)
+                .addString("title", "New title.", false)
+                .addString("start",
+                        "New start time, ISO-8601. When moving a timed event, pass both "
+                        + "'start' and 'end' to keep its duration.", false)
+                .addString("end", "New end time, ISO-8601.", false)
+                .addBoolean("all_day", "Change whether the event is all-day.", false)
+                .addString("location", "New location (empty string clears it).", false)
+                .addString("description", "New description (empty string clears it).", false)
+                .addIntegerArray("reminders",
+                        "Replace reminders with these lead times in minutes.", false)
+                .build();
+
+        return new ToolDefinition(
+                TOOL_NAME,
+                "Update an existing calendar event (move it, rename it, change location or "
+                + "description). Only the provided fields are changed. Recurring events can "
+                + "only have non-time fields updated. Requires user approval.",
+                parameters
+        );
+    }
+
+    @Override
+    public String getApprovalDescription(JsonObject arguments) {
+        try {
+            Long eventId = CalendarArgs.optLong(arguments, "event_id");
+            if (eventId == null) {
+                return "Update calendar event";
+            }
+            String label = "event " + eventId;
+            try {
+                CalendarEvent existing = dataSource.getEvent(eventId);
+                if (existing != null && !existing.getTitle().isEmpty()) {
+                    label = "'" + existing.getTitle() + "' (event " + eventId + ")";
+                }
+            } catch (Exception e) {
+                // Title is cosmetic for the dialog — ignore lookup failures
+            }
+            return "Update calendar " + label;
+        } catch (Exception e) {
+            return "Update calendar event";
+        }
+    }
+
+    @Override
+    public ToolResult execute(JsonObject arguments) {
+        Long eventId;
+        try {
+            eventId = CalendarArgs.optLong(arguments, "event_id");
+        } catch (IllegalArgumentException e) {
+            return ToolResult.error(e.getMessage());
+        }
+        if (eventId == null) {
+            return ToolResult.error("Missing required parameter: event_id");
+        }
+
+        EventSpec spec = new EventSpec();
+        try {
+            String startStr = CalendarArgs.optString(arguments, "start");
+            String endStr = CalendarArgs.optString(arguments, "end");
+            Boolean allDay = CalendarArgs.optBoolean(arguments, "all_day");
+
+            if (startStr != null) {
+                CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse(startStr);
+                boolean eventBecomesAllDay = allDay != null && allDay;
+                long dtStart = eventBecomesAllDay || parsed.isDateOnly()
+                        ? CalendarTimeUtil.toUtcMidnight(parsed.getEpochMillis())
+                        : parsed.getEpochMillis();
+                spec.setDtStart(dtStart);
+            }
+            if (endStr != null) {
+                CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse(endStr);
+                boolean eventBecomesAllDay = allDay != null && allDay;
+                if (eventBecomesAllDay || parsed.isDateOnly()) {
+                    // End date is inclusive for all-day events
+                    spec.setDtEnd(CalendarTimeUtil.toUtcMidnight(parsed.getEpochMillis()) + DAY_MS);
+                } else {
+                    spec.setDtEnd(parsed.getEpochMillis());
+                }
+            }
+            if (spec.getDtStart() != null && spec.getDtEnd() != null
+                    && spec.getDtEnd() <= spec.getDtStart()) {
+                return ToolResult.error("'end' must be after 'start'");
+            }
+
+            spec.setTitle(CalendarArgs.optString(arguments, "title"));
+            spec.setAllDay(allDay);
+            spec.setLocation(CalendarArgs.optString(arguments, "location"));
+            spec.setDescription(CalendarArgs.optString(arguments, "description"));
+            spec.setReminders(CalendarArgs.optIntegerArray(arguments, "reminders"));
+
+            if (spec.getTitle() == null && spec.getDtStart() == null && spec.getDtEnd() == null
+                    && spec.getAllDay() == null && spec.getLocation() == null
+                    && spec.getDescription() == null && spec.getReminders() == null) {
+                return ToolResult.error("Nothing to update: provide at least one field to change");
+            }
+        } catch (IllegalArgumentException e) {
+            return ToolResult.error(e.getMessage());
+        }
+
+        try {
+            boolean updated = dataSource.updateEvent(eventId, spec);
+            if (!updated) {
+                return ToolResult.error(
+                        "Event " + eventId + " not found. Use calendar_list_events to find "
+                        + "current event ids.");
+            }
+            JsonObject out = new JsonObject();
+            out.addProperty("event_id", eventId);
+            out.addProperty("updated", true);
+            return ToolResult.success(out);
+        } catch (CalendarException e) {
+            return ToolResult.error(e.getMessage());
+        }
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/util/CalendarPermissionHelper.java
+++ b/app/src/main/java/io/finett/droidclaw/util/CalendarPermissionHelper.java
@@ -1,0 +1,88 @@
+package io.finett.droidclaw.util;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+/**
+ * Helper for the calendar runtime permissions ({@code READ_CALENDAR} and
+ * {@code WRITE_CALENDAR}). Mirrors {@link NotificationPermissionHelper}.
+ */
+public class CalendarPermissionHelper {
+
+    private static final int REQUEST_CODE_CALENDAR_PERMISSION = 1002;
+
+    private final Context context;
+
+    public CalendarPermissionHelper(Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Static check usable from non-UI code (e.g. ToolRegistry registration).
+     * Returns true when both calendar permissions are granted.
+     */
+    public static boolean hasCalendarPermission(Context context) {
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+                == PackageManager.PERMISSION_GRANTED
+                && ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /** Instance flavour of {@link #hasCalendarPermission(Context)}. */
+    public boolean hasCalendarPermissions() {
+        return hasCalendarPermission(context);
+    }
+
+    /**
+     * Request the calendar permissions. Returns true when already granted,
+     * false when the system dialog was launched.
+     */
+    public boolean requestCalendarPermissions(Activity activity) {
+        if (hasCalendarPermissions()) {
+            return true;
+        }
+        ActivityCompat.requestPermissions(
+                activity,
+                new String[]{
+                        Manifest.permission.READ_CALENDAR,
+                        Manifest.permission.WRITE_CALENDAR
+                },
+                REQUEST_CODE_CALENDAR_PERMISSION
+        );
+        return false;
+    }
+
+    /**
+     * Handle the permission request result. Call from
+     * {@code Fragment.onRequestPermissionsResult()}.
+     */
+    public void handlePermissionResult(int requestCode, String[] permissions,
+                                       int[] grantResults, PermissionCallback callback) {
+        if (requestCode != REQUEST_CODE_CALENDAR_PERMISSION) {
+            return;
+        }
+        boolean allGranted = grantResults.length > 0;
+        for (int result : grantResults) {
+            if (result != PackageManager.PERMISSION_GRANTED) {
+                allGranted = false;
+                break;
+            }
+        }
+        if (allGranted) {
+            callback.onPermissionGranted();
+        } else {
+            callback.onPermissionDenied();
+        }
+    }
+
+    public interface PermissionCallback {
+        void onPermissionGranted();
+
+        void onPermissionDenied();
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -230,6 +230,7 @@ public class SettingsManager {
         config.setBackgroundExecEnabled(json.optBoolean("backgroundExecEnabled", false));
         config.setScreenControlEnabled(json.optBoolean("screenControlEnabled", false));
         config.setScreenControlTrustMode(json.optBoolean("screenControlTrustMode", false));
+        config.setCalendarEnabled(json.optBoolean("calendarEnabled", false));
         config.setShellBackend(json.optString("shellBackend", "local"));
         config.setSshHost(json.optString("sshHost", ""));
         config.setSshPort(json.optInt("sshPort", 22));
@@ -340,6 +341,7 @@ public class SettingsManager {
         json.put("backgroundExecEnabled", config.isBackgroundExecEnabled());
         json.put("screenControlEnabled", config.isScreenControlEnabled());
         json.put("screenControlTrustMode", config.isScreenControlTrustMode());
+        json.put("calendarEnabled", config.isCalendarEnabled());
         json.put("shellBackend", config.getShellBackend());
         json.put("sshHost", config.getSshHost());
         json.put("sshPort", config.getSshPort());

--- a/app/src/main/res/layout/fragment_agent_settings.xml
+++ b/app/src/main/res/layout/fragment_agent_settings.xml
@@ -572,6 +572,42 @@
 
         </LinearLayout>
 
+        <!-- Calendar Access Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="24dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/calendar_access"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/calendar_access_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_calendar_access"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
         <!-- Divider -->
         <View
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,9 @@
     <string name="screen_control_accessibility_granted">Accessibility access granted</string>
     <string name="screen_control_accessibility_not_granted">Accessibility access not granted</string>
     <string name="screen_control_open_accessibility_settings">Open Accessibility Settings</string>
+    <string name="calendar_access">Calendar Access</string>
+    <string name="calendar_access_description">Allow the agent to read and manage your device calendar events (Google and other synced calendars)</string>
+    <string name="calendar_permission_denied">Calendar permission denied — Calendar Access stays off. Grant it in system settings to enable it.</string>
     <string name="accessibility_service_label">DroidClaw Accessibility</string>
     <string name="accessibility_service_description">Lets DroidClaw read the visible UI and control the phone screen for agent tasks</string>
     <string name="network_timeouts">Network Timeouts</string>

--- a/app/src/test/java/io/finett/droidclaw/calendar/CalendarRepositoryTest.java
+++ b/app/src/test/java/io/finett/droidclaw/calendar/CalendarRepositoryTest.java
@@ -1,0 +1,702 @@
+package io.finett.droidclaw.calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.Manifest;
+import android.app.Application;
+import android.content.ContentProvider;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.UriMatcher;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.provider.CalendarContract;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowContentResolver;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * Tests {@link CalendarRepository} against an in-memory fake CalendarContract
+ * provider registered with Robolectric's content resolver.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CalendarRepositoryTest {
+
+    private static final long HOUR_MS = 3600 * 1000L;
+    private static final long DAY_MS = 24 * HOUR_MS;
+
+    private Context context;
+    private FakeCalendarProvider provider;
+    private CalendarRepository repository;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        // Robolectric denies dangerous permissions by default — grant them as the
+        // production flow (Settings toggle -> runtime dialog) would.
+        Shadows.shadowOf((Application) context).grantPermissions(
+                Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR);
+        provider = new FakeCalendarProvider();
+        provider.attachInfo(context, null);
+        ShadowContentResolver.registerProviderInternal(CalendarContract.AUTHORITY, provider);
+        repository = new CalendarRepository(context);
+    }
+
+    // ==================== Helpers ====================
+
+    private long addCalendar(long id, String name, String account, int accessLevel) {
+        ContentValues values = new ContentValues();
+        values.put(CalendarContract.Calendars._ID, id);
+        values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, name);
+        values.put(CalendarContract.Calendars.ACCOUNT_NAME, account);
+        values.put(CalendarContract.Calendars.ACCOUNT_TYPE, "com.google");
+        values.put(CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL, accessLevel);
+        values.put(CalendarContract.Calendars.VISIBLE, 1);
+        values.put(CalendarContract.Calendars.CALENDAR_TIME_ZONE, "UTC");
+        provider.calendars.add(values);
+        return id;
+    }
+
+    private long addEvent(long id, long calendarId, String title, long dtstart, Long dtend,
+                          String rrule) {
+        ContentValues values = new ContentValues();
+        values.put(CalendarContract.Events._ID, id);
+        values.put(CalendarContract.Events.CALENDAR_ID, calendarId);
+        values.put(CalendarContract.Events.TITLE, title);
+        values.put(CalendarContract.Events.DTSTART, dtstart);
+        if (dtend != null) {
+            values.put(CalendarContract.Events.DTEND, dtend);
+        }
+        if (rrule != null) {
+            values.put(CalendarContract.Events.RRULE, rrule);
+        }
+        provider.events.put(id, values);
+        return id;
+    }
+
+    private static void expectCalendarException(Runnable action, String messagePart) {
+        try {
+            action.run();
+            fail("Expected CalendarException containing: " + messagePart);
+        } catch (CalendarException e) {
+            assertTrue("Expected message containing '" + messagePart + "' but got: "
+                    + e.getMessage(), e.getMessage().contains(messagePart));
+        }
+    }
+
+    // ==================== Permission gating ====================
+
+    @Test
+    public void readOperations_withoutPermission_throwGuidingError() {
+        Shadows.shadowOf((Application) context).denyPermissions(
+                Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR);
+        expectCalendarException(() -> repository.getCalendars(), "Calendar permission not granted");
+        expectCalendarException(() -> repository.queryEvents(0, 10_000, null, null, 10),
+                "Calendar permission not granted");
+        expectCalendarException(() -> repository.getEvent(1), "Calendar permission not granted");
+    }
+
+    @Test
+    public void writeOperations_withoutPermission_throwGuidingError() {
+        Shadows.shadowOf((Application) context).denyPermissions(
+                Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR);
+        EventSpec spec = new EventSpec();
+        spec.setTitle("X");
+        spec.setDtStart(1_000L);
+        expectCalendarException(() -> repository.createEvent(spec), "Calendar permission not granted");
+        expectCalendarException(() -> repository.updateEvent(1, spec), "Calendar permission not granted");
+        expectCalendarException(() -> repository.deleteEvent(1), "Calendar permission not granted");
+    }
+
+    // ==================== getCalendars ====================
+
+    @Test
+    public void getCalendars_mapsRowsAndWritableFlag() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);   // owner
+        addCalendar(2, "Birthdays", "me@gmail.com", 200);  // read-only
+
+        List<CalendarInfo> calendars = repository.getCalendars();
+
+        assertEquals(2, calendars.size());
+        CalendarInfo personal = calendars.get(0);
+        assertEquals(1, personal.getId());
+        assertEquals("Personal", personal.getDisplayName());
+        assertEquals("me@gmail.com", personal.getAccountName());
+        assertTrue(personal.isWritable());
+        assertFalse(calendars.get(1).isWritable());
+    }
+
+    @Test
+    public void hasWritableCalendar_reflectsCalendars() {
+        assertFalse(repository.hasWritableCalendar());
+        addCalendar(1, "Birthdays", "me@gmail.com", 200);
+        assertFalse(repository.hasWritableCalendar());
+        addCalendar(2, "Personal", "me@gmail.com", 500);
+        assertTrue(repository.hasWritableCalendar());
+    }
+
+    // ==================== queryEvents ====================
+
+    @Test
+    public void queryEvents_returnsEventsInWindow_withCalendarName() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Lunch", 1_000_000_000_000L, 1_000_000_000_000L + HOUR_MS, null);
+
+        List<CalendarEvent> events = repository.queryEvents(
+                999_999_000_000L, 1_000_001_000_000L, null, null, 100);
+
+        assertEquals(1, events.size());
+        CalendarEvent event = events.get(0);
+        assertEquals(10, event.getEventId());
+        assertEquals("Lunch", event.getTitle());
+        assertEquals("Personal", event.getCalendarName());
+        assertEquals(1_000_000_000_000L, event.getStartMillis());
+        assertFalse(event.isRecurring());
+    }
+
+    @Test
+    public void queryEvents_excludesEventsOutsideWindow() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Inside", 1_000L, 2_000L, null);
+        addEvent(11, 1, "Outside", 50_000L, 51_000L, null);
+
+        List<CalendarEvent> events = repository.queryEvents(0, 10_000, null, null, 100);
+
+        assertEquals(1, events.size());
+        assertEquals("Inside", events.get(0).getTitle());
+    }
+
+    @Test
+    public void queryEvents_calendarFilter_restrictsResults() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addCalendar(2, "Work", "me@work.com", 700);
+        addEvent(10, 1, "Home thing", 1_000L, 2_000L, null);
+        addEvent(11, 2, "Work thing", 1_500L, 2_500L, null);
+
+        List<CalendarEvent> events = repository.queryEvents(0, 10_000, 2L, null, 100);
+
+        assertEquals(1, events.size());
+        assertEquals("Work thing", events.get(0).getTitle());
+    }
+
+    @Test
+    public void queryEvents_textQuery_matchesTitleLocationDescriptionCaseInsensitive() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Dentist Appointment", 1_000L, 2_000L, null);
+        addEvent(11, 1, "Gym", 3_000L, 4_000L, null);
+        provider.events.get(11L).put(CalendarContract.Events.EVENT_LOCATION, "fitness CENTER");
+
+        List<CalendarEvent> byTitle = repository.queryEvents(0, 10_000, null, "dentist", 100);
+        assertEquals(1, byTitle.size());
+        assertEquals("Dentist Appointment", byTitle.get(0).getTitle());
+
+        List<CalendarEvent> byLocation = repository.queryEvents(0, 10_000, null, "center", 100);
+        assertEquals(1, byLocation.size());
+        assertEquals("Gym", byLocation.get(0).getTitle());
+    }
+
+    @Test
+    public void queryEvents_recurringEvent_expandsToOccurrencesWithFlag() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Standup", 1_000L, null, "FREQ=DAILY");
+
+        List<CalendarEvent> events = repository.queryEvents(0, 10 * DAY_MS, null, null, 100);
+
+        assertEquals(3, events.size()); // fake expands recurring events to 3 occurrences
+        for (CalendarEvent event : events) {
+            assertTrue(event.isRecurring());
+            assertEquals("Standup", event.getTitle());
+        }
+        assertTrue(events.get(0).getStartMillis() < events.get(1).getStartMillis());
+    }
+
+    @Test
+    public void queryEvents_invalidWindow_throws() {
+        expectCalendarException(
+                () -> repository.queryEvents(5_000, 1_000, null, null, 100),
+                "End time must be after start time");
+    }
+
+    @Test
+    public void queryEvents_respectsLimit() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        for (int i = 0; i < 5; i++) {
+            addEvent(10 + i, 1, "Event " + i, 1_000L + i * 100, 2_000L + i * 100, null);
+        }
+        List<CalendarEvent> events = repository.queryEvents(0, 10_000, null, null, 2);
+        assertEquals(2, events.size());
+    }
+
+    // ==================== createEvent ====================
+
+    @Test
+    public void createEvent_minimalSpec_insertsRowWithDefaults() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+
+        EventSpec spec = new EventSpec();
+        spec.setTitle("Dentist");
+        spec.setDtStart(1_000_000L);
+
+        long eventId = repository.createEvent(spec);
+
+        assertTrue(eventId > 0);
+        ContentValues stored = provider.events.get(eventId);
+        assertNotNull(stored);
+        assertEquals("Dentist", stored.getAsString(CalendarContract.Events.TITLE));
+        assertEquals(Long.valueOf(1_000_000L), stored.getAsLong(CalendarContract.Events.DTSTART));
+        // Default duration: 1 hour
+        assertEquals(Long.valueOf(1_000_000L + HOUR_MS),
+                stored.getAsLong(CalendarContract.Events.DTEND));
+        assertEquals(Long.valueOf(1L), stored.getAsLong(CalendarContract.Events.CALENDAR_ID));
+        assertEquals(TimeZone.getDefault().getID(),
+                stored.getAsString(CalendarContract.Events.EVENT_TIMEZONE));
+    }
+
+    @Test
+    public void createEvent_allDay_setsFlagAndOneDayDuration() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+
+        EventSpec spec = new EventSpec();
+        spec.setTitle("Holiday");
+        spec.setDtStart(0L);
+        spec.setAllDay(true);
+
+        long eventId = repository.createEvent(spec);
+
+        ContentValues stored = provider.events.get(eventId);
+        assertEquals(Integer.valueOf(1), stored.getAsInteger(CalendarContract.Events.ALL_DAY));
+        assertEquals(Long.valueOf(DAY_MS), stored.getAsLong(CalendarContract.Events.DTEND));
+    }
+
+    @Test
+    public void createEvent_endNotAfterStart_throws() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        EventSpec spec = new EventSpec();
+        spec.setTitle("Broken");
+        spec.setDtStart(2_000L);
+        spec.setDtEnd(1_000L);
+        expectCalendarException(() -> repository.createEvent(spec), "after the start");
+    }
+
+    @Test
+    public void createEvent_missingTitle_throws() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        EventSpec spec = new EventSpec();
+        spec.setDtStart(1_000L);
+        expectCalendarException(() -> repository.createEvent(spec), "title");
+    }
+
+    @Test
+    public void createEvent_noWritableCalendar_throws() {
+        addCalendar(1, "Birthdays", "me@gmail.com", 200);
+        EventSpec spec = new EventSpec();
+        spec.setTitle("X");
+        spec.setDtStart(1_000L);
+        expectCalendarException(() -> repository.createEvent(spec), "No writable calendar");
+    }
+
+    @Test
+    public void createEvent_multipleWritable_withoutExplicitId_throws() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addCalendar(2, "Work", "me@work.com", 700);
+        EventSpec spec = new EventSpec();
+        spec.setTitle("X");
+        spec.setDtStart(1_000L);
+        expectCalendarException(() -> repository.createEvent(spec), "calendar_id");
+    }
+
+    @Test
+    public void createEvent_unknownCalendarId_throws() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        EventSpec spec = new EventSpec();
+        spec.setTitle("X");
+        spec.setDtStart(1_000L);
+        spec.setCalendarId(999L);
+        expectCalendarException(() -> repository.createEvent(spec), "not found");
+    }
+
+    @Test
+    public void createEvent_readOnlyCalendar_throws() {
+        addCalendar(1, "Birthdays", "me@gmail.com", 200);
+        addCalendar(2, "Personal", "me@gmail.com", 700);
+        EventSpec spec = new EventSpec();
+        spec.setTitle("X");
+        spec.setDtStart(1_000L);
+        spec.setCalendarId(1L);
+        expectCalendarException(() -> repository.createEvent(spec), "read-only");
+    }
+
+    @Test
+    public void createEvent_reminders_areInserted() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        EventSpec spec = new EventSpec();
+        spec.setTitle("Call");
+        spec.setDtStart(1_000L);
+        spec.setReminders(Arrays.asList(30, 1440));
+
+        long eventId = repository.createEvent(spec);
+
+        assertEquals(2, provider.reminders.size());
+        assertEquals(Integer.valueOf(30),
+                provider.reminders.get(0).getAsInteger(CalendarContract.Reminders.MINUTES));
+        assertEquals(Long.valueOf(eventId),
+                provider.reminders.get(0).getAsLong(CalendarContract.Reminders.EVENT_ID));
+        assertEquals(Integer.valueOf(CalendarContract.Reminders.METHOD_ALERT),
+                provider.reminders.get(0).getAsInteger(CalendarContract.Reminders.METHOD));
+    }
+
+    // ==================== getEvent ====================
+
+    @Test
+    public void getEvent_returnsEventWithDetails() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        ContentValues values = new ContentValues();
+        values.put(CalendarContract.Events.EVENT_LOCATION, "Office");
+        values.put(CalendarContract.Events.DESCRIPTION, "Bring notes");
+        addEvent(10, 1, "Meeting", 1_000L, 2_000L, null);
+        provider.events.get(10L).putAll(values);
+
+        CalendarEvent event = repository.getEvent(10);
+
+        assertNotNull(event);
+        assertEquals("Meeting", event.getTitle());
+        assertEquals("Office", event.getLocation());
+        assertEquals("Bring notes", event.getDescription());
+        assertEquals("Personal", event.getCalendarName());
+        assertFalse(event.isRecurring());
+    }
+
+    @Test
+    public void getEvent_unknownId_returnsNull() {
+        assertNull(repository.getEvent(999));
+    }
+
+    @Test
+    public void getEvent_recurringSeries_hasRecurringFlag() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Standup", 1_000L, null, "FREQ=DAILY");
+        CalendarEvent event = repository.getEvent(10);
+        assertNotNull(event);
+        assertTrue(event.isRecurring());
+    }
+
+    // ==================== updateEvent ====================
+
+    @Test
+    public void updateEvent_changesTitle() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Old", 1_000L, 2_000L, null);
+
+        EventSpec spec = new EventSpec();
+        spec.setTitle("New");
+
+        assertTrue(repository.updateEvent(10, spec));
+        assertEquals("New", provider.events.get(10L).getAsString(CalendarContract.Events.TITLE));
+    }
+
+    @Test
+    public void updateEvent_movesTimedEvent() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Meeting", 1_000L, 2_000L, null);
+
+        EventSpec spec = new EventSpec();
+        spec.setDtStart(5_000L);
+        spec.setDtEnd(6_000L);
+
+        assertTrue(repository.updateEvent(10, spec));
+        assertEquals(Long.valueOf(5_000L),
+                provider.events.get(10L).getAsLong(CalendarContract.Events.DTSTART));
+        assertEquals(Long.valueOf(6_000L),
+                provider.events.get(10L).getAsLong(CalendarContract.Events.DTEND));
+    }
+
+    @Test
+    public void updateEvent_unknownId_returnsFalse() {
+        EventSpec spec = new EventSpec();
+        spec.setTitle("New");
+        assertFalse(repository.updateEvent(999, spec));
+    }
+
+    @Test
+    public void updateEvent_recurringTimeChange_throws() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Standup", 1_000L, null, "FREQ=DAILY");
+
+        EventSpec spec = new EventSpec();
+        spec.setDtStart(5_000L);
+
+        expectCalendarException(() -> repository.updateEvent(10, spec), "recurring");
+    }
+
+    @Test
+    public void updateEvent_recurringNonTimeChange_allowed() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Standup", 1_000L, null, "FREQ=DAILY");
+
+        EventSpec spec = new EventSpec();
+        spec.setLocation("Room 2");
+
+        assertTrue(repository.updateEvent(10, spec));
+        assertEquals("Room 2",
+                provider.events.get(10L).getAsString(CalendarContract.Events.EVENT_LOCATION));
+    }
+
+    @Test
+    public void updateEvent_emptySpec_throws() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Meeting", 1_000L, 2_000L, null);
+        expectCalendarException(() -> repository.updateEvent(10, new EventSpec()),
+                "No fields to update");
+    }
+
+    @Test
+    public void updateEvent_endNotAfterStart_throws() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Meeting", 1_000L, 2_000L, null);
+
+        EventSpec spec = new EventSpec();
+        spec.setDtStart(9_000L);
+        spec.setDtEnd(8_000L);
+
+        expectCalendarException(() -> repository.updateEvent(10, spec), "after the start");
+    }
+
+    // ==================== deleteEvent ====================
+
+    @Test
+    public void deleteEvent_removesExistingEvent() {
+        addCalendar(1, "Personal", "me@gmail.com", 700);
+        addEvent(10, 1, "Old", 1_000L, 2_000L, null);
+
+        assertTrue(repository.deleteEvent(10));
+        assertFalse(provider.events.containsKey(10L));
+    }
+
+    @Test
+    public void deleteEvent_unknownId_returnsFalse() {
+        assertFalse(repository.deleteEvent(999));
+    }
+
+    // ==================== Fake CalendarContract provider ====================
+
+    /**
+     * Minimal in-memory CalendarContract fake. Supports calendars, events
+     * (with item URIs), reminders, and instance-range queries with simple
+     * expansion of recurring events (3 daily occurrences).
+     */
+    private static class FakeCalendarProvider extends ContentProvider {
+
+        private static final int CALENDARS = 1;
+        private static final int EVENTS = 2;
+        private static final int EVENT_ITEM = 3;
+        private static final int INSTANCES_RANGE = 4;
+        private static final int REMINDERS = 5;
+
+        private static final UriMatcher MATCHER = new UriMatcher(UriMatcher.NO_MATCH);
+
+        static {
+            MATCHER.addURI(CalendarContract.AUTHORITY, "calendars", CALENDARS);
+            MATCHER.addURI(CalendarContract.AUTHORITY, "events", EVENTS);
+            MATCHER.addURI(CalendarContract.AUTHORITY, "events/#", EVENT_ITEM);
+            MATCHER.addURI(CalendarContract.AUTHORITY, "instances/when/*/*", INSTANCES_RANGE);
+            MATCHER.addURI(CalendarContract.AUTHORITY, "reminders", REMINDERS);
+        }
+
+        final List<ContentValues> calendars = new ArrayList<>();
+        final Map<Long, ContentValues> events = new LinkedHashMap<>();
+        final List<ContentValues> reminders = new ArrayList<>();
+        private long nextEventId = 1_000;
+
+        @Override
+        public boolean onCreate() {
+            return true;
+        }
+
+        @Override
+        public Cursor query(Uri uri, String[] projection, String selection,
+                            String[] selectionArgs, String sortOrder) {
+            switch (MATCHER.match(uri)) {
+                case CALENDARS:
+                    return toCursor(projection, calendars);
+
+                case EVENT_ITEM: {
+                    long id = ContentUris.parseId(uri);
+                    ContentValues values = events.get(id);
+                    List<ContentValues> rows = values != null
+                            ? java.util.Collections.singletonList(values)
+                            : java.util.Collections.emptyList();
+                    return toCursor(projection, rows);
+                }
+
+                case INSTANCES_RANGE: {
+                    // Path: instances/when/<begin>/<end>
+                    long begin = Long.parseLong(uri.getPathSegments().get(2));
+                    long end = Long.parseLong(uri.getPathSegments().get(3));
+                    List<ContentValues> occurrences = expandOccurrences(begin, end);
+                    occurrences = applyInstanceFilters(occurrences, selection, selectionArgs);
+                    return toCursor(projection, occurrences);
+                }
+
+                default:
+                    return toCursor(projection, java.util.Collections.emptyList());
+            }
+        }
+
+        @Override
+        public Uri insert(Uri uri, ContentValues values) {
+            switch (MATCHER.match(uri)) {
+                case EVENTS: {
+                    long id = nextEventId++;
+                    ContentValues copy = new ContentValues(values);
+                    copy.put(CalendarContract.Events._ID, id);
+                    events.put(id, copy);
+                    return ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, id);
+                }
+                case REMINDERS: {
+                    reminders.add(new ContentValues(values));
+                    return Uri.withAppendedPath(CalendarContract.Reminders.CONTENT_URI,
+                            String.valueOf(reminders.size()));
+                }
+                default:
+                    return null;
+            }
+        }
+
+        @Override
+        public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+            if (MATCHER.match(uri) == EVENT_ITEM) {
+                long id = ContentUris.parseId(uri);
+                ContentValues existing = events.get(id);
+                if (existing == null) {
+                    return 0;
+                }
+                existing.putAll(values);
+                return 1;
+            }
+            return 0;
+        }
+
+        @Override
+        public int delete(Uri uri, String selection, String[] selectionArgs) {
+            if (MATCHER.match(uri) == EVENT_ITEM) {
+                long id = ContentUris.parseId(uri);
+                if (events.remove(id) != null) {
+                    reminders.removeIf(r -> {
+                        Long eventId = r.getAsLong(CalendarContract.Reminders.EVENT_ID);
+                        return eventId != null && eventId == id;
+                    });
+                    return 1;
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public String getType(Uri uri) {
+            return null;
+        }
+
+        /** Expand stored events into instance rows within [begin, end). */
+        private List<ContentValues> expandOccurrences(long begin, long end) {
+            List<ContentValues> occurrences = new ArrayList<>();
+            for (ContentValues event : events.values()) {
+                long dtstart = event.getAsLong(CalendarContract.Events.DTSTART);
+                Long dtendObj = event.getAsLong(CalendarContract.Events.DTEND);
+                long duration = (dtendObj != null ? dtendObj : dtstart + HOUR_MS) - dtstart;
+                String rrule = event.getAsString(CalendarContract.Events.RRULE);
+                boolean recurring = rrule != null && !rrule.isEmpty();
+
+                int occurrencesCount = recurring ? 3 : 1;
+                for (int i = 0; i < occurrencesCount; i++) {
+                    long occBegin = dtstart + i * DAY_MS;
+                    long occEnd = occBegin + duration;
+                    if (occBegin < end && occEnd > begin) {
+                        ContentValues row = new ContentValues(event);
+                        row.put(CalendarContract.Instances.EVENT_ID,
+                                event.getAsLong(CalendarContract.Events._ID));
+                        row.put(CalendarContract.Instances.BEGIN, occBegin);
+                        row.put(CalendarContract.Instances.END, occEnd);
+                        occurrences.add(row);
+                    }
+                }
+            }
+            occurrences.sort((a, b) -> Long.compare(
+                    a.getAsLong(CalendarContract.Instances.BEGIN),
+                    b.getAsLong(CalendarContract.Instances.BEGIN)));
+            return occurrences;
+        }
+
+        /**
+         * Apply the repository's fixed selection shapes: a calendar_id equality
+         * filter and/or a LOWER(...) LIKE text filter.
+         */
+        private List<ContentValues> applyInstanceFilters(List<ContentValues> rows,
+                                                         String selection, String[] selectionArgs) {
+            if (selection == null || selectionArgs == null) {
+                return rows;
+            }
+            List<ContentValues> result = new ArrayList<>(rows);
+
+            if (selection.contains(CalendarContract.Instances.CALENDAR_ID + " = ?")) {
+                long calendarFilter = Long.parseLong(selectionArgs[0]);
+                result.removeIf(row -> {
+                    Long calendarId = row.getAsLong(CalendarContract.Instances.CALENDAR_ID);
+                    return calendarId == null || calendarId != calendarFilter;
+                });
+            }
+
+            String likeArg = null;
+            for (String arg : selectionArgs) {
+                if (arg != null && arg.startsWith("%") && arg.endsWith("%")) {
+                    likeArg = arg;
+                    break;
+                }
+            }
+            if (likeArg != null) {
+                String needle = likeArg.substring(1, likeArg.length() - 1)
+                        .toLowerCase(Locale.ROOT);
+                result.removeIf(row -> !containsText(row, CalendarContract.Instances.TITLE, needle)
+                        && !containsText(row, CalendarContract.Instances.EVENT_LOCATION, needle)
+                        && !containsText(row, CalendarContract.Instances.DESCRIPTION, needle));
+            }
+            return result;
+        }
+
+        private static boolean containsText(ContentValues row, String column, String needle) {
+            String value = row.getAsString(column);
+            return value != null && value.toLowerCase(Locale.ROOT).contains(needle);
+        }
+
+        private static Cursor toCursor(String[] projection, List<ContentValues> rows) {
+            MatrixCursor cursor = new MatrixCursor(projection);
+            for (ContentValues row : rows) {
+                Object[] values = new Object[projection.length];
+                for (int i = 0; i < projection.length; i++) {
+                    values[i] = row.get(projection[i]);
+                }
+                cursor.addRow(values);
+            }
+            return cursor;
+        }
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/calendar/CalendarTimeUtilTest.java
+++ b/app/src/test/java/io/finett/droidclaw/calendar/CalendarTimeUtilTest.java
@@ -1,0 +1,134 @@
+package io.finett.droidclaw.calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class CalendarTimeUtilTest {
+
+    private static final ZoneId DEVICE = ZoneId.systemDefault();
+
+    private static long expectedLocal(String iso) {
+        return LocalDateTime.parse(iso).atZone(DEVICE).toInstant().toEpochMilli();
+    }
+
+    @Test
+    public void parse_localDateTimeWithoutSeconds() {
+        CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse("2026-06-01T15:00");
+        assertFalse(parsed.isDateOnly());
+        assertEquals(expectedLocal("2026-06-01T15:00:00"), parsed.getEpochMillis());
+    }
+
+    @Test
+    public void parse_localDateTimeWithSeconds() {
+        CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse("2026-06-01T15:30:45");
+        assertEquals(expectedLocal("2026-06-01T15:30:45"), parsed.getEpochMillis());
+    }
+
+    @Test
+    public void parse_spaceSeparatedDateTime() {
+        CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse("2026-06-01 15:30");
+        assertFalse(parsed.isDateOnly());
+        assertEquals(expectedLocal("2026-06-01T15:30:00"), parsed.getEpochMillis());
+    }
+
+    @Test
+    public void parse_explicitPositiveOffset() {
+        CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse("2026-06-01T15:00:00+02:00");
+        long expected = LocalDateTime.parse("2026-06-01T13:00:00")
+                .atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertEquals(expected, parsed.getEpochMillis());
+    }
+
+    @Test
+    public void parse_utcZulu() {
+        CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse("2026-06-01T15:00:00Z");
+        long expected = LocalDateTime.parse("2026-06-01T15:00:00")
+                .atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertEquals(expected, parsed.getEpochMillis());
+    }
+
+    @Test
+    public void parse_bareDate_isDateOnlyAtLocalMidnight() {
+        CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse("2026-06-01");
+        assertTrue(parsed.isDateOnly());
+        long expected = LocalDate.of(2026, 6, 1).atStartOfDay(DEVICE)
+                .toInstant().toEpochMilli();
+        assertEquals(expected, parsed.getEpochMillis());
+    }
+
+    @Test
+    public void parse_trimsWhitespace() {
+        CalendarTimeUtil.ParsedTime parsed = CalendarTimeUtil.parse("  2026-06-01T15:00  ");
+        assertEquals(expectedLocal("2026-06-01T15:00:00"), parsed.getEpochMillis());
+    }
+
+    @Test
+    public void parse_invalidString_throws() {
+        String[] invalid = {null, "", "   ", "tomorrow", "2026/06/01", "15:00", "2026-13-45"};
+        for (String s : invalid) {
+            try {
+                CalendarTimeUtil.parse(s);
+                fail("Expected IllegalArgumentException for input: " + s);
+            } catch (IllegalArgumentException expected) {
+                // ok
+            }
+        }
+    }
+
+    @Test
+    public void format_roundTripsLocalTime() {
+        long millis = expectedLocal("2026-06-01T15:00:00");
+        String formatted = CalendarTimeUtil.format(millis);
+        assertTrue("Formatted value should start with the local date-time, got: " + formatted,
+                formatted.startsWith("2026-06-01T15:00:00"));
+    }
+
+    @Test
+    public void format_invalidTimezoneFallsBackToDevice() {
+        long millis = expectedLocal("2026-06-01T15:00:00");
+        String formatted = CalendarTimeUtil.format(millis, "Not/AZone");
+        assertTrue(formatted.startsWith("2026-06-01T15:00:00"));
+    }
+
+    @Test
+    public void toUtcMidnight_returnsUtcMidnightOfLocalDay() {
+        // Noon local time on 2026-06-01
+        long noon = LocalDateTime.parse("2026-06-01T12:00:00")
+                .atZone(DEVICE).toInstant().toEpochMilli();
+        long utcMidnight = CalendarTimeUtil.toUtcMidnight(noon);
+
+        Instant instant = Instant.ofEpochMilli(utcMidnight);
+        ZonedDateTime utc = instant.atZone(ZoneOffset.UTC);
+        assertEquals(0, utc.getHour());
+        assertEquals(0, utc.getMinute());
+        // The UTC calendar day must match the device-local calendar day
+        LocalDate localDay = Instant.ofEpochMilli(noon).atZone(DEVICE).toLocalDate();
+        assertEquals(localDay, utc.toLocalDate());
+    }
+
+    @Test
+    public void plusOneDay_adds24Hours() {
+        long base = expectedLocal("2026-06-01T15:00:00");
+        assertEquals(base + 24 * 3600 * 1000L, CalendarTimeUtil.plusOneDay(base));
+    }
+
+    @Test
+    public void startOfToday_isAtMostNow_andPlusDaysOrders() {
+        long now = System.currentTimeMillis();
+        long today = CalendarTimeUtil.startOfToday();
+        assertTrue(today <= now);
+        assertTrue(CalendarTimeUtil.startOfTodayPlusDays(1) > today);
+        assertTrue(CalendarTimeUtil.startOfTodayPlusDays(7) > CalendarTimeUtil.startOfTodayPlusDays(1));
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/model/AgentConfigTest.java
+++ b/app/src/test/java/io/finett/droidclaw/model/AgentConfigTest.java
@@ -15,6 +15,13 @@ public class AgentConfigTest {
     }
 
     @Test
+    public void calendarEnabled_defaultIsFalse_andSettable() {
+        assertFalse(config.isCalendarEnabled());
+        config.setCalendarEnabled(true);
+        assertTrue(config.isCalendarEnabled());
+    }
+
+    @Test
     public void defaultConstructor_createsInstance() {
         AgentConfig c = new AgentConfig();
         assertNotNull(c);

--- a/app/src/test/java/io/finett/droidclaw/tool/ToolRegistryTest.java
+++ b/app/src/test/java/io/finett/droidclaw/tool/ToolRegistryTest.java
@@ -3,6 +3,8 @@ package io.finett.droidclaw.tool;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import android.Manifest;
+import android.app.Application;
 import android.content.Context;
 
 import com.google.gson.JsonArray;
@@ -15,11 +17,14 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
 
 import java.io.File;
 import java.util.List;
 
 import io.finett.droidclaw.filesystem.VirtualFileSystem;
+import io.finett.droidclaw.model.AgentConfig;
+import io.finett.droidclaw.util.SettingsManager;
 
 @RunWith(RobolectricTestRunner.class)
 public class ToolRegistryTest {
@@ -270,5 +275,57 @@ public class ToolRegistryTest {
         t2.join();
 
         assertEquals("Tool count should remain consistent", 18, toolRegistry.getToolCount());
+    }
+
+    // ==================== Calendar tool gating ====================
+
+    @Test
+    public void testCalendarTools_notRegisteredWithoutSettings() {
+        assertFalse("Calendar tools should not be registered without settings",
+                toolRegistry.hasToolWithName("calendar_list_events"));
+    }
+
+    @Test
+    public void testCalendarTools_notRegisteredWhenDisabled() {
+        SettingsManager settingsManager = new SettingsManager(context);
+        // calendarEnabled defaults to false
+        ToolRegistry registry = new ToolRegistry(context, settingsManager);
+        assertFalse(registry.hasToolWithName("calendar_list_events"));
+        assertFalse(registry.hasToolWithName("calendar_create_event"));
+    }
+
+    @Test
+    public void testCalendarTools_registeredWhenEnabledAndPermitted() {
+        Shadows.shadowOf((Application) context).grantPermissions(
+                Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR);
+        SettingsManager settingsManager = new SettingsManager(context);
+        // Baseline with calendar disabled (settings present, permission granted).
+        int baseCount = new ToolRegistry(context, settingsManager).getToolCount();
+        AgentConfig config = settingsManager.getAgentConfig();
+        config.setCalendarEnabled(true);
+        settingsManager.setAgentConfig(config);
+
+        ToolRegistry registry = new ToolRegistry(context, settingsManager);
+
+        assertTrue(registry.hasToolWithName("calendar_list_calendars"));
+        assertTrue(registry.hasToolWithName("calendar_list_events"));
+        assertTrue(registry.hasToolWithName("calendar_create_event"));
+        assertTrue(registry.hasToolWithName("calendar_update_event"));
+        assertTrue(registry.hasToolWithName("calendar_delete_event"));
+        assertEquals(baseCount + 5, registry.getToolCount());
+    }
+
+    @Test
+    public void testCalendarTools_notRegisteredWithoutPermission() {
+        // Robolectric denies dangerous permissions by default, mirroring a
+        // fresh install where the user has not granted calendar access.
+        SettingsManager settingsManager = new SettingsManager(context);
+        AgentConfig config = settingsManager.getAgentConfig();
+        config.setCalendarEnabled(true);
+        settingsManager.setAgentConfig(config);
+
+        ToolRegistry registry = new ToolRegistry(context, settingsManager);
+
+        assertFalse(registry.hasToolWithName("calendar_list_events"));
     }
 }

--- a/app/src/test/java/io/finett/droidclaw/tool/impl/CalendarToolsTest.java
+++ b/app/src/test/java/io/finett/droidclaw/tool/impl/CalendarToolsTest.java
@@ -1,0 +1,553 @@
+package io.finett.droidclaw.tool.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.finett.droidclaw.calendar.CalendarDataSource;
+import io.finett.droidclaw.calendar.CalendarEvent;
+import io.finett.droidclaw.calendar.CalendarException;
+import io.finett.droidclaw.calendar.CalendarInfo;
+import io.finett.droidclaw.calendar.CalendarTimeUtil;
+import io.finett.droidclaw.calendar.EventSpec;
+import io.finett.droidclaw.tool.ToolResult;
+
+/**
+ * Unit tests for the calendar tools against an in-memory fake
+ * {@link CalendarDataSource}. Plain JUnit — no Android runtime needed.
+ */
+public class CalendarToolsTest {
+
+    private static final ZoneId DEVICE = ZoneId.systemDefault();
+    private static final long HOUR_MS = 3600 * 1000L;
+    private static final long DAY_MS = 24 * HOUR_MS;
+
+    private FakeDataSource dataSource;
+    private CalendarListCalendarsTool listCalendarsTool;
+    private CalendarListEventsTool listEventsTool;
+    private CalendarCreateEventTool createEventTool;
+    private CalendarUpdateEventTool updateEventTool;
+    private CalendarDeleteEventTool deleteEventTool;
+
+    @Before
+    public void setUp() {
+        dataSource = new FakeDataSource();
+        listCalendarsTool = new CalendarListCalendarsTool(dataSource);
+        listEventsTool = new CalendarListEventsTool(dataSource);
+        createEventTool = new CalendarCreateEventTool(dataSource);
+        updateEventTool = new CalendarUpdateEventTool(dataSource);
+        deleteEventTool = new CalendarDeleteEventTool(dataSource);
+    }
+
+    private static long local(String iso) {
+        return java.time.LocalDateTime.parse(iso).atZone(DEVICE).toInstant().toEpochMilli();
+    }
+
+    private static CalendarEvent event(long id, String title, long start, long end) {
+        return new CalendarEvent(id, 1, "Personal", title, start, end, false,
+                "", "", "UTC", false);
+    }
+
+    // ==================== Definitions & approval flags ====================
+
+    @Test
+    public void toolNames_areStable() {
+        assertEquals("calendar_list_calendars", listCalendarsTool.getName());
+        assertEquals("calendar_list_events", listEventsTool.getName());
+        assertEquals("calendar_create_event", createEventTool.getName());
+        assertEquals("calendar_update_event", updateEventTool.getName());
+        assertEquals("calendar_delete_event", deleteEventTool.getName());
+    }
+
+    @Test
+    public void writeTools_requireApproval_readToolsDoNot() {
+        assertTrue(createEventTool.requiresApproval());
+        assertTrue(updateEventTool.requiresApproval());
+        assertTrue(deleteEventTool.requiresApproval());
+        assertFalse(listCalendarsTool.requiresApproval());
+        assertFalse(listEventsTool.requiresApproval());
+    }
+
+    @Test
+    public void definitions_haveRequiredParametersAndStrictSchema() {
+        JsonObject createParams = createEventTool.getDefinition().getFunction()
+                .getParameters();
+        assertTrue(createParams.getAsJsonArray("required").contains(
+                new com.google.gson.JsonPrimitive("title")));
+        assertTrue(createParams.getAsJsonArray("required").contains(
+                new com.google.gson.JsonPrimitive("start")));
+        assertFalse(createParams.getAsJsonArray("required").contains(
+                new com.google.gson.JsonPrimitive("end")));
+        assertFalse(createParams.get("additionalProperties").getAsBoolean());
+
+        // reminders parameter is an integer array
+        JsonObject reminders = createParams.getAsJsonObject("properties")
+                .getAsJsonObject("reminders");
+        assertEquals("array", reminders.get("type").getAsString());
+        assertEquals("integer", reminders.getAsJsonObject("items").get("type").getAsString());
+    }
+
+    // ==================== calendar_list_calendars ====================
+
+    @Test
+    public void listCalendars_returnsAllCalendarsAsJson() {
+        dataSource.calendars.add(new CalendarInfo(1, "Personal", "me@gmail.com",
+                "com.google", 700, true, "UTC"));
+        dataSource.calendars.add(new CalendarInfo(2, "Birthdays", "me@gmail.com",
+                "com.google", 200, true, "UTC"));
+
+        ToolResult result = listCalendarsTool.execute(new JsonObject());
+
+        assertTrue(result.isSuccess());
+        JsonObject json = com.google.gson.JsonParser.parseString(result.getContent())
+                .getAsJsonObject();
+        assertEquals(2, json.get("count").getAsInt());
+        JsonArray arr = json.getAsJsonArray("calendars");
+        assertEquals(1, arr.get(0).getAsJsonObject().get("calendar_id").getAsLong());
+        assertTrue(arr.get(0).getAsJsonObject().get("writable").getAsBoolean());
+        assertFalse(arr.get(1).getAsJsonObject().get("writable").getAsBoolean());
+    }
+
+    @Test
+    public void listCalendars_providerError_isSurfaced() {
+        dataSource.errorOnRead = "Calendar permission not granted.";
+        ToolResult result = listCalendarsTool.execute(new JsonObject());
+        assertFalse(result.isSuccess());
+        assertEquals("Calendar permission not granted.", result.getError());
+    }
+
+    // ==================== calendar_list_events ====================
+
+    @Test
+    public void listEvents_defaultWindow_returnsEvents() {
+        long start = CalendarTimeUtil.startOfToday();
+        dataSource.events.add(event(10, "Lunch", start + 12 * HOUR_MS, start + 13 * HOUR_MS));
+
+        ToolResult result = listEventsTool.execute(new JsonObject());
+
+        assertTrue(result.isSuccess());
+        assertEquals(start, dataSource.lastBegin);
+        assertEquals(start + 7 * DAY_MS, dataSource.lastEnd);
+        JsonObject json = com.google.gson.JsonParser.parseString(result.getContent())
+                .getAsJsonObject();
+        assertEquals(1, json.get("count").getAsInt());
+        assertEquals("Lunch", json.getAsJsonArray("events").get(0)
+                .getAsJsonObject().get("title").getAsString());
+    }
+
+    @Test
+    public void listEvents_customWindowAndFilters_arePassedThrough() {
+        JsonObject args = new JsonObject();
+        args.addProperty("start", "2026-06-01T09:00");
+        args.addProperty("end", "2026-06-02T09:00");
+        args.addProperty("query", "standup");
+        args.addProperty("calendar_id", 7);
+
+        ToolResult result = listEventsTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        assertEquals(local("2026-06-01T09:00:00"), dataSource.lastBegin);
+        assertEquals(local("2026-06-02T09:00:00"), dataSource.lastEnd);
+        assertEquals("standup", dataSource.lastTextQuery);
+        assertEquals(Long.valueOf(7), dataSource.lastCalendarId);
+    }
+
+    @Test
+    public void listEvents_invalidDate_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("start", "next tuesday");
+        ToolResult result = listEventsTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Unrecognised date/time"));
+    }
+
+    @Test
+    public void listEvents_endBeforeStart_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("start", "2026-06-02T09:00");
+        args.addProperty("end", "2026-06-01T09:00");
+        ToolResult result = listEventsTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("after"));
+    }
+
+    // ==================== calendar_create_event ====================
+
+    @Test
+    public void createEvent_minimalArgs_defaultsToOneHour() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "Dentist");
+        args.addProperty("start", "2026-06-01T15:00");
+
+        ToolResult result = createEventTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        EventSpec spec = dataSource.lastSpec;
+        assertEquals("Dentist", spec.getTitle());
+        assertEquals(Long.valueOf(local("2026-06-01T15:00:00")), spec.getDtStart());
+        assertEquals(Long.valueOf(local("2026-06-01T15:00:00") + HOUR_MS), spec.getDtEnd());
+        assertEquals(Boolean.FALSE, spec.getAllDay());
+
+        JsonObject json = com.google.gson.JsonParser.parseString(result.getContent())
+                .getAsJsonObject();
+        assertEquals(42, json.get("event_id").getAsLong());
+    }
+
+    @Test
+    public void createEvent_dateOnlyStart_becomesAllDay() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "Conference");
+        args.addProperty("start", "2026-06-01");
+
+        ToolResult result = createEventTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        EventSpec spec = dataSource.lastSpec;
+        assertEquals(Boolean.TRUE, spec.getAllDay());
+        long expectedStart = LocalDate.of(2026, 6, 1)
+                .atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertEquals(Long.valueOf(expectedStart), spec.getDtStart());
+        assertEquals(Long.valueOf(expectedStart + DAY_MS), spec.getDtEnd());
+    }
+
+    @Test
+    public void createEvent_allDayWithInclusiveEndDate() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "Vacation");
+        args.addProperty("start", "2026-06-01");
+        args.addProperty("end", "2026-06-03");
+        args.addProperty("all_day", true);
+
+        ToolResult result = createEventTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        EventSpec spec = dataSource.lastSpec;
+        long june1 = LocalDate.of(2026, 6, 1)
+                .atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+        // End date inclusive -> DTEND exclusive = June 4 UTC midnight
+        assertEquals(Long.valueOf(june1), spec.getDtStart());
+        assertEquals(Long.valueOf(june1 + 3 * DAY_MS), spec.getDtEnd());
+    }
+
+    @Test
+    public void createEvent_remindersAndMetadata_passedThrough() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "Call");
+        args.addProperty("start", "2026-06-01T10:00");
+        args.addProperty("end", "2026-06-01T10:30");
+        args.addProperty("location", "Office");
+        args.addProperty("description", "With Sam");
+        args.addProperty("calendar_id", 3);
+        args.addProperty("timezone", "Europe/Berlin");
+        JsonArray reminders = new JsonArray();
+        reminders.add(30);
+        reminders.add(1440);
+        args.add("reminders", reminders);
+
+        ToolResult result = createEventTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        EventSpec spec = dataSource.lastSpec;
+        assertEquals(Long.valueOf(3), spec.getCalendarId());
+        assertEquals("Office", spec.getLocation());
+        assertEquals("With Sam", spec.getDescription());
+        assertEquals("Europe/Berlin", spec.getTimezone());
+        assertEquals(Arrays.asList(30, 1440), spec.getReminders());
+    }
+
+    @Test
+    public void createEvent_missingTitle_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("start", "2026-06-01T15:00");
+        ToolResult result = createEventTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("title"));
+    }
+
+    @Test
+    public void createEvent_invalidStart_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "X");
+        args.addProperty("start", "garbage");
+        ToolResult result = createEventTool.execute(args);
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    public void createEvent_endBeforeStart_returnsError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "X");
+        args.addProperty("start", "2026-06-01T15:00");
+        args.addProperty("end", "2026-06-01T14:00");
+        ToolResult result = createEventTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("after"));
+    }
+
+    @Test
+    public void createEvent_providerError_isSurfaced() {
+        dataSource.errorOnWrite = "Multiple writable calendars exist. Call calendar_list_calendars and pass an explicit calendar_id.";
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "X");
+        args.addProperty("start", "2026-06-01T15:00");
+        ToolResult result = createEventTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("calendar_list_calendars"));
+    }
+
+    @Test
+    public void createEvent_approvalDescription_containsTitleAndTime() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "Dentist");
+        args.addProperty("start", "2026-06-01T15:00");
+        String description = createEventTool.getApprovalDescription(args);
+        assertTrue(description.contains("Dentist"));
+        assertTrue(description.contains("2026-06-01T15:00:00"));
+    }
+
+    @Test
+    public void createEvent_allDayApprovalDescription_marksAllDay() {
+        JsonObject args = new JsonObject();
+        args.addProperty("title", "Holiday");
+        args.addProperty("start", "2026-06-01");
+        String description = createEventTool.getApprovalDescription(args);
+        assertTrue(description.contains("(all-day)"));
+    }
+
+    @Test
+    public void createEvent_invalidArgs_approvalDescriptionFallsBack() {
+        String description = createEventTool.getApprovalDescription(new JsonObject());
+        assertEquals("Create calendar event", description);
+    }
+
+    // ==================== calendar_update_event ====================
+
+    @Test
+    public void updateEvent_renamesEvent() {
+        dataSource.events.add(event(5, "Old title", 0, HOUR_MS));
+
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+        args.addProperty("title", "New title");
+
+        ToolResult result = updateEventTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        assertEquals(Long.valueOf(5), dataSource.lastEventId);
+        assertEquals("New title", dataSource.lastSpec.getTitle());
+        assertNull(dataSource.lastSpec.getDtStart());
+    }
+
+    @Test
+    public void updateEvent_movesTimedEvent() {
+        dataSource.events.add(event(5, "Meeting", 0, HOUR_MS));
+
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+        args.addProperty("start", "2026-06-01T10:30");
+        args.addProperty("end", "2026-06-01T11:00");
+
+        ToolResult result = updateEventTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        assertEquals(Long.valueOf(local("2026-06-01T10:30:00")),
+                dataSource.lastSpec.getDtStart());
+        assertEquals(Long.valueOf(local("2026-06-01T11:00:00")),
+                dataSource.lastSpec.getDtEnd());
+    }
+
+    @Test
+    public void updateEvent_missingEventId_returnsError() {
+        ToolResult result = updateEventTool.execute(new JsonObject());
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("event_id"));
+    }
+
+    @Test
+    public void updateEvent_unknownEvent_returnsNotFoundError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 999);
+        args.addProperty("title", "New title");
+        ToolResult result = updateEventTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("not found"));
+    }
+
+    @Test
+    public void updateEvent_nothingToUpdate_returnsError() {
+        dataSource.events.add(event(5, "Meeting", 0, HOUR_MS));
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+        ToolResult result = updateEventTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("at least one field"));
+    }
+
+    @Test
+    public void updateEvent_endBeforeStart_returnsError() {
+        dataSource.events.add(event(5, "Meeting", 0, HOUR_MS));
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+        args.addProperty("start", "2026-06-01T12:00");
+        args.addProperty("end", "2026-06-01T11:00");
+        ToolResult result = updateEventTool.execute(args);
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    public void updateEvent_providerError_isSurfaced() {
+        dataSource.events.add(new CalendarEvent(5, 1, "Personal", "Series",
+                0, HOUR_MS, false, "", "", "UTC", true));
+        dataSource.errorOnWrite = "Event 5 is a recurring series.";
+
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+        args.addProperty("start", "2026-06-01T12:00");
+        ToolResult result = updateEventTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("recurring"));
+    }
+
+    @Test
+    public void updateEvent_approvalDescription_containsTitle() {
+        dataSource.events.add(event(5, "Team sync", 0, HOUR_MS));
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+        String description = updateEventTool.getApprovalDescription(args);
+        assertTrue(description.contains("Team sync"));
+        assertTrue(description.contains("5"));
+    }
+
+    // ==================== calendar_delete_event ====================
+
+    @Test
+    public void deleteEvent_existingEvent_isDeleted() {
+        dataSource.events.add(event(5, "Old meeting", 0, HOUR_MS));
+
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+
+        ToolResult result = deleteEventTool.execute(args);
+
+        assertTrue(result.isSuccess());
+        assertEquals(Long.valueOf(5), dataSource.lastEventId);
+        assertTrue(dataSource.deletedIds.contains(5L));
+        JsonObject json = com.google.gson.JsonParser.parseString(result.getContent())
+                .getAsJsonObject();
+        assertTrue(json.get("deleted").getAsBoolean());
+        assertEquals("Old meeting", json.get("title").getAsString());
+    }
+
+    @Test
+    public void deleteEvent_unknownEvent_returnsNotFoundError() {
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 999);
+        ToolResult result = deleteEventTool.execute(args);
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("not found"));
+    }
+
+    @Test
+    public void deleteEvent_missingEventId_returnsError() {
+        ToolResult result = deleteEventTool.execute(new JsonObject());
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("event_id"));
+    }
+
+    @Test
+    public void deleteEvent_approvalDescription_marksRecurringSeries() {
+        dataSource.events.add(new CalendarEvent(5, 1, "Personal", "Weekly sync",
+                0, HOUR_MS, false, "", "", "UTC", true));
+        JsonObject args = new JsonObject();
+        args.addProperty("event_id", 5);
+        String description = deleteEventTool.getApprovalDescription(args);
+        assertTrue(description.contains("Weekly sync"));
+        assertTrue(description.contains("ENTIRE recurring series"));
+    }
+
+    // ==================== Fake data source ====================
+
+    private static class FakeDataSource implements CalendarDataSource {
+        final List<CalendarInfo> calendars = new ArrayList<>();
+        final List<CalendarEvent> events = new ArrayList<>();
+        final List<Long> deletedIds = new ArrayList<>();
+
+        long lastBegin;
+        long lastEnd;
+        Long lastCalendarId;
+        String lastTextQuery;
+        EventSpec lastSpec;
+        Long lastEventId;
+        String errorOnRead;
+        String errorOnWrite;
+
+        @Override
+        public List<CalendarInfo> getCalendars() {
+            if (errorOnRead != null) throw new CalendarException(errorOnRead);
+            return calendars;
+        }
+
+        @Override
+        public CalendarEvent getEvent(long eventId) {
+            if (errorOnRead != null) throw new CalendarException(errorOnRead);
+            for (CalendarEvent event : events) {
+                if (event.getEventId() == eventId) return event;
+            }
+            return null;
+        }
+
+        @Override
+        public List<CalendarEvent> queryEvents(long beginMillis, long endMillis,
+                                               Long calendarId, String textQuery, int limit) {
+            if (errorOnRead != null) throw new CalendarException(errorOnRead);
+            lastBegin = beginMillis;
+            lastEnd = endMillis;
+            lastCalendarId = calendarId;
+            lastTextQuery = textQuery;
+            return events;
+        }
+
+        @Override
+        public long createEvent(EventSpec spec) {
+            if (errorOnWrite != null) throw new CalendarException(errorOnWrite);
+            lastSpec = spec;
+            return 42;
+        }
+
+        @Override
+        public boolean updateEvent(long eventId, EventSpec spec) {
+            if (errorOnWrite != null) throw new CalendarException(errorOnWrite);
+            lastEventId = eventId;
+            lastSpec = spec;
+            return getEvent(eventId) != null;
+        }
+
+        @Override
+        public boolean deleteEvent(long eventId) {
+            if (errorOnWrite != null) throw new CalendarException(errorOnWrite);
+            lastEventId = eventId;
+            deletedIds.add(eventId);
+            return true;
+        }
+
+        @Override
+        public boolean hasWritableCalendar() {
+            return true;
+        }
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
+++ b/app/src/test/java/io/finett/droidclaw/util/SettingsManagerTest.java
@@ -138,6 +138,21 @@ public class SettingsManagerTest {
     }
 
     @Test
+    public void calendarEnabled_defaultIsFalse() {
+        assertFalse(settingsManager.getAgentConfig().isCalendarEnabled());
+    }
+
+    @Test
+    public void calendarEnabled_persistsAcrossInstances() {
+        AgentConfig config = settingsManager.getAgentConfig();
+        config.setCalendarEnabled(true);
+        settingsManager.setAgentConfig(config);
+
+        SettingsManager newInstance = new SettingsManager(context);
+        assertTrue(newInstance.getAgentConfig().isCalendarEnabled());
+    }
+
+    @Test
     public void setDefaultModel_storesValue() {
         Provider provider = createTestProvider("test-provider", "Test Provider",
                 "https://api.test.com", "test-api-key");

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,4 @@ Searching references?
 - [User Profile (USER.md)](reference/user.md) — what the agent knows about you
 - [Agent Identity (SOUL.md)](reference/soul.md) — the agent's values, capabilities, and working style
 - [Agent Tools: App & Screen Control](features/agent-tools.md) — how the agent operates your phone and runs shell commands
+- [Calendar Tools](features/calendar.md) — let the agent read and manage your device calendar

--- a/docs/features/calendar-integration-plan.md
+++ b/docs/features/calendar-integration-plan.md
@@ -1,0 +1,223 @@
+# Calendar Integration — Implementation Plan
+
+Status: **implemented** (Phases 1–3; free-time finder deferred as noted in §7)
+Target: agent tools backed by the Android CalendarProvider (`CalendarContract`)
+
+> Implementation summary: `READ_CALENDAR`/`WRITE_CALENDAR` manifest permissions,
+> `calendarEnabled` flag in `AgentConfig`/Settings (Agent settings → Calendar Access,
+> with runtime permission prompt via `CalendarPermissionHelper`), a `calendar` package
+> (`CalendarRepository` over `CalendarContract`, models, `CalendarTimeUtil`), and five
+> tools (`calendar_list_calendars`, `calendar_list_events`, `calendar_create_event`,
+> `calendar_update_event`, `calendar_delete_event`) registered in `ToolRegistry` only
+> when the setting is on and permissions are granted. Write tools require approval.
+> Unit tests: `CalendarTimeUtilTest`, `CalendarRepositoryTest` (fake provider),
+> `CalendarToolsTest`, plus gating tests in `ToolRegistryTest`. Instrumented:
+> `CalendarRepositoryInstrumentedTest` (real device provider; throwaway sync-adapter
+> calendar, API 28+ via `GrantPermissionRule`, auto-skips on providers that reject
+> third-party calendar creation) — run with `./gradlew connectedAndroidTest`.
+
+## 1. Goal
+
+Let the DroidClaw agent read and manage the device calendar through the normal
+tool-calling loop, e.g.:
+
+- "What's on my calendar today / this week?"
+- "Book a dentist appointment Friday 14:00–15:00 in my personal calendar."
+- "Move tomorrow's standup to 10:30." / "Cancel the sync meeting."
+- "When am I free Thursday afternoon?"
+- Combined with existing cron/heartbeat: "Every morning at 08:00, send me my agenda."
+
+## 2. Integration target: Android CalendarProvider
+
+Use the system `CalendarContract` content provider (`READ_CALENDAR` /
+`WRITE_CALENDAR` runtime permissions). One API covers Google Calendar,
+Samsung/Etar, DAVx5 (CalDAV sync), Nextcloud, etc. — whatever the user
+already syncs to the device. No extra SDK, no OAuth, works fully offline,
+min SDK 24 is fine.
+
+Not in first scope (possible later phases):
+
+- Direct CalDAV client (would mirror the `SearxngSearchTool` "self-hosted
+  endpoint" pattern).
+- Google Calendar REST API + OAuth (heavy, network-only, redundant while
+  Google accounts already sync into the provider).
+
+Reminders are inserted as `CalendarContract.Reminders` rows — the calendar
+app fires the alarms, so DroidClaw needs no alarm permissions.
+
+## 3. New components
+
+### 3.1 `calendar` package (data layer)
+
+| Class | Purpose |
+|---|---|
+| `calendar/CalendarRepository.java` | Thin wrapper over `CalendarContract`: list calendars, query events (via `Instances` for recurrence expansion), insert/update/delete events, insert reminders. All cursor/URI handling lives here. |
+| `calendar/CalendarEvent.java` | Plain model: id, calendarId, calendarName/account, title, start/end (epoch millis + ISO-8601 with offset), allDay, location, description, availability. Has `toJson()` for tool output. |
+| `calendar/CalendarInfo.java` | Calendar metadata: id, displayName, accountName, color, access level (`CAL_ACCESS_*` → writable?), `visible`. |
+| `calendar/CalendarTimeUtil.java` | Parse/validate LLM-supplied ISO-8601 (`yyyy-MM-dd'T'HH:mm(:ss)` with optional offset; bare date ⇒ all-day), format output, default timezone = device TZ. |
+| `util/CalendarPermissionHelper.java` | Mirrors `NotificationPermissionHelper`: check/request `READ_CALENDAR`+`WRITE_CALENDAR` (API 23+ runtime permissions). |
+
+Design for testability: tools receive a small `CalendarDataSource` interface
+implemented by `CalendarRepository`; unit tests inject fakes, instrumented
+tests hit the real provider.
+
+### 3.2 Tools (`tool/impl/`)
+
+Follow the `OpenAppTool`/`CreateTaskTool` pattern (Context-injecting ctor,
+`ParametersBuilder` definitions, `getApprovalDescription`).
+
+| Tool | Approval | Notes |
+|---|---|---|
+| `calendar_list_calendars` | DEFAULT (read) | Returns writable calendars so the LLM can pick a `calendar_id` before creating. |
+| `calendar_list_events` | DEFAULT (read) | Args: `start`/`end` (ISO-8601, default = today / next 7 days), optional `query` (text match on title/location/description), optional `calendar_id`. Uses `Instances` so recurring events expand correctly. Returns JSON array of `CalendarEvent`. |
+| `calendar_create_event` | **requiresApproval = true** | Args: `title` (req), `start` (req), `end` (optional ⇒ 1 h default), `calendar_id` (optional ⇒ single writable calendar, else error telling the LLM to call `calendar_list_calendars`), `all_day`, `location`, `description`, `reminders` (int minutes array, default from calendar setting or none). |
+| `calendar_update_event` | **requiresApproval = true** | Args: `event_id` (req) + any subset of create fields. For recurring instances: optional `scope: "this_event"\|"all_events"` — first implementation: only non-recurring + full-series updates; instance exceptions are a phase-3 enhancement. |
+| `calendar_delete_event` | **requiresApproval = true** | Args: `event_id` (req). Recurring: whole series only in phase 1. |
+| `calendar_find_free_time` (stretch) | DEFAULT | Query busy intervals in window, return free slots. Pure computation over `Instances` results — no extra permission. |
+
+Reads follow the global `requireApproval` toggle and are individually
+overridable in the existing Tool Approval settings screen
+(`ToolApprovalMode.DEFAULT / ALWAYS_APPROVE / ALWAYS_REJECT`) — no new
+machinery needed since overrides are keyed by tool name.
+
+Error contract: permission missing ⇒ `ToolResult.error("Calendar permission
+not granted. Ask the user to enable it in Settings → Agent → Calendar
+access.")`; no writable calendar / not found ⇒ instructive errors so the LLM
+self-corrects.
+
+### 3.3 Settings plumbing
+
+- `model/AgentConfig.java`: add `calendarEnabled` (default `false`) +
+  getter/setter, mirroring `screenControlEnabled`.
+- `util/SettingsManager.java`: add to `parseAgentConfig` /
+  `serializeAgentConfig` (`json.optBoolean("calendarEnabled", false)`).
+- `tool/ToolRegistry.registerTools()`: gated registration, mirroring the
+  screen-control block:
+
+```java
+// Calendar tools — only when enabled in settings AND permission granted
+if (settingsManager != null
+        && settingsManager.getAgentConfig().isCalendarEnabled()
+        && CalendarPermissionHelper.hasCalendarPermission(context)) {
+    CalendarRepository repo = new CalendarRepository(context);
+    registerTool(new CalendarListCalendarsTool(repo));
+    registerTool(new CalendarListEventsTool(repo));
+    registerTool(new CalendarCreateEventTool(repo));
+    registerTool(new CalendarUpdateEventTool(repo));
+    registerTool(new CalendarDeleteEventTool(repo));
+}
+```
+
+Because `ToolRegistry` is rebuilt per agent run (ChatFragment,
+`AgentExecutionService`, `BaseTaskWorker`), toggling the setting or granting
+the permission takes effect on the next run with no extra invalidation work.
+Background cron/heartbeat agents automatically get the same tools.
+
+- `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.READ_CALENDAR" />
+<uses-permission android:name="android.permission.WRITE_CALENDAR" />
+```
+
+- UI: `AgentSettingsFragment` — new `switch_calendar_access` block in
+  `fragment_agent_settings.xml` (copy the screen-control section, ~line 507).
+  On enabling: request the runtime permission first
+  (`CalendarPermissionHelper.requestCalendarPermissions(activity)`); if
+  denied, keep the switch off and show a Snackbar explaining why.
+
+### 3.4 System prompt / discoverability
+
+`LlmApiService` already injects the current date/time — the agent can reason
+about "today/tomorrow" and translate to ISO timestamps. No prompt change
+strictly required; optionally mention calendar tools in the built-in skills
+docs (see §5).
+
+## 4. Key implementation details
+
+### 4.1 CalendarContract specifics
+
+- **Calendars**: query `CalendarContract.Calendars` for `_ID`,
+  `CALENDAR_DISPLAY_NAME`, `ACCOUNT_NAME`, `CALENDAR_ACCESS_LEVEL`
+  (writable ⇔ ≥ `CAL_ACCESS_CONTRIBUTOR`), `VISIBLE`, `TIME_ZONE`.
+- **Reading events**: query `CalendarContract.Instances` (not `Events`) with
+  `BEGIN/END` window so recurring events expand. Join back to calendars for
+  display name. Handle `Events.DTSTART == null` exception rows.
+- **All-day events**: set `ALL_DAY=1`, start/end are UTC midnight; convert
+  user's local date ↔ UTC midnight at the edges.
+- **Creating**: `ContentValues` with `CALENDAR_ID`, `TITLE`, `DTSTART`,
+  either `DTEND` (non-recurring) or `RRULE`+`DURATION` (recurring, phase 3),
+  `EVENT_TIMEZONE` = device timezone id.
+- **Updating**: `ContentResolver.update(Event.CONTENT_URI, id)`; moving an
+  event = update `DTSTART`/`DTEND`.
+- **Deleting**: `delete(ContentUris.withAppendedId(Events.CONTENT_URI, id))`.
+- **Reminders**: insert into `Reminders` with `MINUTES` + `METHOD_ALERT`.
+
+### 4.2 Privacy & safety
+
+- Calendar content is personal data that enters the LLM context — the
+  settings toggle wording should say so ("Agent can read your calendar
+  events").
+- Writes always default to approval; power users can set
+  `calendar_create_event` to `ALWAYS_APPROVE` via the existing per-tool
+  approval overrides.
+- Tools never expose events when disabled/unpermitted: they are simply not
+  registered (and `executeTool` errors defensively).
+
+## 5. Documentation & skills
+
+- `docs/features/calendar.md`: user-facing doc in the style of
+  `docs/features/agent-tools.md` (tool table, permission flow, example
+  prompts, privacy note). Link from `docs/user/settings.md`.
+- Optional: built-in skill asset `.agent/skills/calendar_assistant/SKILL.md`
+  with prompting guidance (time-window defaults, list calendars before
+  create, ISO-8601 format) so the agent uses the tools idiomatically.
+
+## 6. Testing plan
+
+Existing infra: JUnit4 + Robolectric + Mockito (`testImplementation`),
+Espresso instrumented tests.
+
+Unit (Robolectric):
+- `CalendarTimeUtilTest` — parse/format edge cases: naive datetime (device
+  TZ), explicit offsets, bare dates ⇒ all-day, invalid strings rejected.
+- `CalendarRepositoryTest` — seed Robolectric's content resolver with
+  `CalendarContract` rows; verify query windows, recurrence expansion,
+  insert/update/delete round-trips, all-day handling.
+- `CalendarToolsTest` — definition validity, required-arg validation,
+  `requiresApproval()` semantics, approval descriptions, permission-missing
+  error text, JSON output shape (mirror `ListAppsToolTest`/`OpenAppToolTest`).
+- Extend `AgentConfigTest` + `SettingsManagerTest` for `calendarEnabled`
+  round-trip.
+
+Instrumented:
+- `CalendarRepositoryInstrumentedTest` — create a dedicated throwaway
+  calendar account (`ACCOUNT_TYPE` local), CRUD events, clean up in
+  `@After`; guard with `@SdkSuppress` where provider behavior differs.
+
+## 7. Phased delivery
+
+| Phase | Scope | Effort est. |
+|---|---|---|
+| **1. Plumbing** | Manifest permissions, `CalendarPermissionHelper`, `AgentConfig.calendarEnabled`, SettingsManager parse/serialize, settings switch + permission flow, gated (empty) registration block. | ~0.5 day |
+| **2. Read path** | `CalendarRepository` read APIs, `CalendarEvent`/`CalendarInfo` models, `CalendarTimeUtil`, `calendar_list_calendars`, `calendar_list_events`, unit tests. | 1–1.5 days |
+| **3. Write path** | `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`, reminders support, approval descriptions, tests. | 1–1.5 days |
+| **4. Polish** | `calendar_find_free_time`, recurring-instance updates (EXDATE/exceptions), docs, optional skill asset. | 1 day |
+
+## 8. Risks & open questions
+
+1. **Recurring-event edits** ("move just this occurrence") need
+   `ORIGINAL_ID`/exception handling — defer to phase 4; phase 1 tools should
+   detect `RRULE != null` and tell the LLM it can only modify the whole
+   series.
+2. **No local calendar on some ROMs** — creation may require an existing
+   writable calendar; `calendar_list_calendars` output must make this
+   explicit, and create errors should guide the user.
+3. **Permission UX on enabling**: Android shows its system dialog; if the
+   user chose "don't ask again", deep-link to app settings (pattern already
+   used elsewhere? — if not, simple Snackbar suffices for v1).
+4. **Read tool privacy**: consider truncating long descriptions / attendee
+   lists in tool output to bound context size and leakage (v1: cap each
+   field, e.g. description at 500 chars).
+5. **Timezones for travelling users**: v1 uses device timezone everywhere;
+   explicit `timezone` param on create can be a later addition.

--- a/docs/features/calendar.md
+++ b/docs/features/calendar.md
@@ -1,0 +1,74 @@
+# Calendar Tools
+
+DroidClaw's agent can read and manage events on your device calendar —
+any calendar synced to the phone through Android's normal calendar system
+(Google, CalDAV apps, local calendars, …). No extra accounts or services
+are involved: the tools talk to the built-in `CalendarContract` provider.
+
+> **Privacy note:** calendar content is personal data. When these tools are
+> enabled, event titles, times, locations and descriptions can enter the
+> LLM context. The feature is off by default.
+
+## Enabling
+
+1. Open **Settings → Agent settings**.
+2. Turn on **Calendar access**. Android will ask for the `READ_CALENDAR` /
+   `WRITE_CALENDAR` runtime permissions — grant them.
+3. If you deny the permission, the switch stays off and the tools are not
+   offered to the agent.
+
+Disabling the switch (or revoking the permission in Android settings) hides
+the tools completely; the agent no longer sees or can call them.
+
+## Tools
+
+| Tool | What it does | Approval |
+|------|--------------|----------|
+| `calendar_list_calendars` | Lists the calendars on the device (id, name, account, writable). | default |
+| `calendar_list_events` | Lists events in a time window, with recurring events expanded to occurrences. | default |
+| `calendar_create_event` | Creates an event (optionally all-day, with location, description, reminders). | required |
+| `calendar_update_event` | Changes fields of an existing event (title, time, location, …). | required |
+| `calendar_delete_event` | Deletes an event. | required |
+
+"required" means the write tools always go through the approval prompt
+(unless you override them per-tool under **Tool Approvals**); the read tools
+follow your normal approval mode.
+
+### Arguments
+
+- **`start` / `end`** — ISO-8601: `2025-06-20T14:00:00`, optionally with an
+  offset (`…+02:00`, `…Z`). Times without an offset use the device timezone.
+  A bare date (`2025-06-20`) implies an all-day event.
+- **`query`** (`calendar_list_events`) — free-text filter matched against
+  title, location and description (case-insensitive).
+- **`calendar_id`** — target calendar. If omitted on create and exactly one
+  writable calendar exists, that one is used; otherwise the agent must list
+  calendars first and pick one.
+- **`all_day`** — all-day events store UTC-midnight boundaries; the tools
+  handle the conversion for you.
+- **`reminders`** — list of lead times in minutes before the event, e.g.
+  `[30, 1440]` = 30 minutes and 1 day ahead.
+- **`event_id`** (update/delete) — the id returned by `calendar_list_events`.
+
+### Recurring events
+
+`calendar_list_events` expands recurring series into individual occurrences
+inside the requested window. Update and delete act on the **whole series**;
+editing a single occurrence of a recurring series is not supported (and time
+changes on recurring events are rejected with an explanatory error).
+
+## Typical flows
+
+- *"What's on my calendar today?"* → `calendar_list_events` with today's window.
+- *"Book a dentist appointment Friday 14:00–15:00"* → the agent lists
+  calendars (if needed), then `calendar_create_event`; you approve the write.
+- *"Move tomorrow's standup to 10:30"* → `calendar_list_events` to find the
+  event id, then `calendar_update_event` with the new start/end.
+- *"Cancel the sync meeting"* → find it, then `calendar_delete_event`.
+- Combined with cron/heartbeat: *"Every morning at 08:00, send me my agenda
+  for today."*
+
+## See also
+
+- [Agent Tools: App & Screen Control](agent-tools.md)
+- [Settings and Configuration](../user/settings.md)

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -73,6 +73,10 @@ When the backend is set to `ssh`, configure the remote connection:
 - **Screen Control**: Enables the screen tools (tap, swipe, type text, read the UI tree). Requires the Android accessibility service to be enabled. Off by default.
 - **Trust Mode**: Skip per-action approval prompts for screen interactions.
 
+## Calendar Access
+
+- **Calendar access**: Enables the calendar tools (`calendar_list_calendars`, `calendar_list_events`, `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`). Requires the Android `READ_CALENDAR` / `WRITE_CALENDAR` permissions, requested when you flip the switch. Off by default. See [Calendar Tools](../features/calendar.md).
+
 ## Cron Tasks & Heartbeat
 
 - **Cron jobs**: Schedule prompts to run on a schedule (e.g. `every_2_hours`, `daily`). Failed runs are retried with exponential backoff (1, 2, 4, … minutes, capped at one day); the job is paused after repeated failures.


### PR DESCRIPTION
## Summary

Adds calendar integration so the agent can read and manage device calendar events through the normal tool-calling loop — backed by Android's built-in `CalendarContract` provider (no extra SDKs, accounts, or OAuth). Follows the plan in `docs/features/calendar-integration-plan.md`.

Example prompts this enables:
- "What's on my calendar today / this week?"
- "Book a dentist appointment Friday 14:00–15:00 in my personal calendar."
- "Move tomorrow's standup to 10:30." / "Cancel the sync meeting."
- Combined with cron/heartbeat: "Every morning at 08:00, send me my agenda."

## What's included

**Data layer** (`calendar/` package)
- `CalendarRepository` over `CalendarContract`: `Instances`-based reads with recurring-event expansion, calendar-name joins, all-day/UTC-midnight handling, reminders, writable-calendar resolution, defensive permission errors
- Models: `CalendarInfo`, `CalendarEvent`, `EventSpec`, `CalendarException`
- `CalendarTimeUtil`: ISO-8601 parse/format (naive → device TZ, explicit offsets, bare dates → all-day)

**Tools** — registered in `ToolRegistry` only when the setting is on **and** permissions granted

| Tool | Approval |
|---|---|
| `calendar_list_calendars`, `calendar_list_events` | default mode |
| `calendar_create_event`, `calendar_update_event`, `calendar_delete_event` | always requires approval |

Plus `ToolDefinition.ParametersBuilder.addIntegerArray` for reminder lead times.

**Plumbing**
- `READ_CALENDAR` / `WRITE_CALENDAR` manifest permissions
- `AgentConfig.calendarEnabled`, persisted via `SettingsManager`
- **Settings → Agent settings → Calendar Access** switch with runtime permission prompt (`CalendarPermissionHelper`); denial keeps it off with a Snackbar

**Docs**
- `docs/features/calendar.md` (user-facing tool reference)
- New "Calendar Access" section in `docs/user/settings.md`, link in `docs/README.md`, tools list in `CLAUDE.md`

## Verification

| Gate | Result |
|---|---|
| `testDebugUnitTest` | ✅ 1451 tests, 0 failures (77 new calendar tests + 7 extended) |
| `assembleDebug` | ✅ |
| `lintDebug` | ✅ |
| **Instrumented (real device)** | ✅ **10/10 passed, 0 skipped** on Infinix X6851B (Android 15) |

Unit coverage: `CalendarTimeUtilTest` (parse/format edge cases), `CalendarRepositoryTest` (Robolectric + in-memory fake `CalendarContract` provider: windows, recurrence expansion, filters, CRUD round-trips, all-day, reminders, error paths, permission gating), `CalendarToolsTest` (definitions, arg validation, approval semantics, JSON output), registry gating tests, `calendarEnabled` persistence round-trips.

`CalendarRepositoryInstrumentedTest` exercises the **real device provider** using a throwaway calendar created via the sync-adapter URI (`CALLER_IS_SYNCADAPTER`) and deleted in `@After`; it auto-skips via `Assume` on OEM providers that reject third-party calendar creation, and is gated to API 28+ (`GrantPermissionRule`). On the Infinix device the provider accepted the test calendar, so full CRUD + reminders + window/text queries ran against real provider behavior.

## Deferred (per plan §7)

- `calendar_find_free_time` (Phase 4)
- Single-occurrence edits of recurring series (update/delete act on whole series; time changes on recurring events are rejected with an explanatory error)

## Testing on a device

```bash
nix develop --command ./gradlew installDebug
# Settings → Agent settings → Calendar access (grant permission)
# then ask the agent: "What's on my calendar today?"
```
