### PR TITLE
docs(settings): document the self-improvement (GUIDELINES.md) toggle

### DIFF
--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -79,6 +79,17 @@ When the backend is set to `ssh`, configure the remote connection:
 
 - **Calendar access**: Enables the calendar tools (`calendar_list_calendars`, `calendar_list_events`, `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`). Requires the Android `READ_CALENDAR` / `WRITE_CALENDAR` permissions, requested when you flip the switch. Off by default. See [Calendar Tools](../features/calendar.md).
 
+## Self-Improvement (Guidelines Learning)
+
+- **Self-Improvement (GUIDELINES.md)**: When enabled (default), the agent runs one extra structured LLM call after each finished conversation. It distills durable workflow lessons — your corrections, preferred formats, recurring workflows — into `.agent/GUIDELINES.md`, which is then injected into every new conversation.
+
+Notes:
+
+- The analysis call goes to your configured LLM provider, so the recent transcript leaves the device — disable the toggle if you don't want that.
+- The file is capped at 8 KB, written atomically with a `.bak` backup, and identical output is never re-written.
+- You can inspect and hand-edit the learned guidelines in the Memory Browser.
+- Design details: [Self-Improvement plan](../features/self-improvement-plan.md).
+
 ## Cron Tasks & Heartbeat
 
 - **Cron jobs**: Schedule prompts to run on a schedule (e.g. `every_2_hours`, `daily`). Failed runs are retried with exponential backoff (1, 2, 4, … minutes, capped at one day); the job is paused after repeated failures.


### PR DESCRIPTION
## Overview

Docs-only follow-up to #128: `guidelinesLearningEnabled` shipped without a user-facing settings doc.

## Changes

New **Self-Improvement (Guidelines Learning)** section in `docs/user/settings.md` (placed between Calendar Access and Cron Tasks):

- What the toggle does (extra structured LLM call per finished chat; learned guidelines injected into every conversation; default on)
- Privacy note: the analysis call sends the recent transcript to the configured LLM provider
- Safety bounds: 8KB cap, atomic write + `.bak` backup, no redundant writes
- Memory Browser: inspect/hand-edit the learned guidelines
- Link to `docs/features/self-improvement-plan.md`