### PR TITLE
feat(self-improvement): daily lesson consolidation into MEMORY.md

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/MainActivity.java
+++ b/app/src/main/java/io/finett/droidclaw/MainActivity.java
@@ -71,6 +71,10 @@ public class MainActivity extends AppCompatActivity {
         settingsManager = new SettingsManager(this);
         apiService = new LlmApiService(settingsManager);
 
+        // Self-improvement: keep the daily lesson consolidation job scheduled.
+        // The worker itself no-ops when the feature is disabled in settings.
+        new io.finett.droidclaw.scheduler.CronJobScheduler(this).ensureConsolidation();
+
         MaterialToolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 

--- a/app/src/main/java/io/finett/droidclaw/agent/LessonConsolidator.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/LessonConsolidator.java
@@ -1,0 +1,243 @@
+package io.finett.droidclaw.agent;
+
+import android.util.Log;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.model.ChatMessage;
+import io.finett.droidclaw.model.Lesson;
+import io.finett.droidclaw.repository.LessonConsolidationRepository;
+import io.finett.droidclaw.repository.LessonRepository;
+import io.finett.droidclaw.repository.MemoryRepository;
+
+/**
+ * Self-improvement layer ② — consolidation.
+ *
+ * <p>Takes the oldest batch of fresh (unconsumed) lessons, asks the model
+ * once to merge them into the existing MEMORY.md (deduping against current
+ * content), rewrites the file, marks the lessons consumed, and appends a
+ * journal entry. On any failure the lessons stay unconsumed and the next
+ * run retries.
+ *
+ * <p>Synchronous — intended to run on a background worker thread.
+ */
+public class LessonConsolidator {
+
+    private static final String TAG = "LessonConsolidator";
+
+    private static final int BATCH_SIZE = 15;
+    private static final int MEMORY_CAP_CHARS = 30 * 1024;
+    private static final int LLM_TIMEOUT_SECONDS = 120;
+
+    private final LlmApiService apiService;
+    private final MemoryRepository memoryRepository;
+    private final LessonRepository lessonRepository;
+    private final LessonConsolidationRepository journalRepository;
+
+    public LessonConsolidator(LlmApiService apiService,
+                              MemoryRepository memoryRepository,
+                              LessonRepository lessonRepository,
+                              LessonConsolidationRepository journalRepository) {
+        this.apiService = apiService;
+        this.memoryRepository = memoryRepository;
+        this.lessonRepository = lessonRepository;
+        this.journalRepository = journalRepository;
+    }
+
+    /**
+     * Runs one consolidation cycle.
+     *
+     * @return true when consolidation succeeded or nothing needed doing,
+     *         false on any failure (safe to retry later).
+     */
+    public boolean runConsolidation() {
+        try {
+            List<Lesson> unconsumed = lessonRepository.readUnconsumed();
+            if (unconsumed.isEmpty()) {
+                Log.d(TAG, "No fresh lessons to consolidate");
+                return true;
+            }
+
+            // readUnconsumed returns newest first — consolidate the oldest batch
+            List<Lesson> batch = unconsumed.size() <= BATCH_SIZE
+                    ? unconsumed
+                    : unconsumed.subList(unconsumed.size() - BATCH_SIZE, unconsumed.size());
+
+            String currentMemory = memoryRepository.readLongTermMemory();
+            String planJson = requestConsolidationPlan(batch, currentMemory);
+            if (planJson == null || planJson.isEmpty()) {
+                Log.w(TAG, "Consolidation call produced no result; lessons stay unconsumed");
+                return false;
+            }
+
+            JsonObject plan = JsonParser.parseString(planJson).getAsJsonObject();
+            String updatedMemory = plan.has("updated_memory")
+                    ? plan.get("updated_memory").getAsString().trim() : "";
+            if (updatedMemory.isEmpty()) {
+                Log.w(TAG, "Model returned empty updated_memory; skipping write");
+                return false;
+            }
+            if (updatedMemory.length() > MEMORY_CAP_CHARS) {
+                updatedMemory = updatedMemory.substring(0, MEMORY_CAP_CHARS);
+            }
+
+            Set<String> batchIds = new HashSet<>();
+            for (Lesson lesson : batch) {
+                batchIds.add(lesson.getId());
+            }
+            List<String> consumedIds = parseIds(plan, "consumed_ids", batchIds);
+            List<String> rejectedIds = parseIds(plan, "rejected_ids", batchIds);
+
+            memoryRepository.writeLongTermMemory(updatedMemory);
+            lessonRepository.markConsumed(consumedIds);
+            lessonRepository.markConsumed(rejectedIds);
+
+            journalRepository.appendConsolidation(System.currentTimeMillis(),
+                    consumedIds, rejectedIds,
+                    plan.has("summary") ? plan.get("summary").getAsString().trim() : "");
+
+            Log.i(TAG, "Consolidated " + consumedIds.size() + " lesson(s), rejected "
+                    + rejectedIds.size() + ", memory " + updatedMemory.length() + " chars");
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "Consolidation failed; lessons stay unconsumed", e);
+            return false;
+        }
+    }
+
+    /** Synchronous structured call via latch; null on error/timeout/refusal. */
+    private String requestConsolidationPlan(List<Lesson> batch, String currentMemory) {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(new ChatMessage(buildSystemPrompt(), ChatMessage.TYPE_SYSTEM));
+        messages.add(new ChatMessage(buildUserPrompt(batch, currentMemory),
+                ChatMessage.TYPE_USER));
+
+        final String[] result = new String[1];
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        apiService.sendMessageStructured(messages, null, null, getResponseSchema(),
+                new LlmApiService.StructuredResponseCallback() {
+                    @Override
+                    public void onSuccess(LlmApiService.StructuredResponse response) {
+                        try {
+                            if (!response.isRefusal() && response.getContent() != null) {
+                                result[0] = response.getContent();
+                            }
+                        } finally {
+                            latch.countDown();
+                        }
+                    }
+
+                    @Override
+                    public void onError(String error) {
+                        Log.w(TAG, "Consolidation LLM call failed: " + error);
+                        latch.countDown();
+                    }
+                });
+
+        try {
+            boolean completed = latch.await(LLM_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!completed) {
+                Log.w(TAG, "Consolidation LLM call timed out after "
+                        + LLM_TIMEOUT_SECONDS + "s");
+                return null;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+        return result[0];
+    }
+
+    /** Extracts an id array, dropping ids not present in the current batch. */
+    List<String> parseIds(JsonObject plan, String field, Set<String> batchIds) {
+        List<String> ids = new ArrayList<>();
+        if (!plan.has(field)) {
+            return ids;
+        }
+        for (JsonElement element : plan.getAsJsonArray(field)) {
+            try {
+                String id = element.getAsString();
+                if (batchIds.contains(id) && !ids.contains(id)) {
+                    ids.add(id);
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return ids;
+    }
+
+    private String buildSystemPrompt() {
+        return "You maintain a personal assistant's long-term memory file (MEMORY.md). "
+                + "You receive the current file content and a batch of fresh lessons "
+                + "extracted from recent conversations. Produce the updated file: merge "
+                + "the valuable lessons in, dedupe against existing entries, keep the "
+                + "structure compact (markdown bullet lists grouped by topic), and stay "
+                + "under " + MEMORY_CAP_CHARS + " characters. Drop nothing valuable, add "
+                + "nothing speculative.";
+    }
+
+    private String buildUserPrompt(List<Lesson> batch, String currentMemory) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("# Current MEMORY.md\n\n");
+        builder.append(currentMemory.isEmpty() ? "(empty)" : currentMemory);
+        builder.append("\n\n# Fresh lessons to consolidate\n\n");
+        for (Lesson lesson : batch) {
+            builder.append("- id: ").append(lesson.getId())
+                    .append(" | category: ").append(lesson.getCategory())
+                    .append(" | scope: ").append(lesson.getScope())
+                    .append(" | confidence: ").append(lesson.getConfidence())
+                    .append("\n  ").append(lesson.getContent()).append("\n");
+        }
+        builder.append("\nConsolidate these lessons into the memory file.");
+        return builder.toString();
+    }
+
+    /** Structured output schema for the consolidation plan. */
+    public static JsonObject getResponseSchema() {
+        JsonObject contentProperty = new JsonObject();
+        contentProperty.addProperty("type", "string");
+        contentProperty.addProperty("description",
+                "The complete updated MEMORY.md content (markdown)");
+
+        JsonObject idArrayProperty = new JsonObject();
+        idArrayProperty.addProperty("type", "array");
+        JsonObject idItem = new JsonObject();
+        idItem.addProperty("type", "string");
+        idArrayProperty.add("items", idItem);
+
+        JsonObject summaryProperty = new JsonObject();
+        summaryProperty.addProperty("type", "string");
+        summaryProperty.addProperty("description",
+                "One sentence describing what changed in this consolidation");
+
+        JsonObject properties = new JsonObject();
+        properties.add("updated_memory", contentProperty);
+        properties.add("consumed_ids", idArrayProperty);
+        properties.add("rejected_ids", idArrayProperty);
+        properties.add("summary", summaryProperty);
+
+        JsonObject schema = new JsonObject();
+        schema.addProperty("type", "object");
+        schema.add("properties", properties);
+        JsonArray required = new JsonArray();
+        required.add("updated_memory");
+        required.add("consumed_ids");
+        required.add("rejected_ids");
+        required.add("summary");
+        schema.add("required", required);
+        schema.addProperty("additionalProperties", false);
+        return schema;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/agent/MemoryContextBuilder.java
+++ b/app/src/main/java/io/finett/droidclaw/agent/MemoryContextBuilder.java
@@ -5,6 +5,10 @@ import android.util.Log;
 import java.io.IOException;
 import java.util.List;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
 import io.finett.droidclaw.model.Lesson;
 import io.finett.droidclaw.repository.LessonRepository;
 import io.finett.droidclaw.repository.MemoryRepository;
@@ -19,15 +23,23 @@ public class MemoryContextBuilder {
 
     private final MemoryRepository memoryRepository;
     private final LessonRepository lessonRepository; // nullable — injection is skipped when absent
+    private final long consolidationLastRunMillis; // 0 = unknown/never ran
 
     public MemoryContextBuilder(MemoryRepository memoryRepository) {
-        this(memoryRepository, null);
+        this(memoryRepository, null, 0L);
     }
 
     public MemoryContextBuilder(MemoryRepository memoryRepository,
                                 LessonRepository lessonRepository) {
+        this(memoryRepository, lessonRepository, 0L);
+    }
+
+    public MemoryContextBuilder(MemoryRepository memoryRepository,
+                                LessonRepository lessonRepository,
+                                long consolidationLastRunMillis) {
         this.memoryRepository = memoryRepository;
         this.lessonRepository = lessonRepository;
+        this.consolidationLastRunMillis = consolidationLastRunMillis;
     }
 
     public String buildMemoryContext() {
@@ -108,6 +120,7 @@ public class MemoryContextBuilder {
             if (included == 0) {
                 return "";
             }
+            section.append(buildConsolidationStatusLine(lessons.size())).append('\n');
             section.append("\n");
             Log.d(TAG, "Injected " + included + " fresh lesson(s)");
             return section.toString();
@@ -115,6 +128,21 @@ public class MemoryContextBuilder {
             Log.w(TAG, "Failed to load lessons for context", e);
             return "";
         }
+    }
+
+    /**
+     * One-line consolidation status so the agent can reason about its own
+     * memory freshness ("N lesson(s) pending; last run <date>").
+     */
+    private String buildConsolidationStatusLine(int pendingCount) {
+        StringBuilder status = new StringBuilder("_Consolidation: ")
+                .append(pendingCount).append(" lesson(s) pending");
+        if (consolidationLastRunMillis > 0) {
+            String formatted = new SimpleDateFormat("yyyy-MM-dd", Locale.US)
+                    .format(new Date(consolidationLastRunMillis));
+            status.append("; last run ").append(formatted);
+        }
+        return status.append("_").toString();
     }
 
     public boolean hasMemory() {

--- a/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
+++ b/app/src/main/java/io/finett/droidclaw/fragment/AgentSettingsFragment.java
@@ -73,6 +73,7 @@ public class AgentSettingsFragment extends Fragment {
     // Self-improvement views
     private SwitchMaterial switchGuidelinesLearning;
     private SwitchMaterial switchLessonExtraction;
+    private SwitchMaterial switchLessonConsolidation;
 
     private Button buttonSave;
 
@@ -170,6 +171,7 @@ public class AgentSettingsFragment extends Fragment {
 
         switchGuidelinesLearning = view.findViewById(R.id.switch_guidelines_learning);
         switchLessonExtraction = view.findViewById(R.id.switch_lesson_extraction);
+        switchLessonConsolidation = view.findViewById(R.id.switch_lesson_consolidation);
 
         buttonSave = view.findViewById(R.id.button_save);
     }
@@ -283,6 +285,7 @@ public class AgentSettingsFragment extends Fragment {
             // Self-improvement
             switchGuidelinesLearning.setChecked(agentConfig.isGuidelinesLearningEnabled());
             switchLessonExtraction.setChecked(agentConfig.isLessonExtractionEnabled());
+            switchLessonConsolidation.setChecked(agentConfig.isLessonConsolidationEnabled());
 
             // Terminal backend
             String backend = agentConfig.getShellBackend();
@@ -648,6 +651,16 @@ public class AgentSettingsFragment extends Fragment {
         agentConfig.setCalendarEnabled(switchCalendarAccess.isChecked());
         agentConfig.setGuidelinesLearningEnabled(switchGuidelinesLearning.isChecked());
         agentConfig.setLessonExtractionEnabled(switchLessonExtraction.isChecked());
+        agentConfig.setLessonConsolidationEnabled(switchLessonConsolidation.isChecked());
+
+        // Keep the daily consolidation job in sync with the toggle
+        io.finett.droidclaw.scheduler.CronJobScheduler consolidationScheduler =
+                new io.finett.droidclaw.scheduler.CronJobScheduler(requireContext());
+        if (switchLessonConsolidation.isChecked()) {
+            consolidationScheduler.ensureConsolidation();
+        } else {
+            consolidationScheduler.cancelConsolidation();
+        }
 
         // Terminal backend
         String backendText = dropdownTerminalBackend.getText().toString();

--- a/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
+++ b/app/src/main/java/io/finett/droidclaw/model/AgentConfig.java
@@ -21,6 +21,7 @@ public class AgentConfig {
     private boolean calendarEnabled; // allow agent to read and manage device calendar events
     private boolean guidelinesLearningEnabled; // analyze each finished chat and update .agent/GUIDELINES.md
     private boolean lessonExtractionEnabled; // extract durable lessons from finished chats into the lesson store
+    private boolean lessonConsolidationEnabled; // daily consolidation of lessons into MEMORY.md
     private int llmConnectTimeout;   // seconds
     private int llmReadTimeout;      // seconds
     private int llmWriteTimeout;     // seconds
@@ -45,6 +46,7 @@ public class AgentConfig {
         this.calendarEnabled = false;
         this.guidelinesLearningEnabled = true;
         this.lessonExtractionEnabled = true;
+        this.lessonConsolidationEnabled = true;
         this.toolApprovalOverrides = new HashMap<>();
         this.shellBackend = "local";
         this.sshPort = 22;
@@ -72,6 +74,7 @@ public class AgentConfig {
         this.calendarEnabled = false;
         this.guidelinesLearningEnabled = true;
         this.lessonExtractionEnabled = true;
+        this.lessonConsolidationEnabled = true;
         this.sshPort = 22;
         this.sshVerifyHostKey = true;
     }
@@ -231,6 +234,14 @@ public class AgentConfig {
 
     public void setLessonExtractionEnabled(boolean lessonExtractionEnabled) {
         this.lessonExtractionEnabled = lessonExtractionEnabled;
+    }
+
+    public boolean isLessonConsolidationEnabled() {
+        return lessonConsolidationEnabled;
+    }
+
+    public void setLessonConsolidationEnabled(boolean lessonConsolidationEnabled) {
+        this.lessonConsolidationEnabled = lessonConsolidationEnabled;
     }
 
     public Map<String, String> getToolApprovalOverrides() {

--- a/app/src/main/java/io/finett/droidclaw/repository/LessonConsolidationRepository.java
+++ b/app/src/main/java/io/finett/droidclaw/repository/LessonConsolidationRepository.java
@@ -1,0 +1,108 @@
+package io.finett.droidclaw.repository;
+
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Append-only journal of lesson consolidation runs
+ * (self-improvement layer ②). One JSON object per line:
+ * {"timestamp": ms, "consumed": [ids], "rejected": [ids], "summary": "..."}
+ */
+public class LessonConsolidationRepository {
+
+    private static final String TAG = "LessonConsolidationRepo";
+
+    private final File journalFile;
+
+    public LessonConsolidationRepository(File lessonsDir) {
+        this.journalFile = new File(lessonsDir, "lesson-consolidations.jsonl");
+        if (!lessonsDir.exists()) {
+            boolean created = lessonsDir.mkdirs();
+            if (created) {
+                Log.d(TAG, "Created lessons directory: " + lessonsDir.getAbsolutePath());
+            }
+        }
+    }
+
+    public synchronized void appendConsolidation(long timestampMillis,
+                                                 List<String> consumedIds,
+                                                 List<String> rejectedIds,
+                                                 String summary) throws IOException {
+        JSONObject entry = new JSONObject();
+        try {
+            entry.put("timestamp", timestampMillis);
+            entry.put("consumed", new JSONArray(consumedIds));
+            entry.put("rejected", new JSONArray(rejectedIds));
+            entry.put("summary", summary);
+        } catch (Exception e) {
+            throw new IOException("Failed to build journal entry", e);
+        }
+
+        FileWriter writer = new FileWriter(journalFile, true);
+        try {
+            writer.write(entry.toString());
+            writer.write('\n');
+        } finally {
+            writer.close();
+        }
+        Log.d(TAG, "Appended consolidation journal entry");
+    }
+
+    /**
+     * Journal entries from the last {@code days} days, most recent first.
+     * Malformed lines are skipped.
+     */
+    public synchronized List<JSONObject> readRecent(int days) {
+        List<JSONObject> result = new ArrayList<>();
+        if (!journalFile.exists()) {
+            return result;
+        }
+
+        long cutoffMillis = System.currentTimeMillis() - (long) days * 24 * 60 * 60 * 1000;
+
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new InputStreamReader(
+                    new FileInputStream(journalFile), StandardCharsets.UTF_8));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+                try {
+                    JSONObject entry = new JSONObject(line);
+                    if (entry.optLong("timestamp", 0L) >= cutoffMillis) {
+                        result.add(entry);
+                    }
+                } catch (Exception e) {
+                    Log.w(TAG, "Skipping malformed journal line");
+                }
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to read consolidation journal", e);
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+
+        result.sort((a, b) -> Long.compare(b.optLong("timestamp"), a.optLong("timestamp")));
+        return result;
+    }
+}

--- a/app/src/main/java/io/finett/droidclaw/repository/MemoryRepository.java
+++ b/app/src/main/java/io/finett/droidclaw/repository/MemoryRepository.java
@@ -98,6 +98,16 @@ public class MemoryRepository {
         Log.d(TAG, "Appended to MEMORY.md: " + content.length() + " characters");
     }
 
+    /**
+     * Full rewrite of MEMORY.md, used by lesson consolidation after merging
+     * fresh lessons into the existing content.
+     */
+    public void writeLongTermMemory(String content) throws IOException {
+        File memoryFile = new File(memoryDir, LONG_TERM_FILE);
+        writeToFile(memoryFile, content, false);
+        Log.d(TAG, "Rewrote MEMORY.md: " + content.length() + " characters");
+    }
+
     public List<File> getAllDailyNotes() {
         File[] files = memoryDir.listFiles((dir, name) ->
             name.matches("\\d{4}-\\d{2}-\\d{2}\\.md")

--- a/app/src/main/java/io/finett/droidclaw/scheduler/CronJobScheduler.java
+++ b/app/src/main/java/io/finett/droidclaw/scheduler/CronJobScheduler.java
@@ -20,6 +20,7 @@ import io.finett.droidclaw.model.CronJob;
 import io.finett.droidclaw.model.HeartbeatConfig;
 import io.finett.droidclaw.worker.CronJobWorker;
 import io.finett.droidclaw.worker.HeartbeatWorker;
+import io.finett.droidclaw.worker.LessonConsolidationWorker;
 
 public class CronJobScheduler {
 
@@ -267,6 +268,56 @@ public class CronJobScheduler {
         );
 
         Log.d(TAG, "Heartbeat queued for immediate execution");
+    }
+
+    // ==================== Lesson consolidation ====================
+
+    private static final String CONSOLIDATION_WORK_NAME = "lesson_consolidation_task";
+
+    /**
+     * Ensures the daily lesson consolidation job is scheduled (roughly once
+     * per 24h; WorkManager decides the exact time). No-op when already
+     * scheduled (KEEP policy).
+     */
+    public void ensureConsolidation() {
+        Constraints constraints = new Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresBatteryNotLow(true)
+                .setRequiresCharging(false)
+                .build();
+
+        PeriodicWorkRequest workRequest = new PeriodicWorkRequest.Builder(
+                LessonConsolidationWorker.class,
+                24, TimeUnit.HOURS)
+                .setConstraints(constraints)
+                .build();
+
+        workManager.enqueueUniquePeriodicWork(
+                CONSOLIDATION_WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                workRequest);
+
+        Log.d(TAG, "Lesson consolidation ensured (daily, KEEP policy)");
+    }
+
+    public void cancelConsolidation() {
+        workManager.cancelUniqueWork(CONSOLIDATION_WORK_NAME);
+        Log.d(TAG, "Lesson consolidation cancelled");
+    }
+
+    public void runConsolidationNow() {
+        String workName = "lesson_consolidation_now_" + System.currentTimeMillis();
+
+        OneTimeWorkRequest oneTimeWork = new OneTimeWorkRequest.Builder(
+                LessonConsolidationWorker.class)
+                .build();
+
+        workManager.enqueueUniqueWork(
+                workName,
+                ExistingWorkPolicy.APPEND,
+                oneTimeWork);
+
+        Log.d(TAG, "Lesson consolidation queued for immediate execution");
     }
 
     public static long parseScheduleToInterval(String schedule) {

--- a/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
+++ b/app/src/main/java/io/finett/droidclaw/service/AgentExecutionService.java
@@ -420,7 +420,8 @@ public class AgentExecutionService extends Service {
             LessonRepository lessonRepository = new LessonRepository(
                     new File(workspaceManager.getMemoryDirectory(), "lessons"));
             MemoryContextBuilder memoryContext = new MemoryContextBuilder(
-                    memoryRepository, lessonRepository);
+                    memoryRepository, lessonRepository,
+                    settingsManager.getLessonConsolidationLastRunMillis());
 
             IdentityManager identityManager = new IdentityManager(
                     getApplicationContext(), workspaceManager);

--- a/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
+++ b/app/src/main/java/io/finett/droidclaw/util/SettingsManager.java
@@ -38,6 +38,7 @@ public class SettingsManager {
     private Map<String, Provider> providers;
     private AgentConfig agentConfig;
     private boolean onboardingCompleted;
+    private long lessonConsolidationLastRunMillis;
     private String userName;
     private Map<String, String> envVars;
 
@@ -148,6 +149,14 @@ public class SettingsManager {
             } else {
                 onboardingCompleted = false;
                 userName = "";
+            }
+
+            // Load lesson consolidation state
+            if (root.has("lessonConsolidation")) {
+                lessonConsolidationLastRunMillis = root.getJSONObject("lessonConsolidation")
+                        .optLong("lastRunMillis", 0L);
+            } else {
+                lessonConsolidationLastRunMillis = 0L;
             }
 
             // Load env vars
@@ -282,6 +291,10 @@ public class SettingsManager {
             onboardingObj.put("completed", onboardingCompleted);
             onboardingObj.put("userName", userName);
             root.put("onboarding", onboardingObj);
+
+            JSONObject lessonConsolidationObj = new JSONObject();
+            lessonConsolidationObj.put("lastRunMillis", lessonConsolidationLastRunMillis);
+            root.put("lessonConsolidation", lessonConsolidationObj);
 
             JSONObject envVarsObj = new JSONObject();
             for (Map.Entry<String, String> entry : envVars.entrySet()) {
@@ -515,6 +528,18 @@ public class SettingsManager {
 
     public void setOnboardingCompleted(boolean completed) {
         this.onboardingCompleted = completed;
+        saveToJson();
+    }
+
+    // ==================== Lesson consolidation ====================
+
+    /** Epoch millis of the last successful lesson consolidation run; 0 = never ran. */
+    public long getLessonConsolidationLastRunMillis() {
+        return lessonConsolidationLastRunMillis;
+    }
+
+    public void setLessonConsolidationLastRunMillis(long millis) {
+        this.lessonConsolidationLastRunMillis = millis;
         saveToJson();
     }
 

--- a/app/src/main/java/io/finett/droidclaw/worker/LessonConsolidationWorker.java
+++ b/app/src/main/java/io/finett/droidclaw/worker/LessonConsolidationWorker.java
@@ -1,0 +1,67 @@
+package io.finett.droidclaw.worker;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import java.io.File;
+
+import io.finett.droidclaw.agent.LessonConsolidator;
+import io.finett.droidclaw.api.LlmApiService;
+import io.finett.droidclaw.filesystem.WorkspaceManager;
+import io.finett.droidclaw.repository.LessonConsolidationRepository;
+import io.finett.droidclaw.repository.LessonRepository;
+import io.finett.droidclaw.repository.MemoryRepository;
+import io.finett.droidclaw.util.SettingsManager;
+
+/**
+ * Daily lesson consolidation worker (self-improvement layer ②).
+ * Merges fresh lessons into MEMORY.md via LessonConsolidator, marks them
+ * consumed, and journals the run. Failure keeps lessons unconsumed and
+ * returns retry.
+ */
+public class LessonConsolidationWorker extends Worker {
+
+    private static final String TAG = "LessonConsolidationWorker";
+
+    public LessonConsolidationWorker(@NonNull Context context,
+                                     @NonNull WorkerParameters workerParams) {
+        super(context, workerParams);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        SettingsManager settingsManager = new SettingsManager(getApplicationContext());
+        if (!settingsManager.getAgentConfig().isLessonConsolidationEnabled()) {
+            Log.d(TAG, "Lesson consolidation is disabled, skipping");
+            return Result.success();
+        }
+
+        try {
+            WorkspaceManager workspaceManager = new WorkspaceManager(getApplicationContext());
+            File lessonsDir = new File(workspaceManager.getMemoryDirectory(), "lessons");
+            LessonConsolidator consolidator = new LessonConsolidator(
+                    new LlmApiService(settingsManager),
+                    new MemoryRepository(workspaceManager),
+                    new LessonRepository(lessonsDir),
+                    new LessonConsolidationRepository(lessonsDir));
+
+            boolean success = consolidator.runConsolidation();
+            if (success) {
+                settingsManager.setLessonConsolidationLastRunMillis(
+                        System.currentTimeMillis());
+                Log.i(TAG, "Lesson consolidation finished successfully");
+                return Result.success();
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Lesson consolidation crashed", e);
+        }
+
+        Log.w(TAG, "Lesson consolidation failed; will retry");
+        return Result.retry();
+    }
+}

--- a/app/src/main/res/layout/fragment_agent_settings.xml
+++ b/app/src/main/res/layout/fragment_agent_settings.xml
@@ -716,6 +716,42 @@
 
         </LinearLayout>
 
+        <!-- Lesson consolidation -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="24dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/lesson_consolidation"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/lesson_consolidation_description"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_lesson_consolidation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
         <!-- Divider -->
         <View
             android:layout_width="match_parent"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -110,6 +110,8 @@
     <string name="guidelines_learning_description">После каждого ответа анализировать чат и дополнять .agent/GUIDELINES.md устойчивыми уроками о рабочих процессах. Файл добавляется в каждый новый диалог.</string>
     <string name="lesson_extraction">Извлечение уроков</string>
     <string name="lesson_extraction_description">После каждого завершённого чата извлекать устойчивые уроки (поправки, предпочтения, паттерны использования инструментов) в хранилище уроков. Свежие уроки добавляются в новые диалоги, агент может сохранять и вспоминать их через инструменты.</string>
+    <string name="lesson_consolidation">Консолидация уроков</string>
+    <string name="lesson_consolidation_description">Раз в день сливать свежие уроки в долговременную память (MEMORY.md) и помечать их как использованные. Хранилище уроков остаётся компактным, а долговременная память — актуальной.</string>
     <string name="calendar_permission_denied">Доступ к календарю запрещён — функция остаётся выключенной. Разрешите доступ в настройках системы.</string>
     <string name="accessibility_service_description">Позволяет DroidClaw читать видимый интерфейс и управлять экраном телефона для задач агента</string>
     <string name="network_timeouts">Сетевые таймауты</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,8 @@
     <string name="guidelines_learning_description">After each response, analyze the chat and update .agent/GUIDELINES.md with durable workflow lessons. The file is injected into every new conversation.</string>
     <string name="lesson_extraction">Lesson Extraction</string>
     <string name="lesson_extraction_description">After each finished chat, extract durable lessons (corrections, preferences, tool patterns) into the lesson store. Fresh lessons are injected into new conversations and the agent can save or recall them with tools.</string>
+    <string name="lesson_consolidation">Lesson Consolidation</string>
+    <string name="lesson_consolidation_description">Once a day, merge fresh lessons into long-term memory (MEMORY.md) and mark them consumed. Keeps the lesson store lean and long-term memory current.</string>
     <string name="calendar_permission_denied">Calendar permission denied — Calendar Access stays off. Grant it in system settings to enable it.</string>
     <string name="accessibility_service_label">DroidClaw Accessibility</string>
     <string name="accessibility_service_description">Lets DroidClaw read the visible UI and control the phone screen for agent tasks</string>

--- a/app/src/test/java/io/finett/droidclaw/agent/LessonConsolidatorTest.java
+++ b/app/src/test/java/io/finett/droidclaw/agent/LessonConsolidatorTest.java
@@ -1,0 +1,95 @@
+package io.finett.droidclaw.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.finett.droidclaw.repository.LessonRepository;
+
+/**
+ * Pure-logic tests for LessonConsolidator: id filtering and the no-op path.
+ * LLM interaction itself is exercised on-device (integration).
+ */
+public class LessonConsolidatorTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private final LessonConsolidator consolidator = new LessonConsolidator(null, null, null, null);
+
+    private JsonObject plan(String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    @Test
+    public void parseIds_keepsOnlyBatchIds() {
+        Set<String> batch = new HashSet<>(Arrays.asList("a", "b"));
+        List<String> ids = consolidator.parseIds(
+                plan("{\"consumed_ids\":[\"a\",\"z\",\"b\"]}"), "consumed_ids", batch);
+        assertEquals(Arrays.asList("a", "b"), ids);
+    }
+
+    @Test
+    public void parseIds_deduplicates() {
+        Set<String> batch = new HashSet<>(Arrays.asList("a"));
+        List<String> ids = consolidator.parseIds(
+                plan("{\"consumed_ids\":[\"a\",\"a\"]}"), "consumed_ids", batch);
+        assertEquals(1, ids.size());
+    }
+
+    @Test
+    public void parseIds_missingFieldReturnsEmpty() {
+        Set<String> batch = new HashSet<>(Arrays.asList("a"));
+        assertTrue(consolidator.parseIds(plan("{}"), "consumed_ids", batch).isEmpty());
+    }
+
+    @Test
+    public void parseIds_ignoresNonStringEntries() {
+        Set<String> batch = new HashSet<>(Arrays.asList("a"));
+        List<String> ids = consolidator.parseIds(
+                plan("{\"consumed_ids\":[\"a\",42,null]}"), "consumed_ids", batch);
+        assertEquals(Arrays.asList("a"), ids);
+    }
+
+    @Test
+    public void runConsolidation_noFreshLessons_returnsTrueWithoutSideEffects() throws Exception {
+        LessonRepository repo = new LessonRepository(tmp.newFolder("lessons"));
+        LessonConsolidator withEmptyStore = new LessonConsolidator(null, null, repo, null);
+        assertTrue(withEmptyStore.runConsolidation());
+    }
+
+    @Test
+    public void runConsolidation_apiFailure_leavesLessonsUnconsumed() throws Exception {
+        LessonRepository repo = new LessonRepository(tmp.newFolder("lessons"));
+        repo.appendLesson(new io.finett.droidclaw.model.Lesson(
+                "s1", io.finett.droidclaw.model.Lesson.CATEGORY_USER_PREFERENCE,
+                "content", "evidence", io.finett.droidclaw.model.Lesson.SCOPE_MEMORY,
+                "auto", 4));
+        // null apiService -> extraction returns no result -> failure, nothing consumed
+        LessonConsolidator failing = new LessonConsolidator(null, null, repo, null);
+        assertFalse(failing.runConsolidation());
+        assertEquals(1, repo.readUnconsumed().size());
+    }
+
+    @Test
+    public void responseSchema_requiresAllFields() {
+        JsonObject schema = LessonConsolidator.getResponseSchema();
+        assertEquals("object", schema.get("type").getAsString());
+        assertTrue(schema.getAsJsonObject("properties").has("updated_memory"));
+        JsonArray required = schema.getAsJsonArray("required");
+        assertEquals(4, required.size());
+    }
+}

--- a/app/src/test/java/io/finett/droidclaw/repository/LessonConsolidationRepositoryTest.java
+++ b/app/src/test/java/io/finett/droidclaw/repository/LessonConsolidationRepositoryTest.java
@@ -1,0 +1,97 @@
+package io.finett.droidclaw.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Round-trip tests for the consolidation journal (append + readRecent).
+ * Robolectric is required for a functional org.json implementation.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LessonConsolidationRepositoryTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private LessonConsolidationRepository repo;
+
+    @Before
+    public void setUp() throws Exception {
+        repo = new LessonConsolidationRepository(tmp.newFolder("lessons"));
+    }
+
+    @Test
+    public void appendAndRead_recentEntryReturned() throws Exception {
+        long now = System.currentTimeMillis();
+        repo.appendConsolidation(now, Arrays.asList("id1", "id2"),
+                Collections.singletonList("id3"), "merged 2 lessons");
+
+        List<JSONObject> entries = repo.readRecent(7);
+        assertEquals(1, entries.size());
+        JSONObject entry = entries.get(0);
+        assertEquals(now, entry.getLong("timestamp"));
+        assertEquals(2, entry.getJSONArray("consumed").length());
+        assertEquals(1, entry.getJSONArray("rejected").length());
+        assertEquals("merged 2 lessons", entry.getString("summary"));
+    }
+
+    @Test
+    public void readRecent_filtersOldEntries() throws Exception {
+        long now = System.currentTimeMillis();
+        repo.appendConsolidation(now - 30L * 24 * 60 * 60 * 1000,
+                Collections.singletonList("old"), Collections.emptyList(), "old run");
+        repo.appendConsolidation(now, Collections.singletonList("new"),
+                Collections.emptyList(), "new run");
+
+        List<JSONObject> entries = repo.readRecent(7);
+        assertEquals(1, entries.size());
+        assertEquals("new run", entries.get(0).getString("summary"));
+    }
+
+    @Test
+    public void readRecent_mostRecentFirst() throws Exception {
+        long now = System.currentTimeMillis();
+        repo.appendConsolidation(now - 60_000, Collections.singletonList("a"),
+                Collections.emptyList(), "first");
+        repo.appendConsolidation(now, Collections.singletonList("b"),
+                Collections.emptyList(), "second");
+
+        List<JSONObject> entries = repo.readRecent(7);
+        assertEquals(2, entries.size());
+        assertEquals("second", entries.get(0).getString("summary"));
+        assertEquals("first", entries.get(1).getString("summary"));
+    }
+
+    @Test
+    public void readRecent_skipsMalformedLines() throws Exception {
+        repo.appendConsolidation(System.currentTimeMillis(),
+                Collections.singletonList("ok"), Collections.emptyList(), "valid");
+
+        // Corrupt the file by appending garbage
+        java.io.FileWriter writer = new java.io.FileWriter(
+                new java.io.File(tmp.getRoot(), "lessons/lesson-consolidations.jsonl"), true);
+        writer.write("{not json\n");
+        writer.close();
+
+        List<JSONObject> entries = repo.readRecent(7);
+        assertEquals(1, entries.size());
+        assertTrue(entries.get(0).has("summary"));
+    }
+
+    @Test
+    public void readRecent_emptyWhenNoJournal() {
+        assertTrue(repo.readRecent(7).isEmpty());
+    }
+}


### PR DESCRIPTION
Second self-improvement layer on top of the lesson capture pipeline (#134): once a day, merge the oldest batch of fresh lessons into MEMORY.md via a structured LLM call, mark them consumed, and journal the run.

## What's added

**Consolidation engine**
- `LessonConsolidator` — batched (15 oldest fresh lessons) consolidation with a dedupe prompt, 30KB memory cap, schema-validated plan (`updated_memory`, `consumed_ids`, `rejected_ids`, `summary`), id filtering against the batch. Any failure leaves lessons unconsumed so the next run retries.

**Scheduling**
- `LessonConsolidationWorker` — daily WorkManager job gated by the settings toggle; records last-run timestamp on success, returns retry on failure.
- `CronJobScheduler.ensureConsolidation()/cancelConsolidation()/runConsolidationNow()` — 24h periodic work with network + battery constraints, KEEP policy; kept alive from `MainActivity`.
- `SettingsManager` persists `lessonConsolidation.lastRunMillis`.

**Storage**
- `LessonConsolidationRepository` — append-only JSONL journal (`lesson-consolidations.jsonl`) with `readRecent(days)`.
- `MemoryRepository.writeLongTermMemory()` for full MEMORY.md rewrites.

**Context & UI**
- `MemoryContextBuilder` injects a one-line consolidation status (`N lesson(s) pending; last run YYYY-MM-DD`) so the agent can reason about memory freshness.
- Agent Settings: **Lesson Consolidation** toggle with EN + RU strings; save syncs the scheduler job.

## Tests
- `LessonConsolidatorTest` — id parsing/filtering, no-op path, failure-keeps-lessons path, schema shape.
- `LessonConsolidationRepositoryTest` — journal round-trip, recency filter, ordering, malformed-line tolerance.

`./gradlew testDebugUnitTest` green.