### PR TITLE
fix(self-improvement): prune consumed lessons after consolidation

### DIFF
--- a/app/src/main/java/io/finett/droidclaw/worker/LessonConsolidationWorker.java
+++ b/app/src/main/java/io/finett/droidclaw/worker/LessonConsolidationWorker.java
@@ -44,14 +44,18 @@ public class LessonConsolidationWorker extends Worker {
         try {
             WorkspaceManager workspaceManager = new WorkspaceManager(getApplicationContext());
             File lessonsDir = new File(workspaceManager.getMemoryDirectory(), "lessons");
+            LessonRepository lessonRepository = new LessonRepository(lessonsDir);
             LessonConsolidator consolidator = new LessonConsolidator(
                     new LlmApiService(settingsManager),
                     new MemoryRepository(workspaceManager),
-                    new LessonRepository(lessonsDir),
+                    lessonRepository,
                     new LessonConsolidationRepository(lessonsDir));
 
             boolean success = consolidator.runConsolidation();
             if (success) {
+                // Drop consumed lessons past their retention window so the
+                // store stays compact after consolidation.
+                lessonRepository.pruneConsumed();
                 settingsManager.setLessonConsolidationLastRunMillis(
                         System.currentTimeMillis());
                 Log.i(TAG, "Lesson consolidation finished successfully");


### PR DESCRIPTION
Stacked on top of #135 (targets the consolidation branch until that merges; re-target to `main` afterwards).

## Problem
`LessonRepository.pruneConsumed()` was never called anywhere. Its javadoc promises consumed lessons are pruned "during consolidation", but nothing invoked it — so consumed lessons accumulated in the daily JSONL files forever.

## Fix
`LessonConsolidationWorker` now calls `lessonRepository.pruneConsumed()` right after a successful consolidation run, before recording the last-run timestamp. This keeps the lesson store compact (drops consumed lessons older than the 90-day retention window; removes emptied day files).

Prune behavior itself is already covered by `LessonRepositoryTest.pruneConsumed_*`; relevant test classes re-run green locally.